### PR TITLE
qtouch: Increase calibration threshold

### DIFF
--- a/external/asf4-drivers/qtouch/qtouch.h
+++ b/external/asf4-drivers/qtouch/qtouch.h
@@ -184,7 +184,7 @@ extern "C" {
  * Range: RECAL_100/ RECAL_50 / RECAL_25 / RECAL_12_5 / RECAL_6_25 / MAX_RECAL
  * Default value: RECAL_100.
  */
-#define DEF_ANTI_TCH_RECAL_THRSHLD RECAL_12_5
+#define DEF_ANTI_TCH_RECAL_THRSHLD RECAL_50
 
 /* Rate at which sensor reference value is adjusted towards sensor signal value
  * when signal value is greater than reference.


### PR DESCRIPTION
Users reported issues with the sensors becoming unresponsive. This was
due to the calibration threshold being set too low which made the
calibration kick in even if the user was present. Increasing this value
makes the device less likely to become unresponsive.