### PR TITLE
u2f: reduce time to response

### DIFF
--- a/src/u2f/u2f_app.h
+++ b/src/u2f/u2f_app.h
@@ -20,10 +20,11 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-typedef enum {
+enum u2f_app_confirm_t {
     U2F_APP_REGISTER,
     U2F_APP_AUTHENTICATE,
-} u2f_app_confirm_t;
+    U2F_APP_BOGUS,
+};
 
 /**
  * User confirm auth/registration for a website given by the U2F app ID.
@@ -31,6 +32,6 @@ typedef enum {
  * @param[in] app_id U2F app ID to identify the website.
  * @return true if the user accepts, false for rejection or timeout.
  */
-USE_RESULT bool u2f_app_confirm(u2f_app_confirm_t type, const uint8_t* app_id);
+USE_RESULT bool u2f_app_confirm(enum u2f_app_confirm_t type, const uint8_t* app_id);
 
 #endif


### PR DESCRIPTION
with our current firmware architecture and the fact that windows
requires a response within 2-3s we need to reduce the time for the user
to respond to less than 1s.

This timeout was empirically found using windows 1903.