### PR TITLE
Create tracing/logging framework.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,11 @@ endif()
 
 project(bitbox02 C)
 
+# nosys is set in arm.cmake so that `project(c)` above works. Remove it since it interferes with compile options
+if(CMAKE_CROSSCOMPILING)
+  string(REPLACE "--specs=nosys.specs" "" CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS})
+endif()
+
 # Where to find custom cmake modules
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/tools/nanopb/extra)
@@ -74,6 +79,7 @@ if(CMAKE_CROSSCOMPILING)
   find_program(CMAKE_SIZE "${TOOLCHAIN_PREFIX}size" HINTS /usr/local/bin)
   message(STATUS size: ${CMAKE_SIZE} ${TOOLCHAIN_PREFIX}size)
 endif()
+
 
 #-----------------------------------------------------------------------------
 # Create version header file
@@ -277,6 +283,9 @@ string(APPEND CMAKE_C_FLAGS " -fstack-protector-all")
 
 # For `struct timespec` and `strdup`
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_XOPEN_SOURCE=600")
+
+string(LENGTH "${CMAKE_SOURCE_DIR}/" SOURCE_PATH_SIZE)
+add_definitions("-DSOURCE_PATH_SIZE=${SOURCE_PATH_SIZE}")
 
 
 #-----------------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,9 @@ firmware: | build
 # Generate python bindings for protobuf for test scripts
 	$(MAKE) -C py
 	$(MAKE) -C build firmware.elf
+firmware-semihosting: | build
+	$(MAKE) -C py
+	$(MAKE) -C build firmware-semihosting.elf
 bootloader: | build
 	$(MAKE) -C build bootloader.elf
 bootloader-devdevice: | build
@@ -74,6 +77,8 @@ jlink-flash-bootloader: | build
 	JLinkExe -if SWD -device ATSAMD51J20 -speed 4000 -autoconnect 1 -CommanderScript ./build/scripts/bootloader-development.jlink
 jlink-flash-firmware: | build
 	JLinkExe -if SWD -device ATSAMD51J20 -speed 4000 -autoconnect 1 -CommanderScript ./build/scripts/firmware.jlink
+jlink-flash-firmware-semihosting: | build
+	JLinkExe -if SWD -device ATSAMD51J20 -speed 4000 -autoconnect 1 -CommanderScript ./build/scripts/firmware-semihosting.jlink
 dockerinit:
 	docker build --pull --force-rm -t shiftcrypto/firmware_v2 .
 dockerdev:

--- a/arm.cmake
+++ b/arm.cmake
@@ -17,6 +17,6 @@ set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 set(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")
 set(CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS "")
 
-# Avoid linking error:
-#    exit.c:(.text.exit+0x2c): undefined reference to `_exit'
-set(CMAKE_EXE_LINKER_FLAGS "--specs=nosys.specs --specs=nano.specs" CACHE INTERNAL "")
+# nosys selects an weak "no-op" implementation of the system commands. This allows CMake to link its test executables.
+# weak means that if a symbol is provided, like _break, that will be used instead.
+set(CMAKE_EXE_LINKER_FLAGS "--specs=nosys.specs" CACHE INTERNAL "")

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -27,7 +27,10 @@ set(NOISEC_CFLAGS "\
 ")
 # Hide some warnings
 set(NOISEC_CFLAGS "${NOISEC_CFLAGS} -Wformat=0 -Wno-implicit-fallthrough -Wno-undef -Wno-cast-qual -Wno-switch-default -Wno-packed -Wno-pedantic -Wno-missing-prototypes -Wno-unused-parameter -Wno-redundant-decls -Wno-missing-declarations -Wno-shadow")
-set(NOISEC_LDFLAGS "${CMAKE_EXE_LINKER_FLAGS} ${CMAKE_C_LINK_FLAGS} -lc")
+if(CMAKE_CROSSCOMPILING)
+  set(NOISEC_LDFLAGS "--specs=nosys.specs")
+endif()
+set(NOISEC_LDFLAGS "${NOISEC_LDFLAGS} ${CMAKE_C_LINK_FLAGS} -lc")
 
 ExternalProject_Add(noise-c
   PREFIX          ${CMAKE_CURRENT_BINARY_DIR}/noise-c
@@ -75,7 +78,10 @@ set(LIBWALLY_CFLAGS "${LIBWALLY_CFLAGS} -Wno-cast-qual -Wno-cast-align \
   -Wno-switch-default -Wno-missing-declarations \
   -Wno-array-bounds \
 ")
-set(LIBWALLY_LDFLAGS "${CMAKE_EXE_LINKER_FLAGS} ${CMAKE_C_LINK_FLAGS}")
+if(CMAKE_CROSSCOMPILING)
+  set(LIBWALLY_LDFLAGS --specs=nosys.specs)
+endif()
+set(LIBWALLY_LDFLAGS "${LIBWALLY_LDFLAGS} ${CMAKE_C_LINK_FLAGS}")
 
 ExternalProject_Add(libwally-core
   PREFIX          ${CMAKE_CURRENT_BINARY_DIR}/libwally-core

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -1,6 +1,6 @@
 if(PYTHONINTERP_FOUND)
   # This template flashes with an offset
-  foreach(target firmware factory-setup)
+  foreach(target firmware firmware-semihosting factory-setup)
     execute_process(
       COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/expand_template ${CMAKE_CURRENT_SOURCE_DIR}/template-firmware.jlink file=build/bin/${target}.bin -o ${target}.jlink
       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
@@ -8,7 +8,7 @@ if(PYTHONINTERP_FOUND)
   endforeach()
 
   # This template flashes without an offset
-  foreach(target bootloader bootloader-development)
+  foreach(target bootloader bootloader-development bootloader-semihosting bootloader-production)
     execute_process(
       COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/expand_template ${CMAKE_CURRENT_SOURCE_DIR}/template-bootloader.jlink file=build/bin/${target}.bin -o ${target}.jlink
       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}

--- a/scripts/bootloader.jlink
+++ b/scripts/bootloader.jlink
@@ -1,3 +1,0 @@
-loadfile build/bin/bootloader.bin
-r
-q

--- a/scripts/firmware.jlink
+++ b/scripts/firmware.jlink
@@ -1,3 +1,0 @@
-loadbin build/bin/firmware.bin 0x10000
-r
-q

--- a/scripts/jlink-gdb-debug/.gdbinit
+++ b/scripts/jlink-gdb-debug/.gdbinit
@@ -1,0 +1,8 @@
+# Start a JLink gdb server with the following command:
+# $ JLinkGDBServer -if SWD -device ATSAMD51J20 -speed 4000 -ir
+# See I/O using telnet:
+# $ telnet localhost 2333
+file ../../build/bin/firmware-semihosting.elf
+target remote :2331
+monitor semihosting enable
+monitor reset

--- a/scripts/jlink-gdb-debug/README.md
+++ b/scripts/jlink-gdb-debug/README.md
@@ -1,0 +1,71 @@
+# Debugging with JLinkGDBServer
+
+If the firmware is compiled with semihosting support, the input and output is redirected to the
+developers computer. See instructions below.
+
+## Compile and flash firmware with semihosting support
+
+In the root directory of the project run:
+
+```
+make firmware-semihosting
+make jlink-flash-firmware-semihosting
+```
+
+
+## Configure GDB
+
+If you want to use the `.gdbinit` helper script you need to allow it by creating `~/.gdbinit` with
+the following content:
+
+```
+set auto-load safe-path /
+```
+
+## Run JLinkGDBServer
+
+Start the JLink GDB server with the following command:
+
+```
+JLinkGDBServer -if SWD -device ATSAMD51J20 -speed 4000 -ir
+```
+
+## Run GDB (with arm support)
+
+The GDB init file, `.gdbinit`, contains the following commands:
+
+```
+file ../../build/bin/firmware-semihosting.elf
+target remote :2331
+monitor semihosting enable
+monitor reset
+```
+
+First it will load the symbols from `firmware-semihosting.elf` then it will connect to the JLink GDB Server.
+After that it will enable "semihosting" to redirect IO to the JLink GDB Server. Finally it will reset the
+device.
+
+Change your current working directory to the directory with the `.gdbinit` file and run `gdb`.
+
+```
+cd <project-dir>/scripts/jlink-gdb-debug
+gdb-multiarch
+```
+
+## See input and output
+
+In a new terminal, run `telnet localhost 2333` to connect to the IO of the device through the GDB
+Server.
+
+```
+$ telnet localhost 2333
+Trying 127.0.0.1...
+Connected to localhost.
+Escape character is '^]'.
+SEGGER J-Link GDB Server V6.44h - Terminal output channel
+```
+
+
+## Start debugging
+
+To start debugging run the command `continue` in GDB.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -413,7 +413,7 @@ if(CMAKE_CROSSCOMPILING)
   set(STACK_SIZE ${STACK_SIZE} PARENT_SCOPE)
   set(HEAP_SIZE "0x18000" CACHE STRING "Specify heap size for bootloader/firmware")
   set(HEAP_SIZE ${HEAP_SIZE} PARENT_SCOPE)
-  foreach(bootloader bootloader bootloader-development bootloader-production)
+  foreach(bootloader bootloader bootloader-development bootloader-semihosting bootloader-production)
     set(elf ${bootloader}.elf)
     add_executable(${elf} ${BOOTLOADER-SOURCES})
     target_include_directories(${elf} PRIVATE ${INCLUDES})
@@ -426,13 +426,26 @@ if(CMAKE_CROSSCOMPILING)
     target_link_libraries(${elf} PRIVATE "-Wl,-Map=\"${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${bootloader}.map\" -T\"${CMAKE_SOURCE_DIR}/bootloader.ld\"")
     target_link_libraries(${elf} PRIVATE -Wl,--defsym=STACK_SIZE=${STACK_SIZE} -Wl,-defsym=HEAP_SIZE=${HEAP_SIZE})
     target_link_libraries(${elf} PRIVATE qtouchlib_a qtouchlib_b qtouchlib_t)
+    # Select the smaller version of libc called nano.
+    target_compile_options(${elf} PRIVATE --specs=nano.specs)
+    target_link_libraries(${elf} PRIVATE --specs=nano.specs)
+    if(NOT bootloader STREQUAL "bootloader-semihosting")
+      target_compile_options(${elf} PRIVATE --specs=nosys.specs)
+      target_link_libraries(${elf} PRIVATE --specs=nosys.specs)
+    endif()
   endforeach(bootloader)
 
   target_compile_definitions(bootloader-development.elf PRIVATE BOOTLOADER_DEVDEVICE)
+
+  # Select an implementation of the system calls that can communicate with the debugger
+  target_compile_options(bootloader-semihosting.elf PRIVATE --specs=rdimon.specs)
+  target_link_libraries(bootloader-semihosting.elf PRIVATE --specs=rdimon.specs)
+  target_compile_definitions(bootloader-semihosting.elf PRIVATE BOOTLOADER_DEVDEVICE SEMIHOSTING)
+
   target_compile_definitions(bootloader-production.elf PRIVATE BOOTLOADER_PRODUCTION)
   set_property(TARGET bootloader-production.elf PROPERTY EXCLUDE_FROM_ALL ON)
 
-  foreach(firmware firmware factory-setup)
+  foreach(firmware firmware firmware-semihosting factory-setup)
     set(elf ${firmware}.elf)
     add_executable(${elf} ${FIRMWARE-SOURCES})
     add_dependencies(${elf} generate-hww generate-backup)
@@ -466,13 +479,28 @@ if(CMAKE_CROSSCOMPILING)
     target_link_libraries(${elf} PRIVATE wallycore secp256k1)
     target_link_libraries(${elf} PRIVATE qtouchlib_a qtouchlib_b qtouchlib_t)
 
+    # Select the smaller version of libc called nano.
+    target_compile_options(${elf} PRIVATE --specs=nano.specs)
+    target_link_libraries(${elf} PRIVATE --specs=nano.specs)
+    if(NOT firmware STREQUAL "firmware-semihosting")
+      target_compile_options(${elf} PRIVATE --specs=nosys.specs)
+      target_link_libraries(${elf} PRIVATE --specs=nosys.specs)
+    endif()
+
   endforeach(firmware)
 
   target_sources(firmware.elf PRIVATE firmware.c)
+
+  target_sources(firmware-semihosting.elf PRIVATE firmware.c)
+  # Select an implementation of the system calls that can communicate with the debugger
+  target_compile_options(firmware-semihosting.elf PRIVATE --specs=rdimon.specs)
+  target_link_libraries(firmware-semihosting.elf PRIVATE --specs=rdimon.specs)
+  target_compile_definitions(firmware-semihosting.elf PRIVATE SEMIHOSTING)
+
   target_sources(factory-setup.elf PRIVATE factorysetup.c)
   target_compile_definitions(factory-setup.elf PRIVATE FACTORYSETUP)
 
-  foreach(name bootloader bootloader-development bootloader-production firmware factory-setup)
+  foreach(name bootloader bootloader-development bootloader-semihosting bootloader-production firmware firmware-semihosting factory-setup)
     add_custom_command(
       TARGET ${name}.elf POST_BUILD
       COMMAND ${CMAKE_SIZE} ${name}.elf

--- a/src/drivers/SAMD51_DFP/1.0.70/gcc/gcc/startup_samd51.c
+++ b/src/drivers/SAMD51_DFP/1.0.70/gcc/gcc/startup_samd51.c
@@ -344,7 +344,7 @@ void SDHC1_Handler           ( void ) __attribute__ ((weak, alias("Dummy_Handler
 #endif
 
 /* Exception Table */
-__attribute__ ((section(".vectors")))
+__attribute__ ((section(".vectors"), used))
 const DeviceVectors exception_table = {
 
     /* Configure Initial Stack Pointer, using linker-generated symbols */

--- a/src/drivers/driver_init.c
+++ b/src/drivers/driver_init.c
@@ -29,6 +29,8 @@ struct rand_sync_desc RAND_0;
 PPUKCL_PARAM pvPUKCLParam;
 PUKCL_PARAM PUKCLParam;
 
+extern void initialise_monitor_handles(void);
+
 bool _is_initialized = false;
 
 /**
@@ -302,6 +304,9 @@ void system_init(void)
     _flash_memory_init();
     // USB
     _usb_init();
+#if defined(SEMIHOSTING)
+    initialise_monitor_handles();
+#endif
     _is_initialized = true;
 }
 

--- a/src/drivers/hal/utils/src/utils_syscalls.c
+++ b/src/drivers/hal/utils/src/utils_syscalls.c
@@ -104,6 +104,8 @@ extern int link(char *old, char *_new)
 	return -1;
 }
 
+#if !defined(SEMIHOSTING)
+
 /**
  * \brief Replacement of C library of _close
  */
@@ -169,6 +171,8 @@ extern int _getpid(void)
 {
 	return -1;
 }
+
+#endif
 
 #ifdef __cplusplus
 }

--- a/src/drivers/usb/class/hid/hww/hid_hww.h
+++ b/src/drivers/usb/class/hid/hww/hid_hww.h
@@ -18,13 +18,6 @@
 #include "hid.h"
 
 /**
- * Sets the buffer address for the outgoing endpoint.
- * The length of the data to be written is defined in USB_HID_REPORT_OUT_SIZE.
- * @param[IN] size The size of the buffer.
- */
-int32_t hid_hww_write(uint8_t *buf);
-
-/**
  * Initializes a HWW HID interface.
  * @param[in] callback The callback that is called upon status update (enabling/disabling or the endpoints).
  */

--- a/src/hardfault.c
+++ b/src/hardfault.c
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "hardfault.h"
+#include "util.h"
 #include <screen.h>
 #include <usb/usb.h>
 #ifndef TESTING
@@ -32,6 +33,7 @@ void MemManage_Handler(void)
 void Abort(const char* msg)
 {
     screen_print_debug(msg, 0);
+    traceln("Aborted: %s", msg);
     usb_stop();
 #ifndef TESTING
     system_close_interfaces();

--- a/src/util.h
+++ b/src/util.h
@@ -94,4 +94,36 @@ bool safe_uint64_add(uint64_t* a, uint64_t b);
 #define UTIL_WARN_UNUSED_RESULT
 #endif
 
+/**
+ * Tracing tools. Only enabled in semihosting builds
+ *
+ * Since we are using C99 it is necessary to provide at least 1 argument to "...". To print a
+ * string, provide the format string "%s" and your string as the second argument.
+ *
+ * "do {} while" is a hack to make a macro work like a function in some cases.
+ *
+ * stderr is not buffered and takes forever to print stdout is used instead.
+ *
+ * SOURCE_PATH_SIZE is a definition provided from the command line which is the length of the path
+ * to the project directory.
+ */
+
+#if defined(SEMIHOSTING)
+#define LOG_LEVEL 1
+#else
+#define LOG_LEVEL 0
+#endif
+#define FILENAME (__FILE__ + SOURCE_PATH_SIZE)
+
+#define trace(format, ...)                                                                     \
+    do {                                                                                       \
+        if (LOG_LEVEL > 0) fprintf(stdout, "%s:%d: " format, FILENAME, __LINE__, __VA_ARGS__); \
+    } while (0)
+
+#define traceln(format, ...)                                                         \
+    do {                                                                             \
+        if (LOG_LEVEL > 0)                                                           \
+            fprintf(stdout, "%s:%d: " format "\n", FILENAME, __LINE__, __VA_ARGS__); \
+    } while (0)
+
 #endif

--- a/test/device-test/CMakeLists.txt
+++ b/test/device-test/CMakeLists.txt
@@ -72,6 +72,11 @@ target_include_directories(bitbox SYSTEM PUBLIC ${CMAKE_SOURCE_DIR}/external/lib
 # needed to find version.h
 target_include_directories(bitbox SYSTEM PUBLIC ${CMAKE_BINARY_DIR}/src)
 
+# Always enable semihosting for the test firmwares
+target_compile_definitions(bitbox PUBLIC SEMIHOSTING)
+target_link_libraries(bitbox PUBLIC --specs=nano.specs --specs=rdimon.specs)
+target_compile_options(bitbox PUBLIC --specs=nano.specs --specs=rdimon.specs)
+
 add_library(qtouchlib_a STATIC IMPORTED)
 set_property(TARGET qtouchlib_a PROPERTY IMPORTED_LOCATION
   ${CMAKE_SOURCE_DIR}/src/drivers/qtouch/lib/gcc/libqtm_acq_samd51_0x000f.a
@@ -99,6 +104,7 @@ set(TEST_LIST
   slide_info
   ssp
   tap_menu
+  trace
   usb_cmd_process
   usb_composed_ep_in
   usb_composed_ep_out
@@ -121,11 +127,11 @@ foreach(name ${TEST_LIST})
   target_link_libraries(${elf} PRIVATE -Wl,--defsym=STACK_SIZE=${STACK_SIZE} -Wl,-defsym=HEAP_SIZE=${HEAP_SIZE})
 
   add_dependencies(${elf} noise-c)
-  target_link_libraries(${elf} PRIVATE noiseprotocol)
-
   add_dependencies(${elf} libwally-core)
   # We must link against libc before libbitbox because malloc depends on _sbrk
-  target_link_libraries(${elf} PRIVATE c bitbox)
+  # We must mark "exception_table" as used, otherwise it won't be linked in since it is in a static library
+  target_link_libraries(${elf} PRIVATE c bitbox -Wl,-u,exception_table)
+  target_link_libraries(${elf} PRIVATE noiseprotocol)
   target_link_libraries(${elf} PRIVATE wallycore secp256k1)
   target_link_libraries(${elf} PRIVATE qtouchlib_a qtouchlib_b qtouchlib_t)
 

--- a/test/device-test/src/framework/test_common.c
+++ b/test/device-test/src/framework/test_common.c
@@ -335,7 +335,7 @@ void test_hww_out_echo(const uint8_t ep, const enum usb_xfer_code rc, const uint
     read_and_print2screen(hww_metadata);
 
     echo_data(&hww_metadata->packet, &hww_metadata->write_frame);
-    hid_hww_write((uint8_t*)&hww_metadata->write_frame);
+    // hid_hww_write((uint8_t*)&hww_metadata->write_frame);
 
     // Wait for data
     // TODO: marko refactored the USB stuff, needs to be fixed

--- a/test/device-test/src/test_trace.c
+++ b/test/device-test/src/test_trace.c
@@ -13,22 +13,14 @@
 // limitations under the License.
 
 #include "common_main.h"
-#include "drivers/driver_init.h"
+#include "driver_init.h"
 #include "hardfault.h"
-#include "keystore.h"
-#include "memory.h"
 #include "qtouch.h"
 #include "screen.h"
-#include "sd.h"
-#include "ui/screen_process.h"
-#include "workflow/workflow.h"
+#include "util.h"
+#include <string.h>
 
-static workflow_interface_functions_t _workflow_interface_functions = {
-    .is_seeded = memory_is_seeded,
-    .sd_card_inserted = sd_card_inserted,
-    .get_bip39_mnemonic = keystore_get_bip39_mnemonic,
-    .get_bip39_word = keystore_get_bip39_word,
-};
+#include <usb/usb.h>
 
 uint32_t __stack_chk_guard = 0;
 
@@ -38,13 +30,12 @@ int main(void)
     system_init();
     __stack_chk_guard = common_stack_chk_guard();
     screen_init();
+    screen_print_debug("hej", 1001);
     screen_splash();
     qtouch_init();
-    common_main();
-    traceln("%s", "Device initialized");
-    // dev convenience
-    // if (memory_is_seeded()) { memory_reset_hww(); }
-    workflow_set_interface_functions(&_workflow_interface_functions);
-    workflow_change_state(WORKFLOW_STATE_CHOOSE_ORIENTATION);
-    ui_screen_process(NULL);
+    traceln("%s", "testytest");
+    traceln("%lu", __stack_chk_guard);
+    Abort("End of main");
+    while (1) {
+    }
 }


### PR DESCRIPTION
This PR introduces two things:

* [x] Debugging with semihosting
* [x] ~Retarget stdout/stderr to the screen.~ (future feature)
* [x] Introduces `trace(args...)`
 
# Debugging with semihosting

The detailed instructions are in `/scripts/jlink-gdb-debug/README.md`. Essentially this allows you to add regular `printf`s and they are printed on a screen on the computer running the GDB Server.

Semihosting also allows us to open files and dump binary data with normal `fopen`/`fwrite` libc functions.

# Retarget stdout/stderr

`printf` uses a function called `_write` to actually write the resulting bytes. This PR implements it by printing the bytes to the screen. The default implementation of `_write` is a no-op and does nothing. 

# `trace(args...)`
`trace` is a macro that expands to printf in a semihosted build and expands to no-op in a non-semihosted build. This allows us to leave some debugging functionality in the firmware and reduce the churn while implementing new features.



# Test

You can test it with a device test firmware:

```
make -C build fw_test_trace.elf
JLinkExe -if SWD -device ATSAMD51J20 -speed 4000 -autoconnect 1 -CommanderScript ./build/test/device-test/fw_test_trace.jlink
```