### PR TITLE
Separate screen-, workflow- and usb-related functions

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 set(DBB-FIRMWARE-SOURCES
+  ${CMAKE_SOURCE_DIR}/src/firmware_main_loop.c
   ${CMAKE_SOURCE_DIR}/src/commander/commander.c
   ${CMAKE_SOURCE_DIR}/src/commander/commander_btc.c
   ${CMAKE_SOURCE_DIR}/src/commander/commander_states.c

--- a/src/firmware.c
+++ b/src/firmware.c
@@ -14,11 +14,11 @@
 
 #include "common_main.h"
 #include "driver_init.h"
+#include "firmware_main_loop.h"
 #include "hardfault.h"
 #include "peripherals_init.h"
 #include "qtouch.h"
 #include "screen.h"
-#include "ui/screen_process.h"
 #include "util.h"
 #include "workflow/workflow.h"
 
@@ -36,5 +36,6 @@ int main(void)
     common_main();
     traceln("%s", "Device initialized");
     workflow_change_state(WORKFLOW_STATE_CHOOSE_ORIENTATION);
-    ui_screen_process(NULL);
+    firmware_main_loop();
+    return 0;
 }

--- a/src/firmware_main_loop.c
+++ b/src/firmware_main_loop.c
@@ -1,0 +1,37 @@
+#include "firmware_main_loop.h"
+
+#include "hardfault.h"
+#include "ui/screen_process.h"
+#include "usb/usb_processing.h"
+
+#include <stdbool.h>
+
+/*
+ * "is_done" callback that only spins the UI
+ * once.
+ */
+static bool _is_done_run_once(void* param)
+{
+    if (!param) {
+        Abort("_is_done_run_once called\nwith NULL param.");
+    }
+    bool* already_run = (bool*)param;
+    if (!(*already_run)) {
+        *already_run = true;
+        return false;
+    }
+    return true;
+}
+
+void firmware_main_loop(void)
+{
+    bool already_run;
+    while (1) {
+        already_run = false;
+        ui_screen_process(_is_done_run_once, &already_run);
+        usb_processing_process(usb_processing_hww());
+#if defined(APP_U2F)
+        usb_processing_process(usb_processing_u2f());
+#endif
+    }
+}

--- a/src/firmware_main_loop.c
+++ b/src/firmware_main_loop.c
@@ -1,34 +1,26 @@
+// Copyright 2019 Shift Cryptosecurity AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "firmware_main_loop.h"
 
-#include "hardfault.h"
 #include "ui/screen_process.h"
 #include "usb/usb_processing.h"
 
-#include <stdbool.h>
-
-/*
- * "is_done" callback that only spins the UI
- * once.
- */
-static bool _is_done_run_once(void* param)
-{
-    if (!param) {
-        Abort("_is_done_run_once called\nwith NULL param.");
-    }
-    bool* already_run = (bool*)param;
-    if (!(*already_run)) {
-        *already_run = true;
-        return false;
-    }
-    return true;
-}
-
 void firmware_main_loop(void)
 {
-    bool already_run;
     while (1) {
-        already_run = false;
-        ui_screen_process(_is_done_run_once, &already_run);
+        screen_process();
         usb_processing_process(usb_processing_hww());
 #if defined(APP_U2F)
         usb_processing_process(usb_processing_u2f());

--- a/src/firmware_main_loop.h
+++ b/src/firmware_main_loop.h
@@ -1,0 +1,23 @@
+// Copyright 2019 Shift Cryptosecurity AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _FIRMWARE_MAIN_LOOP_H_
+#define _FIRMWARE_MAIN_LOOP_H_
+
+/**
+ * Runs the main UI of the bitbox.
+ */
+void firmware_main_loop(void);
+
+#endif

--- a/src/u2f/u2f_app.c
+++ b/src/u2f/u2f_app.c
@@ -1,6 +1,7 @@
 #include "u2f_app.h"
 
 #include <hardfault.h>
+#include <ui/screen_process.h>
 #include <util.h>
 #include <workflow/confirm.h>
 
@@ -65,5 +66,5 @@ bool u2f_app_confirm(enum u2f_app_confirm_t type, const uint8_t* app_id)
     }
     // 75 here is approximately 1 second. According to the protocol we need to respond within 3s
     // and the rest of the code need something like 1-1.5s.
-    return workflow_confirm_with_timeout(title, app_string, false, 75);
+    return workflow_confirm_with_timeout(title, app_string, false, 75 * SCREEN_FRAME_RATE);
 }

--- a/src/ui/screen_process.c
+++ b/src/ui/screen_process.c
@@ -87,47 +87,17 @@ static component_t* _get_ui_top_component(void)
     return result;
 }
 
-static void _run_blocking_ui(
-    bool (*is_done)(void*),
-    void* is_done_param,
-    void (*on_timeout)(void),
-    const uint32_t timeout)
+void screen_process(void)
 {
-    if (is_done == NULL) {
-        Abort("is_done function\nis NULL.");
-    }
-    uint32_t timeout_cnt = 0;
+    component_t* component = _get_ui_top_component();
+    _screen_draw(component);
 
-    while (!is_done(is_done_param)) {
-        if (on_timeout != NULL && timeout_cnt > timeout) {
-            on_timeout();
-        }
-        timeout_cnt += 1;
+    /*
+     * If we have changed activity, the gestures
+     * detection must start over.
+     */
+    bool screen_new = _screen_has_changed(component);
+    gestures_detect(screen_new, component->emit_without_release);
 
-        component_t* component = _get_ui_top_component();
-        _screen_draw(component);
-
-        /*
-         * If we have changed activity, the gestures
-         * detection must start over.
-         */
-        bool screen_new = _screen_has_changed(component);
-        gestures_detect(screen_new, component->emit_without_release);
-
-        ui_screen_stack_cleanup();
-    }
-}
-
-void ui_screen_process(bool (*is_done)(void*), void* is_done_param)
-{
-    _run_blocking_ui(is_done, is_done_param, NULL, 0);
-}
-
-void ui_screen_process_with_timeout(
-    bool (*is_done)(void*),
-    void* is_done_param,
-    void (*on_timeout)(void),
-    uint32_t timeout)
-{
-    _run_blocking_ui(is_done, is_done_param, on_timeout, timeout);
+    ui_screen_stack_cleanup();
 }

--- a/src/ui/screen_process.c
+++ b/src/ui/screen_process.c
@@ -19,7 +19,6 @@
 #include <ui/components/waiting.h>
 #include <ui/screen_process.h>
 #include <ui/ugui/ugui.h>
-#include <usb/usb_processing.h>
 
 #define SCREEN_FRAME_RATE 30
 
@@ -34,6 +33,23 @@ void ui_screen_render_component(component_t* component)
     UG_SendBuffer();
 }
 
+/**
+ * Detects if the screen component being displayed has changed
+ * since the last time this function was called.
+ * This stores the last observed component into a global.
+ *
+ * @param[in] current_component Current on-screen component.
+ */
+static bool _screen_has_changed(const component_t* current_component)
+{
+    static const component_t* last_observed_comp = NULL;
+    if (last_observed_comp != current_component) {
+        last_observed_comp = current_component;
+        return true;
+    }
+    return false;
+}
+
 static component_t* _get_waiting_screen(void)
 {
     static component_t* waiting_screen = NULL;
@@ -46,26 +62,36 @@ static component_t* _get_waiting_screen(void)
     return waiting_screen;
 }
 
-static void _screen_process(bool (*is_done)(void), void (*on_timeout)(void), const uint32_t timeout)
+static void _screen_process(
+    bool (*is_done)(void*),
+    void* is_done_param,
+    void (*on_timeout)(void),
+    const uint32_t timeout)
 {
     component_t* waiting_screen = _get_waiting_screen();
     uint32_t timeout_cnt = 0;
 
-    bool screen_new = false;
     component_t* component = NULL;
-    while (is_done == NULL || !is_done()) {
-        component_t* next_component = ui_screen_stack_top();
-        if (next_component == NULL) {
-            next_component = waiting_screen;
+
+    if (is_done == NULL) {
+        Abort("is_done function\nis NULL.");
+    }
+
+    while (!is_done(is_done_param)) {
+        /*
+         * Pick which activity we should draw next
+         * (or fallback to the idle screen).
+         * If we have changed activity, the gestures
+         * detection must start over.
+         */
+        component = ui_screen_stack_top();
+        if (component == NULL) {
+            component = waiting_screen;
         }
-        screen_new = false;
-        if (next_component != component) {
-            screen_new = true;
-            component = next_component;
-        }
+        bool screen_new = _screen_has_changed(component);
         gestures_detect(screen_new, component->emit_without_release);
         if (screen_frame_cnt == SCREEN_FRAME_RATE) {
-            if (is_done != NULL && on_timeout != NULL && timeout_cnt > timeout) {
+            if (on_timeout != NULL && timeout_cnt > timeout) {
                 on_timeout();
             }
             screen_frame_cnt = 0;
@@ -74,24 +100,19 @@ static void _screen_process(bool (*is_done)(void), void (*on_timeout)(void), con
         }
         screen_frame_cnt++;
         ui_screen_stack_cleanup();
-        if (is_done == NULL) {
-            usb_processing_process(usb_processing_hww());
-#if defined(APP_U2F)
-            usb_processing_process(usb_processing_u2f());
-#endif
-        }
     }
 }
 
-void ui_screen_process(bool (*is_done)(void))
+void ui_screen_process(bool (*is_done)(void*), void* is_done_param)
 {
-    _screen_process(is_done, NULL, 0);
+    _screen_process(is_done, is_done_param, NULL, 0);
 }
 
 void ui_screen_process_with_timeout(
-    bool (*is_done)(void),
+    bool (*is_done)(void*),
+    void* is_done_param,
     void (*on_timeout)(void),
     uint32_t timeout)
 {
-    _screen_process(is_done, on_timeout, timeout);
+    _screen_process(is_done, is_done_param, on_timeout, timeout);
 }

--- a/src/ui/screen_process.h
+++ b/src/ui/screen_process.h
@@ -42,4 +42,10 @@ void ui_screen_process_with_timeout(
     void (*on_timeout)(void),
     uint32_t timeout);
 
+/**
+ * Period of screen updates.
+ * The screen is refreshed every SCREEN_FRAME_RATE event loops cycles.
+ */
+#define SCREEN_FRAME_RATE 30
+
 #endif

--- a/src/ui/screen_process.h
+++ b/src/ui/screen_process.h
@@ -23,10 +23,12 @@ void ui_screen_render_component(component_t* component);
 /**
  * Process screen, gestures, in a loop. If is_done is NULL, usb packets are also
  * processed.
- * @param[in] is_done if NULL, runs forever. Otherwise runs until is_done().
- * This mode should only be called during the processing of a usb packet.
+ * @param[in] is_done Runs until is_done(is_done_param).
+ *            This should return true if and only if this GUI should
+ *            terminate.
+ * @param[in] is_done_param Parameter to be passed to \a is_done (can be NULL).
  */
-void ui_screen_process(bool (*is_done)(void));
+void ui_screen_process(bool (*is_done)(void*), void* is_done_param);
 
 /**
  * Process screen, gestures, in a loop with timeout.
@@ -35,7 +37,8 @@ void ui_screen_process(bool (*is_done)(void));
  * @param[in] timeout number of screen refreshes until timeout
  */
 void ui_screen_process_with_timeout(
-    bool (*is_done)(void),
+    bool (*is_done)(void*),
+    void* is_done_param,
     void (*on_timeout)(void),
     uint32_t timeout);
 

--- a/src/ui/screen_process.h
+++ b/src/ui/screen_process.h
@@ -21,26 +21,12 @@
 void ui_screen_render_component(component_t* component);
 
 /**
- * Process screen, gestures, in a loop. If is_done is NULL, usb packets are also
- * processed.
- * @param[in] is_done Runs until is_done(is_done_param).
- *            This should return true if and only if this GUI should
- *            terminate.
- * @param[in] is_done_param Parameter to be passed to \a is_done (can be NULL).
+ * Runs the UI once.
+ *
+ * This function will update the screen (if needed)
+ * and process gesture-related events.
  */
-void ui_screen_process(bool (*is_done)(void*), void* is_done_param);
-
-/**
- * Process screen, gestures, in a loop with timeout.
- * @param[in] is_done
- * @param[in] on_timeout called when timout occurs
- * @param[in] timeout number of screen refreshes until timeout
- */
-void ui_screen_process_with_timeout(
-    bool (*is_done)(void*),
-    void* is_done_param,
-    void (*on_timeout)(void),
-    uint32_t timeout);
+void screen_process(void);
 
 /**
  * Period of screen updates.

--- a/src/workflow/blocking.c
+++ b/src/workflow/blocking.c
@@ -12,31 +12,71 @@ typedef enum {
 
 static _done_t _done = UNBLOCKED_NORMAL;
 
-static bool _is_done(void* param)
+static bool _is_done(void)
 {
-    if (param) {
-        Abort("Unexpected is_done param\n");
-    }
     return _done != BLOCKED;
+}
+
+/**
+ * Process screen, gestures, in a loop.
+ * @param[in] is_done Runs until is_done().
+ *            This should return true if and only if this GUI should
+ *            terminate.
+ */
+static void _run_blocking_ui(bool (*is_done)(void))
+{
+    if (is_done == NULL) {
+        Abort("is_done function\nis NULL.");
+    }
+    while (!is_done()) {
+        screen_process();
+    }
+}
+
+/**
+ * Process screen, gestures, in a loop with timeout.
+ * @param[in] is_done
+ * @param[in] on_timeout called when timeout occurs
+ * @param[in] timeout number of event loop cycles until timeout
+ */
+static void _run_blocking_ui_with_timeout(
+    bool (*is_done)(void),
+    void (*on_timeout)(void),
+    uint32_t timeout)
+{
+    if (!is_done) {
+        Abort("is_done function\nis NULL.");
+    }
+    if (!on_timeout) {
+        Abort("on_timeout function\nis NULL.");
+    }
+    uint32_t timeout_cnt = 0;
+    while (!is_done()) {
+        if (on_timeout != NULL && timeout_cnt > timeout) {
+            on_timeout();
+        }
+        timeout_cnt += 1;
+        screen_process();
+    }
 }
 
 bool workflow_blocking_block(void)
 {
-    if (!_is_done(NULL)) {
+    if (!_is_done()) {
         Abort("workflow_blocking_block");
     }
     _done = BLOCKED;
-    ui_screen_process(_is_done, NULL);
+    _run_blocking_ui(_is_done);
     return _done == UNBLOCKED_NORMAL;
 }
 
 bool workflow_blocking_block_with_timeout(uint32_t timeout)
 {
-    if (!_is_done(NULL)) {
+    if (!_is_done()) {
         Abort("workflow_blocking_block");
     }
     _done = BLOCKED;
-    ui_screen_process_with_timeout(_is_done, NULL, workflow_blocking_unblock_force, timeout);
+    _run_blocking_ui_with_timeout(_is_done, workflow_blocking_unblock_force, timeout);
     return _done == UNBLOCKED_NORMAL;
 }
 

--- a/src/workflow/blocking.c
+++ b/src/workflow/blocking.c
@@ -1,6 +1,7 @@
 #include "blocking.h"
 
 #include <hardfault.h>
+#include <stddef.h>
 #include <ui/screen_process.h>
 
 typedef enum {
@@ -11,28 +12,31 @@ typedef enum {
 
 static _done_t _done = UNBLOCKED_NORMAL;
 
-static bool _is_done(void)
+static bool _is_done(void* param)
 {
+    if (param) {
+        Abort("Unexpected is_done param\n");
+    }
     return _done != BLOCKED;
 }
 
 bool workflow_blocking_block(void)
 {
-    if (!_is_done()) {
+    if (!_is_done(NULL)) {
         Abort("workflow_blocking_block");
     }
     _done = BLOCKED;
-    ui_screen_process(_is_done);
+    ui_screen_process(_is_done, NULL);
     return _done == UNBLOCKED_NORMAL;
 }
 
 bool workflow_blocking_block_with_timeout(uint32_t timeout)
 {
-    if (!_is_done()) {
+    if (!_is_done(NULL)) {
         Abort("workflow_blocking_block");
     }
     _done = BLOCKED;
-    ui_screen_process_with_timeout(_is_done, workflow_blocking_unblock_force, timeout);
+    ui_screen_process_with_timeout(_is_done, NULL, workflow_blocking_unblock_force, timeout);
     return _done == UNBLOCKED_NORMAL;
 }
 

--- a/test/device-test/src/test_all_variants_menu.c
+++ b/test/device-test/src/test_all_variants_menu.c
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 #include <driver_init.h>
+#include <firmware_main_loop.h>
 #include <screen.h>
 #include <string.h>
 #include <ui/components/scroll_through_all_variants.h>
-#include <ui/screen_process.h>
 #include <ui/screen_stack.h>
 #include <usb/usb.h>
 
@@ -50,7 +50,7 @@ int main(void)
         scroll_through_all_variants_create(words, NULL, 7, true, NULL, _cancel, NULL);
 
     ui_screen_stack_push(test_scroll_through_all_variants);
-    ui_screen_process(NULL);
+    firmware_main_loop();
 }
 
 #pragma GCC diagnostic pop

--- a/test/device-test/src/test_bip39.c
+++ b/test/device-test/src/test_bip39.c
@@ -22,7 +22,7 @@
 
 #include <wally_bip39.h>
 
-#include <ui/screen_process.h>
+#include <firmware_main_loop.h>
 
 #include "hardfault.h"
 #include "keystore.h"
@@ -80,7 +80,7 @@ int main(void)
 
     workflow_show_mnemonic_create();
 
-    ui_screen_process(NULL);
+    firmware_main_loop();
 }
 
 #pragma GCC diagnostic pop

--- a/test/device-test/src/test_button_tap.c
+++ b/test/device-test/src/test_button_tap.c
@@ -16,11 +16,11 @@
 #include "random.h"
 #include "util.h"
 #include <driver_init.h>
+#include <firmware_main_loop.h>
 #include <screen.h>
 #include <string.h>
 #include <ui/components/button.h>
 #include <ui/components/label.h>
-#include <ui/screen_process.h>
 #include <ui/screen_stack.h>
 #include <ui/ui_util.h>
 #include <usb/usb.h>
@@ -190,7 +190,7 @@ int main(void)
 
     component_t* test_buttons_screen = test_buttons_create();
     ui_screen_stack_push(test_buttons_screen);
-    ui_screen_process(NULL);
+    firmware_main_loop();
 }
 
 #pragma GCC diagnostic pop

--- a/test/device-test/src/test_confirm_bip39.c
+++ b/test/device-test/src/test_confirm_bip39.c
@@ -20,8 +20,8 @@
 #include <ui/screen_stack.h>
 #include <wally_bip39.h>
 
+#include <firmware_main_loop.h>
 #include <ui/components/confirm_mnemonic.h>
-#include <ui/screen_process.h>
 
 #include "hardfault.h"
 #include "keystore.h"
@@ -136,7 +136,7 @@ int main(void)
         confirm_mnemonic_create(wordlist, NUM_CONFIRM_WORDS, 0, _confirm_mnemonic, _cancel);
     ui_screen_stack_switch(confirm_mnemonic);
 
-    ui_screen_process(NULL);
+    firmware_main_loop();
 }
 
 #pragma GCC diagnostic pop

--- a/test/device-test/src/test_entry_screen.c
+++ b/test/device-test/src/test_entry_screen.c
@@ -17,13 +17,13 @@
 #include <string.h>
 
 #include <driver_init.h>
+#include <firmware_main_loop.h>
 #include <screen.h>
 #include <touch/gestures.h>
 #include <ui/components/entry_screen.h>
 #include <ui/event.h>
 #include <ui/event_handler.h>
 #include <ui/fonts/arial_fonts.h>
-#include <ui/screen_process.h>
 #include <ui/screen_stack.h>
 #include <ui/ui_util.h>
 
@@ -131,7 +131,7 @@ int main(void)
     screen_init();
     qtouch_init();
     ui_screen_stack_push(entry_screen_create("Enter password", done_callback));
-    ui_screen_process(NULL);
+    firmware_main_loop();
 }
 
 #pragma GCC diagnostic pop

--- a/test/device-test/src/test_scroll_menu.c
+++ b/test/device-test/src/test_scroll_menu.c
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #include <driver_init.h>
+#include <firmware_main_loop.h>
 #include <screen.h>
 #include <string.h>
-#include <ui/screen_process.h>
 #include <ui/screen_stack.h>
 #include <usb/usb.h>
 
@@ -46,7 +46,7 @@ int main(void)
     // component_t* test_scroll_through = scroll_through_create(words, NULL, 4, true);
 
     // ui_screen_stack_push(test_scroll_through);
-    ui_screen_process(NULL);
+    firmware_main_loop();
 }
 
 #pragma GCC diagnostic pop

--- a/test/device-test/src/test_scroll_menu_2.c
+++ b/test/device-test/src/test_scroll_menu_2.c
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #include <driver_init.h>
+#include <firmware_main_loop.h>
 #include <screen.h>
 #include <string.h>
-#include <ui/screen_process.h>
 #include <ui/screen_stack.h>
 #include <usb/usb.h>
 
@@ -46,7 +46,7 @@ int main(void)
     // component_t* test_scroll_through_2 = scroll_through_2_create(words, NULL, 4, true);
 
     // ui_screen_stack_push(test_scroll_through_2);
-    ui_screen_process(NULL);
+    firmware_main_loop();
 }
 
 #pragma GCC diagnostic pop

--- a/test/device-test/src/test_simple_slide.c
+++ b/test/device-test/src/test_simple_slide.c
@@ -16,11 +16,11 @@
 #include "random.h"
 #include "util.h"
 #include <driver_init.h>
+#include <firmware_main_loop.h>
 #include <screen.h>
 #include <string.h>
 #include <ui/components/label.h>
 #include <ui/event.h>
-#include <ui/screen_process.h>
 #include <ui/screen_stack.h>
 #include <ui/ui_util.h>
 #include <usb/usb.h>
@@ -100,7 +100,7 @@ int main(void)
 
     component_t* test_slide_screen = test_slide_create();
     ui_screen_stack_push(test_slide_screen);
-    ui_screen_process(NULL);
+    firmware_main_loop();
 }
 
 #pragma GCC diagnostic pop

--- a/test/device-test/src/test_slide_info.c
+++ b/test/device-test/src/test_slide_info.c
@@ -16,11 +16,11 @@
 #include "random.h"
 #include "util.h"
 #include <driver_init.h>
+#include <firmware_main_loop.h>
 #include <screen.h>
 #include <string.h>
 #include <touch/gestures.h>
 #include <ui/components/label.h>
-#include <ui/screen_process.h>
 #include <ui/screen_stack.h>
 #include <usb/usb.h>
 
@@ -127,7 +127,7 @@ int main(void)
 
     component_t* test_slide_screen = test_slide_create();
     ui_screen_stack_push(test_slide_screen);
-    ui_screen_process(NULL);
+    firmware_main_loop();
 }
 
 #pragma GCC diagnostic pop

--- a/test/device-test/src/test_tap_menu.c
+++ b/test/device-test/src/test_tap_menu.c
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #include <driver_init.h>
+#include <firmware_main_loop.h>
 #include <screen.h>
 #include <string.h>
-#include <ui/screen_process.h>
 #include <ui/screen_stack.h>
 #include <usb/usb.h>
 
@@ -46,7 +46,7 @@ int main(void)
     // component_t* test_tap_through = tap_through_create(words, NULL, 4, true);
 
     // ui_screen_stack_push(test_tap_through);
-    ui_screen_process(NULL);
+    firmware_main_loop();
 }
 
 #pragma GCC diagnostic pop

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -195,7 +195,7 @@ set(TEST_LIST
    commander_set_mnemonic_passphrase_enabled
    "-Wl,--wrap=workflow_confirm,--wrap=memory_set_mnemonic_passphrase_enabled"
    workflow_blocking
-   "-Wl,--wrap=ui_screen_process,--wrap=ui_screen_process_with_timeout"
+   "-Wl,--wrap=screen_process"
    workflow_status
    "-Wl,--wrap=ui_screen_stack_push,--wrap=ui_screen_stack_pop,--wrap=status_create,--wrap=workflow_blocking_block,--wrap=workflow_blocking_unblock"
    workflow_cancel


### PR DESCRIPTION
Moved the usb processing and is_done() logic outside of `_screen_process()`.

Only the main loop should be responsible for calling the USB handlers - does this have anything to do with the GUI after all? Same for the workflow-related logic (blocking, timeouts, etc).

Note that this is just code wrangling so the new implementation should be 100% equivalent to the current one - if it isn't, that's a bug.

Depends on #147.