### PR TITLE
ui/components/trinary_input_char: remove redundant set_alphabet

### DIFF
--- a/src/ui/components/trinary_input_char.c
+++ b/src/ui/components/trinary_input_char.c
@@ -297,7 +297,6 @@ void trinary_input_char_set_alphabet(
 /********************************** Create Instance **********************************/
 
 component_t* trinary_input_char_create(
-    const char* alphabet,
     void (*character_chosen_cb)(component_t*, char),
     component_t* parent)
 {
@@ -319,8 +318,6 @@ component_t* trinary_input_char_create(
     component->dimension.height = SCREEN_HEIGHT;
 
     data->character_chosen_cb = character_chosen_cb;
-
-    trinary_input_char_set_alphabet(component, alphabet, 1);
 
     return component;
 }

--- a/src/ui/components/trinary_input_char.h
+++ b/src/ui/components/trinary_input_char.h
@@ -20,13 +20,11 @@
 
 /**
  * Presents user input in form of three buttons at the bottom, with at most three taps needed to
- * select a character.
- * @param[in] alphabet are the available characters. Can be at most 26 chars (27 including null).
+ * select a character. Use `trinary_input_char_set_alphabet()` to set the current keyboard.
  * @param[in] character_chosen_cb will be called after a letter is chosen.
  * @param[in] parent parent component.
  */
 component_t* trinary_input_char_create(
-    const char* alphabet,
     void (*character_chosen_cb)(component_t*, char),
     component_t* parent);
 

--- a/src/ui/components/trinary_input_string.c
+++ b/src/ui/components/trinary_input_string.c
@@ -417,7 +417,7 @@ static component_t* _create(
     data->title_component = label_create(title, NULL, CENTER, component);
     ui_util_add_sub_component(component, data->title_component);
 
-    data->trinary_char_component = trinary_input_char_create("", _letter_chosen, component);
+    data->trinary_char_component = trinary_input_char_create(_letter_chosen, component);
     ui_util_add_sub_component(component, data->trinary_char_component);
     _set_alphabet(component);
     _set_can_confirm(component);


### PR DESCRIPTION
The parent component (trinary_input_string) takes care of handling the
alphabet. It was awkward for it to be done twice, once with an
arbitrary horizontal space.