### PR TITLE
workflow.c: Remove the useless "workflow_change_state" function.

### DIFF
--- a/src/firmware.c
+++ b/src/firmware.c
@@ -19,6 +19,7 @@
 #include "peripherals_init.h"
 #include "qtouch.h"
 #include "screen.h"
+#include "ui/screen_stack.h"
 #include "util.h"
 #include "workflow/workflow.h"
 
@@ -35,7 +36,7 @@ int main(void)
     qtouch_init();
     common_main();
     traceln("%s", "Device initialized");
-    workflow_change_state(WORKFLOW_STATE_CHOOSE_ORIENTATION);
+    workflow_start_orientation_screen();
     firmware_main_loop();
     return 0;
 }

--- a/src/workflow/workflow.c
+++ b/src/workflow/workflow.c
@@ -43,6 +43,17 @@ void workflow_confirm_dismiss(const char* title, const char* body)
     ui_screen_stack_switch(confirm_create(title, body, false, _confirm_dismiss, NULL));
 }
 
+void workflow_start(void)
+{
+    usb_start(hww_setup);
+    ui_screen_stack_pop_all();
+    ui_screen_stack_push(info_centered_create("See the BitBox App", NULL));
+}
+
+/**
+ * Called when the "select orientation" screen is over.
+ * Switch to the main view.
+ */
 static void _select_orientation_done(bool upside_down)
 {
     if (upside_down) {
@@ -52,23 +63,8 @@ static void _select_orientation_done(bool upside_down)
     ui_screen_stack_switch(show_logo);
 }
 
-void workflow_start(void)
+void workflow_start_orientation_screen(void)
 {
-    usb_start(hww_setup);
-    ui_screen_stack_pop_all();
-    ui_screen_stack_push(info_centered_create("See the BitBox App", NULL));
-}
-
-void workflow_change_state(workflow_state_t state)
-{
-    switch (state) {
-    case WORKFLOW_STATE_CHOOSE_ORIENTATION: {
-        component_t* select_orientation = orientation_arrows_create(_select_orientation_done);
-        ui_screen_stack_switch(select_orientation);
-        break;
-    }
-    default:
-        Abort("invalid state");
-        break;
-    }
+    component_t* select_orientation = orientation_arrows_create(_select_orientation_done);
+    ui_screen_stack_switch(select_orientation);
 }

--- a/src/workflow/workflow.h
+++ b/src/workflow/workflow.h
@@ -18,8 +18,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-typedef enum { WORKFLOW_STATE_CHOOSE_ORIENTATION } workflow_state_t;
-
 /**
  * Pushes a confirm string on the screen a with a "Dismiss" button, to show data
  * on the screen for the user to verify.
@@ -27,14 +25,14 @@ typedef enum { WORKFLOW_STATE_CHOOSE_ORIENTATION } workflow_state_t;
 void workflow_confirm_dismiss(const char* title, const char* body);
 
 /**
- * Invokes a workflow based on the input.
- */
-void workflow_change_state(workflow_state_t state);
-
-/**
  * Switches to either the initialization or the unlock state depending on if the
  * device is initialized or not.
  */
 void workflow_start(void);
+
+/**
+ * Loads the "Select orientation" screen.
+ */
+void workflow_start_orientation_screen(void);
 
 #endif


### PR DESCRIPTION
`workflow_change_state` was supposed to be "switching workflows based on
user inputs" (as per the docs), but in practice all what it was doing was switching to
the "Tap this side" screen.