### PR TITLE
.codecov: remove unneeded ignores

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,4 +1,2 @@
 ignore:
-  - 'test'
-  - 'external'
   - 'src/drivers/**/*'


### PR DESCRIPTION
Seems like codecov only looks in src/ anyway.