### PR TITLE
CMakeLists: bump versions to v4.2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,8 +86,8 @@ endif()
 #
 # Versions MUST contain three parts and start with lowercase 'v'.
 # Example 'v1.0.0'. They MUST not contain a pre-release label such as '-beta'.
-set(FIRMWARE_VERSION "v4.1.0")
-set(FIRMWARE_BTC_ONLY_VERSION "v4.1.1")
+set(FIRMWARE_VERSION "v4.2.0")
+set(FIRMWARE_BTC_ONLY_VERSION "v4.2.0")
 set(BOOTLOADER_VERSION "v1.0.1")
 
 find_package(PythonInterp 3.6 REQUIRED)


### PR DESCRIPTION
Minor bump because of one added feature (special chars in the optional passphrase).