### PR TITLE
external: update libwally-core, clean up secp256k1

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -79,17 +79,22 @@ set_property(
 #----------------------
 # wally-core
 
-set(LIBWALLY_CONFIGURE_FLAGS --enable-static --disable-shared --disable-tests)
+# configure flags for secp256k1 bundled in libwally core, to reduce memory consumption
+set(LIBWALLY_SECP256k1_FLAGS --with-ecmult-window=2 --with-ecmult-gen-precision=2 --enable-ecmult-static-precomputation)
+set(LIBWALLY_CONFIGURE_FLAGS --enable-static --disable-shared --disable-tests ${LIBWALLY_SECP256k1_FLAGS})
 if(SANITIZE_ADDRESS)
   set(LIBWALLY_CFLAGS "-fsanitize=address")
 endif()
 if(SANITIZE_UNDEFINED)
   set(LIBWALLY_CFLAGS "${LIBWALLY_CFLAGS} -fsanitize=undefined")
 endif()
+# USE_BASIC_CONFIG is for secp256k1
+# _DEFAULT_SOURCE enables the BSD explicit_bzero function referenced by libwally.
 set(LIBWALLY_CFLAGS  "\
   ${LIBWALLY_CFLAGS} \
   ${MODIFIED_C_FLAGS} ${CMAKE_C_FLAGS_${CMAKE_BUILD_TYPE}} \
-  -DUSE_BASIC_CONFIG=1 -DUSE_ECMULT_STATIC_PRECOMPUTATION=1 \
+  -DUSE_BASIC_CONFIG=1 \
+  -D_DEFAULT_SOURCE \
   -fno-strict-aliasing \
 ")
 

--- a/src/keystore.c
+++ b/src/keystore.c
@@ -476,13 +476,6 @@ static bool _get_xprv_twice(
     return true;
 }
 
-static void _xkey_strip_private_key(struct ext_key* key_out)
-{
-    // copied from libwally's bip32.c.
-    key_out->priv_key[0] = BIP32_FLAG_KEY_PUBLIC;
-    util_zero(key_out->priv_key + 1, sizeof(key_out->priv_key) - 1);
-}
-
 bool keystore_get_xpub(
     const uint32_t* keypath,
     const size_t keypath_len,
@@ -492,7 +485,7 @@ bool keystore_get_xpub(
     if (!_get_xprv_twice(keypath, keypath_len, &xprv)) {
         return false;
     }
-    _xkey_strip_private_key(&xprv); // neuter
+    bip32_key_strip_private_key(&xprv); // neuter
     *hdkey_neutered_out = xprv;
     return true;
 }


### PR DESCRIPTION
- new branch
https://github.com/shiftdevices/libwally-core/tree/bitbox02-firmware-20191011,
which is based on
https://github.com/ElementsProject/libwally-core/commit/ff01f0749006161e25363234bcf9bad7da60f985

- the bundled sep256k1 is replaced with
https://github.com/digitalbitbox/secp256k1-zkp/tree/bitbox02-20191013,
which is based on
https://github.com/ElementsProject/secp256k1-zkp/commit/85bcb7c951ed697acc4560a7e857b06cc7790618,
with cherry-picked
https://github.com/bitcoin-core/secp256k1/pull/337/commits/dcb2e3b3fff0b287d576842aabe5c79f2fe4df30

Deleted the build related custom wally commits, as we can configure it
from our own CMakeLists.txt. The big commit is replaced with the above
cherry picked upstream commit and configured with --with-ecmult-gen-precision=2.