### PR TITLE
CMakeLists: new target, bootloader-development-locked

### DIFF
--- a/.ci/ci
+++ b/.ci/ci
@@ -15,6 +15,7 @@ make prepare-tidy
 # Bootloader variants
 make -j8 bootloader
 make -j8 bootloader-devdevice
+make -j8 bootloader-devdevice-locked
 make -j8 bootloader-production
 
 make -j8 bootloader-btc

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,8 @@ bootloader: | build
 	$(MAKE) -C build bootloader.elf
 bootloader-devdevice: | build
 	$(MAKE) -C build bootloader-development.elf
+bootloader-devdevice-locked: | build
+	$(MAKE) -C build bootloader-development-locked.elf
 bootloader-production: | build
 	$(MAKE) -C build bootloader-production.elf
 bootloader-btc: | build

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -414,7 +414,7 @@ if(CMAKE_CROSSCOMPILING)
   set(HEAP_SIZE "0x18000" CACHE STRING "Specify heap size for bootloader/firmware")
   set(HEAP_SIZE ${HEAP_SIZE} PARENT_SCOPE)
 
-  set(BOOTLOADERS bootloader bootloader-development bootloader-semihosting bootloader-production bootloader-btc bootloader-btc-development bootloader-btc-production)
+  set(BOOTLOADERS bootloader bootloader-development bootloader-development-locked bootloader-semihosting bootloader-production bootloader-btc bootloader-btc-development bootloader-btc-production)
   set(BOOTLOADERS ${BOOTLOADERS} PARENT_SCOPE)
   foreach(bootloader ${BOOTLOADERS})
     set(elf ${bootloader}.elf)
@@ -439,6 +439,8 @@ if(CMAKE_CROSSCOMPILING)
   endforeach(bootloader)
 
   target_compile_definitions(bootloader-development.elf PRIVATE BOOTLOADER_DEVDEVICE)
+  target_compile_definitions(bootloader-development-locked.elf PRIVATE BOOTLOADER_DEVDEVICE BOOTLOADER_PRODUCTION)
+  set_property(TARGET bootloader-development-locked.elf PROPERTY EXCLUDE_FROM_ALL ON)
 
   # Select an implementation of the system calls that can communicate with the debugger
   target_compile_options(bootloader-semihosting.elf PRIVATE --specs=rdimon.specs)


### PR DESCRIPTION
Locks the dev bootloader so it can't be erased.