### PR TITLE
src/util: Improve min/max

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -21,8 +21,24 @@
 #include <string.h>
 
 #define UTIL_BUFFER_LEN 0x1000
-#define MIN(a, b) (((a) < (b)) ? (a) : (b))
-#define MAX(a, b) (((a) > (b)) ? (a) : (b))
+#define MIN(a, b)                                       \
+    __extension__({                                     \
+        _Pragma("GCC diagnostic push");                 \
+        _Pragma("GCC diagnostic ignored \"-Wshadow\""); \
+        __typeof__(a) _a = (a);                         \
+        __typeof__(b) _b = (b);                         \
+        _Pragma("GCC diagnostic pop");                  \
+        _a > _b ? _b : _a;                              \
+    })
+#define MAX(a, b)                                       \
+    __extension__({                                     \
+        _Pragma("GCC diagnostic push");                 \
+        _Pragma("GCC diagnostic ignored \"-Wshadow\""); \
+        __typeof__(a) _a = (a);                         \
+        __typeof__(b) _b = (b);                         \
+        _Pragma("GCC diagnostic pop");                  \
+        _a > _b ? _a : _b;                              \
+    })
 #define strlens(s) ((s) == NULL ? 0 : strlen(s))
 #define STREQ(a, b) (strcmp((a), (b)) == 0)
 #define MEMEQ(a, b, c) (memcmp((a), (b), (c)) == 0)

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -169,3 +169,7 @@ add_test(NAME test_app_eth COMMAND test_app_eth)
 add_executable(test_app_eth_common test_app_eth_common.c)
 target_link_libraries(test_app_eth_common bitbox cmocka)
 add_test(NAME test_app_eth_common COMMAND test_app_eth_common)
+
+add_executable(test_util test_util.c)
+target_link_libraries(test_util bitbox cmocka)
+add_test(NAME test_util COMMAND test_util)

--- a/test/unit-test/test_util.c
+++ b/test/unit-test/test_util.c
@@ -1,0 +1,61 @@
+#include "util.h"
+
+// Copyright 2019 Shift Cryptosecurity AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <cmocka.h>
+
+#include "util.h"
+
+static void test_minmax(void** state)
+{
+    (void)state;
+
+    assert_true(1);
+
+    int res = MIN(5, 10);
+    assert_int_equal(res, 5);
+
+    res = MIN(10, 5);
+    assert_int_equal(res, 5);
+
+    res = MAX(5, 10);
+    assert_int_equal(res, 10);
+
+    res = MAX(10, 5);
+    assert_int_equal(res, 10);
+
+    res = MIN(5, 10);
+    assert_int_not_equal(res, 10);
+
+    res = MIN(10, 5);
+    assert_int_not_equal(res, 10);
+
+    res = MAX(5, 10);
+    assert_int_not_equal(res, 5);
+
+    res = MAX(10, 5);
+    assert_int_not_equal(res, 5);
+}
+
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_minmax),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
This stops double evaluation of arguments to min/max. With previous macro, `MIN(i++,16)` would have increased `i` twice.