### PR TITLE
U2F Separation

### DIFF
--- a/bootloader.ld
+++ b/bootloader.ld
@@ -110,7 +110,7 @@ SECTIONS
     . = ALIGN(4);
     _etext = .;
 
-    .relocate : AT (_etext)
+    .relocate :
     {
         . = ALIGN(4);
         _srelocate = .;
@@ -118,7 +118,7 @@ SECTIONS
         *(.data .data.*);
         . = ALIGN(4);
         _erelocate = .;
-    } > ram
+    } > ram AT> rom
 
     .bkupram (NOLOAD):
     {

--- a/firmware.ld
+++ b/firmware.ld
@@ -109,7 +109,7 @@ SECTIONS
     . = ALIGN(4);
     _etext = .;
 
-    .relocate : AT (_etext)
+    .relocate :
     {
         . = ALIGN(4);
         _srelocate = .;
@@ -117,7 +117,7 @@ SECTIONS
         *(.data .data.*);
         . = ALIGN(4);
         _erelocate = .;
-    } > ram
+    } > ram AT> rom
 
     .bkupram (NOLOAD):
     {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -410,7 +410,7 @@ set_property(TARGET qtouchlib_t PROPERTY IMPORTED_LOCATION
 if(CMAKE_CROSSCOMPILING)
   set(STACK_SIZE "0x10000" CACHE STRING "Specify stack size for bootloader/firmware")
   set(STACK_SIZE ${STACK_SIZE} PARENT_SCOPE)
-  set(HEAP_SIZE "0x20000" CACHE STRING "Specify heap size for bootloader/firmware")
+  set(HEAP_SIZE "0x18000" CACHE STRING "Specify heap size for bootloader/firmware")
   set(HEAP_SIZE ${HEAP_SIZE} PARENT_SCOPE)
   foreach(bootloader bootloader bootloader-development bootloader-production)
     set(elf ${bootloader}.elf)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -78,6 +78,7 @@ set(DBB-FIRMWARE-USB-SOURCES
   ${CMAKE_SOURCE_DIR}/src/usb/usb.c
   ${CMAKE_SOURCE_DIR}/src/usb/usb_frame.c
   ${CMAKE_SOURCE_DIR}/src/usb/usb_packet.c
+  ${CMAKE_SOURCE_DIR}/src/u2f/u2f_packet.c
   ${CMAKE_SOURCE_DIR}/src/usb/usb_processing.c
   ${CMAKE_SOURCE_DIR}/src/queue.c
 )

--- a/src/bootloader/bootloader.c
+++ b/src/bootloader/bootloader.c
@@ -779,7 +779,7 @@ static void _api_setup(void)
 {
     const CMD_Callback cmd_callbacks[] = {{BOOTLOADER_CMD, _api_msg}};
 
-    usb_processing_register_cmds(cmd_callbacks, 1);
+    usb_processing_register_cmds(usb_processing_hww(), cmd_callbacks, 1);
 }
 
 #ifdef BOOTLOADER_PRODUCTION

--- a/src/bootloader/startup.c
+++ b/src/bootloader/startup.c
@@ -50,7 +50,7 @@ int main(void)
 
     // If did not jump to firmware code, begin USB processing
     while (1) {
-        usb_processing_process();
+        usb_processing_process(usb_processing_hww());
     }
 
     return 0;

--- a/src/drivers/usb/class/hid/hww/hid_hww.c
+++ b/src/drivers/usb/class/hid/hww/hid_hww.c
@@ -17,6 +17,7 @@
 #include <queue.h>
 #include "hid_hww.h"
 #include "usb_desc.h"
+#include "usb/usb_processing.h"
 
 #define HID_HWW_VERSION 0x00000001u
 
@@ -124,6 +125,8 @@ void hid_hww_setup(void) {
     hid_hww_register_callback(HID_CB_READ, (FUNC_PTR) _out);
     // usb_report_sent is called when the outgoing usb frame is fully transmitted.
     hid_hww_register_callback(HID_CB_WRITE, (FUNC_PTR) _sent_done);
+
+    usb_processing_set_send(usb_processing_hww(), _send_next);
 
     // Wait for data
     _read();

--- a/src/drivers/usb/class/hid/hww/hid_hww.c
+++ b/src/drivers/usb/class/hid/hww/hid_hww.c
@@ -65,7 +65,7 @@ static int32_t _read(void)
  * Sends the next frame, if the USB interface is ready.
  */
 static void _send_next(void) {
-    const uint8_t *data = queue_pull();
+    const uint8_t *data = queue_pull(queue_hww_queue());
     if (data != NULL) {
         hid_write(&_func_data, data, USB_HID_REPORT_OUT_SIZE);
     } else {

--- a/src/drivers/usb/class/hid/u2f/hid_u2f.c
+++ b/src/drivers/usb/class/hid/u2f/hid_u2f.c
@@ -65,7 +65,7 @@ static int32_t _read(void)
  * Sends the next data, if the USB interface is ready.
  */
 static void _send_next(void) {
-    const uint8_t *data = queue_pull();
+    const uint8_t *data = queue_pull(queue_hww_queue());
     if (data != NULL) {
         hid_write(&_func_data, data, USB_HID_REPORT_OUT_SIZE);
     } else {

--- a/src/factorysetup.c
+++ b/src/factorysetup.c
@@ -170,7 +170,8 @@ static void _api_msg(const Packet* in_packet, Packet* out_packet, const size_t m
 static void _api_setup(void)
 {
     const CMD_Callback cmd_callbacks[] = {{FACTORYSETUP_CMD, _api_msg}};
-    usb_processing_register_cmds(cmd_callbacks, sizeof(cmd_callbacks) / sizeof(CMD_Callback));
+    usb_processing_register_cmds(
+        usb_processing_hww(), cmd_callbacks, sizeof(cmd_callbacks) / sizeof(CMD_Callback));
     screen_print_debug("READY", 0);
 }
 
@@ -197,6 +198,6 @@ int main(void)
     }
     usb_start(_api_setup);
     while (1) {
-        usb_processing_process();
+        usb_processing_process(usb_processing_hww());
     }
 }

--- a/src/hww.c
+++ b/src/hww.c
@@ -110,5 +110,5 @@ void hww_setup(void)
 {
     const CMD_Callback hww_cmd_callbacks[] = {{HWW_MSG, _msg}};
     usb_processing_register_cmds(
-        hww_cmd_callbacks, sizeof(hww_cmd_callbacks) / sizeof(CMD_Callback));
+        usb_processing_hww(), hww_cmd_callbacks, sizeof(hww_cmd_callbacks) / sizeof(CMD_Callback));
 }

--- a/src/queue.c
+++ b/src/queue.c
@@ -25,8 +25,8 @@
 
 // `start` and `end` are indices into `items`
 struct queue {
-    uint32_t start;
-    uint32_t end;
+    uint32_t volatile start;
+    uint32_t volatile end;
     uint8_t items[QUEUE_NUM_REPORTS][USB_REPORT_SIZE];
 };
 
@@ -47,7 +47,7 @@ const uint8_t* queue_pull(struct queue* ctx)
     return ctx->items[p];
 }
 
-int32_t queue_push(struct queue* ctx, const uint8_t* data)
+queue_error_t queue_push(struct queue* ctx, const uint8_t* data)
 {
     uint32_t next = (ctx->end + 1) % QUEUE_NUM_REPORTS;
     if (ctx->start == next) {

--- a/src/queue.h
+++ b/src/queue.h
@@ -18,25 +18,42 @@
 #include <stdint.h>
 #include <string.h>
 
-#define ERR_NONE 0
-#define ERR_QUEUE_FULL 7
+#define QUEUE_ERR_NONE 0
+#define QUEUE_ERR_FULL -1
+
+struct queue;
 
 /**
  * Append the given data to the queue.
- * Returns ERR_NONE if the data was added and ERR_QUEUE_FULL if the buffer was full.
+ * Returns QUEUE_ERR_NONE if the data was added and QUEUE_ERR_FULL if the buffer was full.
+ * data must be USB_REPORT_SIZE large
  */
-uint8_t queue_push(const uint8_t* data);
+int32_t queue_push(struct queue* ctx, const uint8_t* data);
 
 /**
  * Return the first data that was added to the queue.
+ * Returns NULL if empty
  */
-const uint8_t* queue_pull(void);
+const uint8_t* queue_pull(struct queue* ctx);
 
 /**
  * Clear the queue.
  */
-void queue_clear(void);
+void queue_clear(struct queue* ctx);
 
-const uint8_t* queue_peek(void);
+/**
+ * Peek at the tip of the queue. Returns NULL if queue is empty.
+ */
+const uint8_t* queue_peek(struct queue* ctx);
+
+/**
+ * Get a pointer to the hww queue
+ */
+struct queue* queue_hww_queue(void);
+
+/**
+ * Get a pointer ot the u2f queue
+ */
+struct queue* queue_u2f_queue(void);
 
 #endif

--- a/src/queue.h
+++ b/src/queue.h
@@ -18,8 +18,10 @@
 #include <stdint.h>
 #include <string.h>
 
-#define QUEUE_ERR_NONE 0
-#define QUEUE_ERR_FULL -1
+typedef enum {
+    QUEUE_ERR_NONE = 0,
+    QUEUE_ERR_FULL = 1,
+} queue_error_t;
 
 struct queue;
 
@@ -28,7 +30,7 @@ struct queue;
  * Returns QUEUE_ERR_NONE if the data was added and QUEUE_ERR_FULL if the buffer was full.
  * data must be USB_REPORT_SIZE large
  */
-int32_t queue_push(struct queue* ctx, const uint8_t* data);
+queue_error_t queue_push(struct queue* ctx, const uint8_t* data);
 
 /**
  * Return the first data that was added to the queue.

--- a/src/u2f.c
+++ b/src/u2f.c
@@ -577,6 +577,6 @@ void u2f_device_setup(void)
         {U2FHID_MSG, _cmd_msg},
     };
     usb_processing_register_cmds(
-        u2f_cmd_callbacks, sizeof(u2f_cmd_callbacks) / sizeof(CMD_Callback));
+        usb_processing_u2f(), u2f_cmd_callbacks, sizeof(u2f_cmd_callbacks) / sizeof(CMD_Callback));
 #endif
 }

--- a/src/u2f.c
+++ b/src/u2f.c
@@ -564,11 +564,12 @@ static void _cmd_msg(const Packet* in_packet, Packet* out_packet, const size_t m
  */
 void u2f_device_setup(void)
 {
+#if 0
     (void)_cmd_wink;
     (void)_cmd_ping;
     (void)_cmd_init;
     (void)_cmd_msg;
-#if 0
+#else
     const CMD_Callback u2f_cmd_callbacks[] = {
         {U2FHID_PING, _cmd_ping},
         {U2FHID_WINK, _cmd_wink},

--- a/src/u2f/u2f_packet.c
+++ b/src/u2f/u2f_packet.c
@@ -12,14 +12,43 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "usb_packet.h"
+#include "u2f_packet.h"
 #include "err_codes.h"
 #include "queue.h"
 #include "screen.h"
-#include "usb_processing.h"
-#include <err_codes.h>
+#include "usb/usb_processing.h"
 #include <stdbool.h>
 #include <stdlib.h>
+
+// We can handle up to NUM_TIMEOUT_COUNTERS missing continuation frames
+#define NUM_TIMEOUT_COUNTERS 3
+
+struct frame_counter {
+    uint32_t cid;
+    uint8_t counter;
+};
+
+// cid == 0 indicates that there isn't any active timer for that slot
+static volatile struct frame_counter _timeout_counters[NUM_TIMEOUT_COUNTERS];
+
+static void _reset_timeout(uint32_t cid)
+{
+    for (int i = 0; i < NUM_TIMEOUT_COUNTERS; ++i) {
+        if (_timeout_counters[i].cid == cid) {
+            _timeout_counters[i].counter = 0;
+        }
+    }
+}
+
+static void _timeout_disable(uint32_t cid)
+{
+    for (int i = 0; i < NUM_TIMEOUT_COUNTERS; ++i) {
+        if (_timeout_counters[i].cid == cid) {
+            _timeout_counters[i].cid = 0;
+            _timeout_counters[i].counter = 0;
+        }
+    }
+}
 
 /**
  * Keeps a state for the frame processing of incoming frames.
@@ -31,13 +60,14 @@ static State _in_state;
  */
 static void _reset_state(void)
 {
-    queue_clear(queue_hww_queue());
+    queue_clear(queue_u2f_queue());
+    _timeout_disable(_in_state.cid);
     memset(&_in_state, 0, sizeof(_in_state));
 }
 
 static queue_error_t _queue_push(const uint8_t* data)
 {
-    return queue_push(queue_hww_queue(), data);
+    return queue_push(queue_u2f_queue(), data);
 }
 
 /**
@@ -56,9 +86,49 @@ static bool _need_more_data(void)
     return (_in_state.buf_ptr - _in_state.data) < (signed)_in_state.len;
 }
 
-bool usb_packet_process(const USB_FRAME* frame, void (*send_packet)(void))
+void u2f_packet_timeout_enable(uint32_t cid)
 {
-    struct usb_processing* ctx = usb_processing_hww();
+    for (int i = 0; i < NUM_TIMEOUT_COUNTERS; ++i) {
+        if (_timeout_counters[i].cid == 0) {
+            _timeout_counters[i].cid = cid;
+            _timeout_counters[i].counter = 0;
+            return;
+        }
+    }
+}
+
+bool u2f_packet_timeout_get(uint32_t* cid)
+{
+    for (int i = 0; i < NUM_TIMEOUT_COUNTERS; ++i) {
+        *cid = _timeout_counters[i].cid;
+        if (_timeout_counters[i].cid != 0 && _timeout_counters[i].counter >= 5) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void u2f_packet_timeout_tick(void)
+{
+    for (int i = 0; i < NUM_TIMEOUT_COUNTERS; ++i) {
+        if (_timeout_counters[i].cid != 0) {
+            _timeout_counters[i].counter += 1;
+        }
+    }
+}
+
+void u2f_packet_timeout(uint32_t cid)
+{
+    _timeout_disable(cid);
+    if (cid == _in_state.cid) {
+        _reset_state();
+    }
+    usb_frame_prepare_err(FRAME_ERR_MSG_TIMEOUT, cid, _queue_push);
+}
+
+bool u2f_packet_process(const USB_FRAME* frame, void (*send_packet)(void))
+{
+    struct usb_processing* ctx = usb_processing_u2f();
     switch (usb_frame_process(frame, &_in_state)) {
     case FRAME_ERR_IGNORE:
         // Ignore this frame, i.e. no response.
@@ -79,6 +149,7 @@ bool usb_packet_process(const USB_FRAME* frame, void (*send_packet)(void))
         _queue_err(FRAME_ERR_INVALID_LEN, frame->cid);
         break;
     case ERR_NONE:
+        _reset_timeout(frame->cid);
         if (_need_more_data()) {
             // Do not send a message yet
             return true;
@@ -89,6 +160,7 @@ bool usb_packet_process(const USB_FRAME* frame, void (*send_packet)(void))
             return false;
         }
         // Else: Currently processing a message, reset the state and forget about this packet
+        _timeout_disable(frame->cid);
         _reset_state();
         _queue_err(FRAME_ERR_CHANNEL_BUSY, frame->cid);
         break;
@@ -98,7 +170,6 @@ bool usb_packet_process(const USB_FRAME* frame, void (*send_packet)(void))
         _queue_err(FRAME_ERR_OTHER, frame->cid);
         break;
     }
-    // Send one of the error packets we have queued
     send_packet();
     return false;
 }

--- a/src/u2f/u2f_packet.h
+++ b/src/u2f/u2f_packet.h
@@ -1,0 +1,51 @@
+// Copyright 2019 Shift Cryptosecurity AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _U2F_PACKET_H_
+#define _U2F_PACKET_H_
+
+#include "usb/usb_frame.h"
+#include "usb/usb_packet.h"
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/**
+ * Processes an incoming USB packet.
+ * @param[in] frame The frame that is to be processed.
+ * @param[in] send_packet The function to be called to send the response packet.
+ * @return true if we are waiting for more frames to complete a packet, false otherwise.
+ */
+bool u2f_packet_process(const USB_FRAME* frame, void (*send_packet)(void));
+
+/**
+ * Checks if there has been a timeout
+ */
+bool u2f_packet_timeout_get(uint32_t* cid);
+
+/**
+ * Queue a timeout packet for cid
+ */
+void u2f_packet_timeout(uint32_t cid);
+
+/**
+ * Increase the timout timers with 1 step (steps in 100ms)
+ */
+void u2f_packet_timeout_tick(void);
+
+/**
+ * Enable timer for this cid
+ */
+void u2f_packet_timeout_enable(uint32_t cid);
+#endif

--- a/src/ui/screen_process.c
+++ b/src/ui/screen_process.c
@@ -69,7 +69,8 @@ static void _screen_process(bool (*is_done)(void), void (*on_timeout)(void), con
         screen_frame_cnt++;
         ui_screen_stack_cleanup();
         if (is_done == NULL) {
-            usb_processing_process();
+            usb_processing_process(usb_processing_hww());
+            usb_processing_process(usb_processing_u2f());
         }
     }
 }

--- a/src/usb/usb.c
+++ b/src/usb/usb.c
@@ -22,9 +22,11 @@
 #include <usb/class/hid/u2f/hid_u2f.h>
 #endif
 #endif
+#include "usb_processing.h"
 
 #ifndef TESTING
 #include <hal_timer.h>
+#include <u2f/u2f_packet.h>
 #include <usb/usb_packet.h>
 extern struct timer_descriptor TIMER_0;
 #endif
@@ -72,7 +74,7 @@ static void _u2f_endpoint_available(void)
 static void _timeout_cb(const struct timer_task* const timer_task)
 {
     (void)timer_task;
-    usb_packet_timeout_tick();
+    u2f_packet_timeout_tick();
 }
 #endif
 
@@ -109,6 +111,7 @@ int32_t usb_start(void (*on_hww_init)(void))
 #else
     (void)on_hww_init;
 #endif
+    usb_processing_init();
     return 0;
 }
 

--- a/src/usb/usb_frame.c
+++ b/src/usb/usb_frame.c
@@ -118,7 +118,7 @@ uint8_t usb_frame_reply(
     const uint8_t* data,
     const uint32_t len,
     const uint32_t cid,
-    uint8_t(add_frame_callback)(const uint8_t*))
+    int32_t(add_frame_callback)(const uint8_t*))
 {
     USB_FRAME frame;
     uint32_t cnt = 0;
@@ -135,7 +135,7 @@ uint8_t usb_frame_reply(
     // Init frame
     psz = MIN(sizeof(frame.init.data), l);
     memcpy(frame.init.data, data, psz);
-    uint8_t err = add_frame_callback((const uint8_t*)&frame);
+    int32_t err = add_frame_callback((const uint8_t*)&frame);
     if (err != ERR_NONE) {
         return err;
     }
@@ -166,7 +166,7 @@ uint8_t usb_frame_reply(
 uint8_t usb_frame_prepare_err(
     uint8_t err,
     uint32_t cid,
-    uint8_t(add_frame_callback)(const uint8_t*))
+    int32_t(add_frame_callback)(const uint8_t*))
 {
     USB_FRAME frame;
 

--- a/src/usb/usb_frame.h
+++ b/src/usb/usb_frame.h
@@ -17,6 +17,7 @@
 
 #include <stdint.h>
 
+#include "queue.h"
 #include <usb/class/usb_desc.h>
 
 #define FRAME_TYPE_MASK 0x80 // Frame type mask
@@ -102,12 +103,12 @@ typedef struct {
  * @param[in] cid The channel ID.
  * @param[in] add_frame_callback The callback to which the prepared frames are passed to.
  */
-uint8_t usb_frame_reply(
+queue_error_t usb_frame_reply(
     uint8_t cmd,
     const uint8_t* data,
     uint32_t len,
     uint32_t cid,
-    int32_t(add_frame_callback)(const uint8_t*));
+    queue_error_t(add_frame_callback)(const uint8_t*));
 
 /**
  * Takes data and a channel id and constructs USB frames that are added
@@ -128,10 +129,10 @@ void usb_frame_send_cmd(uint8_t cmd, const uint8_t* data, uint32_t len, uint8_t 
  * @param[in] err The error send to the host.
  * @param[in] add_frame_callback The callback to which we add the frame.
  */
-uint8_t usb_frame_prepare_err(
+queue_error_t usb_frame_prepare_err(
     uint8_t err,
     uint32_t cid,
-    int32_t(add_frame_callback)(const uint8_t*));
+    queue_error_t(add_frame_callback)(const uint8_t*));
 
 /**
  * Processes usb frame requests.

--- a/src/usb/usb_frame.h
+++ b/src/usb/usb_frame.h
@@ -107,7 +107,7 @@ uint8_t usb_frame_reply(
     const uint8_t* data,
     uint32_t len,
     uint32_t cid,
-    uint8_t(add_frame_callback)(const uint8_t*));
+    int32_t(add_frame_callback)(const uint8_t*));
 
 /**
  * Takes data and a channel id and constructs USB frames that are added
@@ -131,7 +131,7 @@ void usb_frame_send_cmd(uint8_t cmd, const uint8_t* data, uint32_t len, uint8_t 
 uint8_t usb_frame_prepare_err(
     uint8_t err,
     uint32_t cid,
-    uint8_t(add_frame_callback)(const uint8_t*));
+    int32_t(add_frame_callback)(const uint8_t*));
 
 /**
  * Processes usb frame requests.

--- a/src/usb/usb_packet.c
+++ b/src/usb/usb_packet.c
@@ -16,6 +16,7 @@
 #include "queue.h"
 #include "screen.h"
 #include "usb_processing.h"
+#include <err_codes.h>
 #include <stdbool.h>
 #include <stdlib.h>
 
@@ -59,9 +60,14 @@ static State _in_state;
  */
 static void _reset_state(void)
 {
-    queue_clear();
+    queue_clear(queue_hww_queue());
     _timeout_disable(_in_state.cid);
     memset(&_in_state, 0, sizeof(_in_state));
+}
+
+static int32_t _queue_push(const uint8_t* data)
+{
+    return queue_push(queue_hww_queue(), data);
 }
 
 /**
@@ -72,7 +78,7 @@ static void _reset_state(void)
  */
 static void _queue_err(const uint8_t err, uint32_t cid)
 {
-    usb_frame_prepare_err(err, cid, queue_push);
+    usb_frame_prepare_err(err, cid, _queue_push);
 }
 
 static bool _need_more_data(void)

--- a/src/usb/usb_packet.h
+++ b/src/usb/usb_packet.h
@@ -47,23 +47,4 @@ typedef struct {
  */
 bool usb_packet_process(const USB_FRAME* frame, void (*send_packet)(void));
 
-/**
- * Checks if there has been a timeout
- */
-bool usb_packet_timeout_get(uint32_t* cid);
-
-/**
- * Queue a timeout packet for cid
- */
-void usb_packet_timeout(uint32_t cid);
-
-/**
- * Increase the timout timers with 1 step (steps in 100ms)
- */
-void usb_packet_timeout_tick(void);
-
-/**
- * Enable timer for this cid
- */
-void usb_packet_timeout_enable(uint32_t cid);
 #endif

--- a/src/usb/usb_processing.h
+++ b/src/usb/usb_processing.h
@@ -18,26 +18,34 @@
 #include "usb_frame.h"
 #include "usb_packet.h"
 
+struct usb_processing;
+
 /**
  * Register a command callback that is executed when a USB frame with
  * a specific cmd id is received.
  * @param[in] cmd_callbacks The available callbacks for incoming commands.
  * @param[in] num_cmds The number of registered commands.
  */
-void usb_processing_register_cmds(const CMD_Callback* cmd_callbacks, int num_cmds);
+void usb_processing_register_cmds(
+    struct usb_processing*,
+    const CMD_Callback* cmd_callbacks,
+    int num_cmds);
 
 /**
  * Enqueues a usb packet for processing. Ownership is transferred, and the
  * memory will be freed in `usb_processing_dequeue`.
  * @param[in] in_state The packet is built from in_state and queued.
- * @param[in] function to be called to send the response. This is passed as it
- * could be one of multiple USB interfaces.
  * @return false if there is already a packet in the queue (need to process it
  * first).
  */
-bool usb_processing_enqueue(const State* in_state, void (*send)(void));
-void usb_processing_process(void);
+bool usb_processing_enqueue(struct usb_processing*, const State* in_state);
+void usb_processing_process(struct usb_processing*);
 
-void usb_processing_set_send(void (*send)(void));
+void usb_processing_set_send(struct usb_processing*, void (*send)(void));
+
+struct usb_processing* usb_processing_u2f(void);
+struct usb_processing* usb_processing_hww(void);
+
+void usb_processing_init(void);
 
 #endif

--- a/test/device-test/src/framework/test_common.c
+++ b/test/device-test/src/framework/test_common.c
@@ -297,7 +297,7 @@ uint8_t test_usb_init(
  */
 void test_hid_send(enum interface_type interface)
 {
-    uint8_t* data = queue_pull();
+    uint8_t* data = queue_pull(queue_hww_queue());
     if (data != NULL) {
         (void)interface;
         // TODO: marko refactored the USB stuff, needs to be fixed

--- a/test/device-test/src/test_usb_cmd_process.c
+++ b/test/device-test/src/test_usb_cmd_process.c
@@ -46,7 +46,8 @@ static void usb_hww_endpoint_available(void)
         screen_print_debug("HWW interface disabled", 1000);
         return;
     };
-    usb_processing_register_cmds(hww_cmd_callbacks, NUM_REGISTERED_HWW_COMMANDS);
+    usb_processing_register_cmds(
+        usb_processing_hww(), hww_cmd_callbacks, NUM_REGISTERED_HWW_COMMANDS);
 
     hid_hww_setup();
 }
@@ -59,7 +60,8 @@ static void usb_u2f_endpoint_available(void)
         screen_print_debug("U2F interface disabled", 1000);
         return;
     };
-    usb_processing_register_cmds(u2f_cmd_callbacks, NUM_REGISTERED_U2F_COMMANDS);
+    usb_processing_register_cmds(
+        usb_processing_u2f(), u2f_cmd_callbacks, NUM_REGISTERED_U2F_COMMANDS);
 
     hid_u2f_setup();
 }

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -228,7 +228,7 @@ foreach(I RANGE 0 ${U2F_TESTS_LEN} 2)
     ${TEST_LINK_ARGS}
   )
   target_compile_definitions(${EXE} PRIVATE "TESTING")
-#  add_test(NAME test_${TEST_NAME} COMMAND ${EXE})
+  add_test(NAME test_${TEST_NAME} COMMAND ${EXE})
 
   # Running these two tests require a hardware device connected and they link to the real libhidapi.
   set(EXE test_${TEST_NAME}_with_hardware)

--- a/test/unit-test/framework/mock_hidapi.c
+++ b/test/unit-test/framework/mock_hidapi.c
@@ -139,7 +139,7 @@ int hid_read_timeout(hid_device* dev, unsigned char* r, size_t r_len, int to)
         usb_processing_process();
     }
     usb_processing_process();
-    uint8_t* p = queue_pull();
+    uint8_t* p = queue_pull(queue_hww_queue());
     // printf("Queue: %p\n", p);
     if (p != NULL) {
         memcpy(r, p, MIN(r_len, BUFSIZE));
@@ -148,7 +148,7 @@ int hid_read_timeout(hid_device* dev, unsigned char* r, size_t r_len, int to)
         _delay(600);
         return -127;
     }
-    if (queue_peek() == NULL) {
+    if (queue_peek(queue_hww_queue()) == NULL) {
         _have_data = false;
     }
     _expect_more = false;


### PR DESCRIPTION
Fix issues with U2F and HWW functionality stepping on each others toes.

To test/build either wipe `/build` or run `cmake -DHEAP_SIZE=0x18000`. The value in the build directory is cached and will not change, even though it changed in the cmake files.