### PR TITLE
components/insert_sd_card: use button directly

### DIFF
--- a/src/ui/components/insert_sd_card.c
+++ b/src/ui/components/insert_sd_card.c
@@ -82,7 +82,7 @@ component_t* insert_sd_card_create(void (*continue_callback)(void))
             screen_is_upside_down() ? RIGHT_CENTER : LEFT_CENTER,
             insert_sd_card));
     ui_util_add_sub_component(
-        insert_sd_card, confirm_create("", "", false, _continue_callback, NULL));
+        insert_sd_card, icon_button_create(bottom_slider, ICON_BUTTON_CHECK, _continue_callback));
 
     return insert_sd_card;
 }

--- a/src/ui/components/remove_sd_card.c
+++ b/src/ui/components/remove_sd_card.c
@@ -78,7 +78,8 @@ component_t* remove_sd_card_create(void (*continue_callback)(void))
             NULL,
             screen_is_upside_down() ? RIGHT_CENTER : LEFT_CENTER,
             remove_sd_card));
-    ui_util_add_sub_component(remove_sd_card, confirm_create("", "", false, _dismiss, NULL));
+    ui_util_add_sub_component(
+        remove_sd_card, icon_button_create(bottom_slider, ICON_BUTTON_CHECK, _dismiss));
 
     return remove_sd_card;
 }


### PR DESCRIPTION
Instead of an empty screen containing the button.