### PR TITLE
usb/hid: Separate the code sending and receiving packets.

### DIFF
--- a/src/u2f/u2f_packet.c
+++ b/src/u2f/u2f_packet.c
@@ -127,7 +127,7 @@ void u2f_packet_timeout(uint32_t cid)
     usb_frame_prepare_err(FRAME_ERR_MSG_TIMEOUT, cid, _queue_push);
 }
 
-bool u2f_packet_process(const USB_FRAME* frame, void (*send_packet)(void))
+bool u2f_packet_process(const USB_FRAME* frame)
 {
     struct usb_processing* ctx = usb_processing_u2f();
     switch (usb_frame_process(frame, &_in_state)) {
@@ -155,6 +155,7 @@ bool u2f_packet_process(const USB_FRAME* frame, void (*send_packet)(void))
             // Do not send a message yet
             return true;
         }
+        /* We have received a complete frame. Buffer it for processing. */
         if (usb_processing_enqueue(ctx, &_in_state)) {
             // Queue filled and will be sent during usb processing
             _reset_state();
@@ -171,6 +172,5 @@ bool u2f_packet_process(const USB_FRAME* frame, void (*send_packet)(void))
         _queue_err(FRAME_ERR_OTHER, frame->cid);
         break;
     }
-    send_packet();
     return false;
 }

--- a/src/u2f/u2f_packet.h
+++ b/src/u2f/u2f_packet.h
@@ -24,10 +24,9 @@
 /**
  * Processes an incoming USB packet.
  * @param[in] frame The frame that is to be processed.
- * @param[in] send_packet The function to be called to send the response packet.
  * @return true if we are waiting for more frames to complete a packet, false otherwise.
  */
-bool u2f_packet_process(const USB_FRAME* frame, void (*send_packet)(void));
+bool u2f_packet_process(const USB_FRAME* frame);
 
 /**
  * Checks if there has been a timeout

--- a/src/usb/class/hid/u2f/hid_u2f.c
+++ b/src/usb/class/hid/u2f/hid_u2f.c
@@ -62,17 +62,25 @@ static int32_t _read(void)
     return hid_read(&_func_data, _out_report, USB_HID_REPORT_OUT_SIZE);
 }
 
+/** Set when the send channel is busy sending data. */
+static bool _send_busy = false;
+
 /**
  * Sends the next data, if the USB interface is ready.
  */
 static void _send_next(void)
 {
+    if (_send_busy) {
+        /*
+         * We can't send yet. Whenever the current sender finished, it will
+         * flush anything that's still queued.
+         */
+        return;
+    }
     const uint8_t* data = queue_pull(queue_u2f_queue());
     if (data != NULL) {
+        _send_busy = true;
         hid_write(&_func_data, data, USB_HID_REPORT_OUT_SIZE);
-    } else {
-        // Read again after we sent everything.
-        _read();
     }
 }
 
@@ -87,10 +95,9 @@ static uint8_t _out(const uint8_t ep, const enum usb_xfer_code rc, const uint32_
     (void)rc;
     (void)count;
 
-    bool need_more = u2f_packet_process((const USB_FRAME*)_out_report, _send_next);
-    if (need_more) {
-        _read();
-    }
+    u2f_packet_process((const USB_FRAME*)_out_report);
+    /* Incoming data has been processed completely. Start a new read. */
+    _read();
     return ERR_NONE;
 }
 
@@ -100,7 +107,12 @@ static uint8_t _out(const uint8_t ep, const enum usb_xfer_code rc, const uint32_
  */
 static void _sent_done(void)
 {
-    // Continue sending from the queue.
+    _send_busy = false;
+    /*
+     * If there is more data queued, push it immediately to save some time.
+     * Otherwise, sending will stop until somebody explicitely queues
+     * a frame again.
+     */
     _send_next();
 }
 

--- a/src/usb/usb_packet.c
+++ b/src/usb/usb_packet.c
@@ -56,7 +56,7 @@ static bool _need_more_data(void)
     return (_in_state.buf_ptr - _in_state.data) < (signed)_in_state.len;
 }
 
-bool usb_packet_process(const USB_FRAME* frame, void (*send_packet)(void))
+bool usb_packet_process(const USB_FRAME* frame)
 {
     struct usb_processing* ctx = usb_processing_hww();
     switch (usb_frame_process(frame, &_in_state)) {
@@ -98,7 +98,5 @@ bool usb_packet_process(const USB_FRAME* frame, void (*send_packet)(void))
         _queue_err(FRAME_ERR_OTHER, frame->cid);
         break;
     }
-    // Send one of the error packets we have queued
-    send_packet();
     return false;
 }

--- a/src/usb/usb_packet.h
+++ b/src/usb/usb_packet.h
@@ -42,9 +42,8 @@ typedef struct {
 /**
  * Processes an incoming USB packet.
  * @param[in] frame The frame that is to be processed.
- * @param[in] send_packet The function to be called to send the response packet.
  * @return true if we are waiting for more frames to complete a packet, false otherwise.
  */
-bool usb_packet_process(const USB_FRAME* frame, void (*send_packet)(void));
+bool usb_packet_process(const USB_FRAME* frame);
 
 #endif

--- a/test/unit-test/framework/mock_hidapi.c
+++ b/test/unit-test/framework/mock_hidapi.c
@@ -107,7 +107,7 @@ int hid_write(hid_device* dev, const unsigned char* data, size_t length)
     }
     memcpy(_buf, data + 1, length - 1);
     _buf_len = length - 1;
-    _expect_more = u2f_packet_process((const USB_FRAME*)_buf, _send_packet_cb);
+    _expect_more = u2f_packet_process((const USB_FRAME*)_buf);
     if (!_expect_more) {
         // printf("Got complete packet\n");
         _have_data = true;


### PR DESCRIPTION
Remove the assumption spread throughout hid_hww.c, hid_u2f.c, and
usb_processing.c, that sends should start only after a receive and
receives should start only when a frame has been sent.

Split the single code flow performing the send->rcv->send->rcv... operations
into two separate call stacks. The read part will reissue a (async) read
as soon as data arrives and finished processing. The write part will
continuously issue (async) sends until the write buffer is flushed
completely. Whenever somebody queues new data to write, a new series of
sends will start.