### PR TITLE
Enable R/W access to pages 2000-2047 in the MPU.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,6 +26,7 @@ set(DBB-FIRMWARE-SOURCES
   ${CMAKE_SOURCE_DIR}/src/sd.c
   ${CMAKE_SOURCE_DIR}/src/hww.c
   ${CMAKE_SOURCE_DIR}/src/memory.c
+  ${CMAKE_SOURCE_DIR}/src/mpu.c
   ${CMAKE_SOURCE_DIR}/src/salt.c
   ${CMAKE_SOURCE_DIR}/src/i2c_ecc.c
   ${CMAKE_SOURCE_DIR}/src/touch/gestures.c
@@ -126,7 +127,8 @@ set(DBB-BOOTLOADER-SOURCES
   ${CMAKE_SOURCE_DIR}/src/pukcc/pukcc.c
   ${CMAKE_SOURCE_DIR}/src/bootloader/bootloader.c
   ${CMAKE_SOURCE_DIR}/src/bootloader/startup.c
-  ${CMAKE_SOURCE_DIR}/src/bootloader/mpu.c
+  ${CMAKE_SOURCE_DIR}/src/bootloader/mpu_regions.c
+  ${CMAKE_SOURCE_DIR}/src/mpu.c
   ${CMAKE_SOURCE_DIR}/src/queue.c
   ${CMAKE_SOURCE_DIR}/src/usb/usb_processing.c
   ${CMAKE_SOURCE_DIR}/src/ui/ugui/ugui.c

--- a/src/bootloader/bootloader.c
+++ b/src/bootloader/bootloader.c
@@ -15,7 +15,7 @@
 #include "bootloader.h"
 #include "bootloader_version.h"
 #include "leds.h"
-#include "mpu.h"
+#include "mpu_regions.h"
 
 #include <driver_init.h>
 #include <stdint.h>
@@ -266,7 +266,7 @@ static void _binary_exec(void)
     rand_sync_disable(&RAND_0);
 
     // Update MPU settings for firmware mode
-    mpu_firmware_init();
+    mpu_regions_firmware_init();
 
     __disable_irq();
     for (i = 0; i < 8; i++) {

--- a/src/bootloader/mpu_regions.c
+++ b/src/bootloader/mpu_regions.c
@@ -12,88 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "mpu.h"
+#include "mpu_regions.h"
+
+#ifndef TESTING
 
 #include <flags.h>
-#include <stdint.h>
-#ifndef TESTING
+#include <mpu.h>
+
 #include <core_cm4.h>
 #include <samd51j20a.h>
 
-/**
- * MPU - Memory Protection Unit
- */
-#define MPU_ENABLE (0x01)
-#define MPU_DISABLE (0x00)
-
-/**
- * RBAR - Region Base Address Register (CMSIS: SCB->RBAR)
- *
- * Bit 0..3   - Region number. `0` is lowest priority. `7` is highest priority
- * Bit 4      - Region valid
- * Bit 5..31  - Base address of the region. Bottom 5 bits ignored. Base address must be a multiple
- * of its region size. Regions can overlap.
- */
-#define MPU_REGION_NUMBER_FLASH (0u)
-#define MPU_REGION_NUMBER_SRAM (1u)
-#define MPU_REGION_NUMBER_BOOTLOADER (2u)
-#define MPU_REGION_NUMBER_SHARED_DATA (3u)
-#define MPU_REGION_NUMBER_APPDATA_0 (4u)
-#define MPU_REGION_NUMBER_APPDATA_1 (5u)
-#define MPU_REGION_NUMBER_BOOTDATA (6u)
-#define MPU_REGION_VALID (0x01 << MPU_RBAR_VALID_Pos)
-
-/**
- * RASR - MPU Region Attribute and Size Register (CMSIS: SCB->RASR)
- *
- * Bit 0      – Enable region
- * Bit 1..5   – Region size; 2^(flash_size + 1)
- * Bit 16..21 – Memory type; TEX | Shareable | Cacheable | Bufferable
- * Bit 24..26 – Access Privilege
- * Bit 28     – Non-excutable region (XN)
- */
-#define MPU_REGION_DISABLE (0x00 << MPU_RASR_ENABLE_Pos)
-#define MPU_REGION_ENABLE (0x01 << MPU_RASR_ENABLE_Pos)
-#define MPU_REGION_TYPE_NORMAL \
-    (0x08 << MPU_RASR_ATTRS_Pos) // TEX:b001 S:b0 C:b0 B:b0 - non-shareable, non-cacheable
-#define MPU_REGION_TYPE_STRONGLY_ORDERED (0x04 << MPU_RASR_ATTRS_Pos) // TEX:b000 S:b1 C:b0 B:b0
-#define MPU_REGION_TYPE_DEVICE (0x05 << MPU_RASR_ATTRS_Pos) // TEX:b000 S:b1 C:b0 B:b1
-#define MPU_REGION_NO_ACCESS (0x00 << MPU_RASR_AP_Pos)
-#define MPU_REGION_PRIVILEGED_READ_WRITE (0x01 << MPU_RASR_AP_Pos) // No user-mode access
-#define MPU_REGION_PRIVILEGED_RW_USER_RO (0x02 << MPU_RASR_AP_Pos) // No user-mode access
-#define MPU_REGION_READ_WRITE (0x03 << MPU_RASR_AP_Pos)
-#define MPU_REGION_PRIVILEGED_READ_ONLY (0x05 << MPU_RASR_AP_Pos) // No user-mode access
-#define MPU_REGION_READ_ONLY (0x06 << MPU_RASR_AP_Pos)
-#define MPU_REGION_EXECUTE_NEVER (0x01 << MPU_RASR_XN_Pos)
-
-static uint32_t _region_size(uint32_t size)
-{
-    uint32_t regionSize = 32;
-    uint32_t ret = 4;
-
-    while (ret < 31) {
-        if (size <= regionSize) {
-            break;
-        }
-        ret++;
-        regionSize <<= 1;
-    }
-    return (ret << MPU_RASR_SIZE_Pos);
-}
-
-// Set region properties and enable region
-static void _set_region(uint32_t rbar, uint32_t rasr)
-{
-    MPU->RBAR = rbar;
-    MPU->RASR = rasr;
-}
-
-// Disable a region
-static void _disable_region(uint32_t region_number)
-{
-    MPU->RNR = region_number;
-    MPU->RASR &= 0xfffffffe;
-}
+#include <stdint.h>
 
 static void _set_mpu_regions(void)
 {
@@ -104,32 +33,32 @@ static void _set_mpu_regions(void)
     // read-write
     // 0 to 1 MB
     rbar = FLASH_ADDR | MPU_REGION_VALID | MPU_REGION_NUMBER_FLASH;
-    rasr = MPU_REGION_ENABLE | MPU_REGION_TYPE_NORMAL | _region_size(FLASH_SIZE) |
+    rasr = MPU_REGION_ENABLE | MPU_REGION_TYPE_NORMAL | mpu_region_size(FLASH_SIZE) |
            MPU_REGION_READ_WRITE;
-    _set_region(rbar, rasr);
+    mpu_set_region(rbar, rasr);
 
     // SRAM region
     // read-write non-excutable (overlaps flash region but higher priority)
     rbar = HSRAM_ADDR | MPU_REGION_VALID | MPU_REGION_NUMBER_SRAM;
     rasr = MPU_REGION_ENABLE | MPU_REGION_TYPE_NORMAL | MPU_REGION_EXECUTE_NEVER |
-           _region_size(HSRAM_SIZE) | MPU_REGION_READ_WRITE;
-    _set_region(rbar, rasr);
+           mpu_region_size(HSRAM_SIZE) | MPU_REGION_READ_WRITE;
+    mpu_set_region(rbar, rasr);
 
     // Bootloader region
     // read-only (overlaps flash region but has higher priority)
     // 0 to 64 kB
     rbar = FLASH_BOOT_START | MPU_REGION_VALID | MPU_REGION_NUMBER_BOOTLOADER;
     rasr = MPU_REGION_ENABLE | MPU_REGION_TYPE_NORMAL |
-           _region_size(FLASH_APP_START - FLASH_BOOT_START) | MPU_REGION_READ_ONLY;
-    _set_region(rbar, rasr);
+           mpu_region_size(FLASH_APP_START - FLASH_BOOT_START) | MPU_REGION_READ_ONLY;
+    mpu_set_region(rbar, rasr);
 
     // Shared data region after bootloader and before firmware app
     // read-write non-excutable (overlaps bootloader region but higher priority)
     // 56 to 64 kB
     rbar = FLASH_SHARED_DATA_START | MPU_REGION_VALID | MPU_REGION_NUMBER_SHARED_DATA;
     rasr = MPU_REGION_ENABLE | MPU_REGION_TYPE_NORMAL | MPU_REGION_EXECUTE_NEVER |
-           _region_size(FLASH_SHARED_DATA_LEN) | MPU_REGION_READ_WRITE;
-    _set_region(rbar, rasr);
+           mpu_region_size(FLASH_SHARED_DATA_LEN) | MPU_REGION_READ_WRITE;
+    mpu_set_region(rbar, rasr);
 
     // Appdata region 0 after firmware app
     // Due to MPU alignment rules, the 64kB area must be split into 2 32kB regions.
@@ -137,22 +66,22 @@ static void _set_mpu_regions(void)
     // End of FLASH_APP to FLASH_END - 8kB
     rbar = FLASH_APPDATA_START | MPU_REGION_VALID | MPU_REGION_NUMBER_APPDATA_0;
     rasr = MPU_REGION_ENABLE | MPU_REGION_TYPE_NORMAL | MPU_REGION_EXECUTE_NEVER |
-           _region_size(FLASH_APPDATA_LEN / 2) | MPU_REGION_READ_WRITE;
-    _set_region(rbar, rasr);
+           mpu_region_size(FLASH_APPDATA_LEN / 2) | MPU_REGION_READ_WRITE;
+    mpu_set_region(rbar, rasr);
     // Appdata region 1 after firmware app
     rbar = (FLASH_APPDATA_START + (FLASH_APPDATA_LEN / 2)) | MPU_REGION_VALID |
            MPU_REGION_NUMBER_APPDATA_1;
     rasr = MPU_REGION_ENABLE | MPU_REGION_TYPE_NORMAL | MPU_REGION_EXECUTE_NEVER |
-           _region_size(FLASH_APPDATA_LEN / 2) | MPU_REGION_READ_WRITE;
-    _set_region(rbar, rasr);
+           mpu_region_size(FLASH_APPDATA_LEN / 2) | MPU_REGION_READ_WRITE;
+    mpu_set_region(rbar, rasr);
 
     // Bootdata region
     // read-write non-excutable
     // FLASH_END - 8kB to FLASH_END (overlaps flash region but higher priority)
     rbar = FLASH_BOOTDATA_START | MPU_REGION_VALID | MPU_REGION_NUMBER_BOOTDATA;
     rasr = MPU_REGION_ENABLE | MPU_REGION_TYPE_NORMAL | MPU_REGION_EXECUTE_NEVER |
-           _region_size(FLASH_BOOTDATA_LEN) | MPU_REGION_READ_WRITE;
-    _set_region(rbar, rasr);
+           mpu_region_size(FLASH_BOOTDATA_LEN) | MPU_REGION_READ_WRITE;
+    mpu_set_region(rbar, rasr);
 }
 
 static void _update_mpu_regions(void)
@@ -163,21 +92,21 @@ static void _update_mpu_regions(void)
     // Whole flash region background
     // read-only
     rbar = FLASH_ADDR | MPU_REGION_VALID | MPU_REGION_NUMBER_FLASH;
-    rasr = MPU_REGION_ENABLE | MPU_REGION_TYPE_NORMAL | _region_size(FLASH_SIZE) |
+    rasr = MPU_REGION_ENABLE | MPU_REGION_TYPE_NORMAL | mpu_region_size(FLASH_SIZE) |
            MPU_REGION_READ_ONLY;
-    _disable_region(MPU_REGION_NUMBER_FLASH);
-    _set_region(rbar, rasr);
+    mpu_disable_region(MPU_REGION_NUMBER_FLASH);
+    mpu_set_region(rbar, rasr);
 
     // Bootdata region
     // no-access non-excutable (overlaps flash region but higher priority)
     rbar = FLASH_BOOTDATA_START | MPU_REGION_VALID | MPU_REGION_NUMBER_BOOTDATA;
     rasr = MPU_REGION_ENABLE | MPU_REGION_TYPE_NORMAL | MPU_REGION_EXECUTE_NEVER |
-           _region_size(FLASH_BOOTDATA_LEN) | MPU_REGION_NO_ACCESS;
-    _disable_region(MPU_REGION_NUMBER_BOOTDATA);
-    _set_region(rbar, rasr);
+           mpu_region_size(FLASH_BOOTDATA_LEN) | MPU_REGION_NO_ACCESS;
+    mpu_disable_region(MPU_REGION_NUMBER_BOOTDATA);
+    mpu_set_region(rbar, rasr);
 }
 
-void mpu_bootloader_init(void)
+void mpu_regions_bootloader_init(void)
 {
     // Disable interrupts
     __disable_irq();
@@ -206,7 +135,7 @@ void mpu_bootloader_init(void)
     __enable_irq();
 }
 
-void mpu_firmware_init(void)
+void mpu_regions_firmware_init(void)
 {
     // Disable interrupts
     __disable_irq();

--- a/src/bootloader/mpu_regions.c
+++ b/src/bootloader/mpu_regions.c
@@ -63,7 +63,7 @@ static void _set_mpu_regions(void)
     // Appdata region 0 after firmware app
     // Due to MPU alignment rules, the 64kB area must be split into 2 32kB regions.
     // read-write non-excutable (overlaps flash region but higher priority)
-    // End of FLASH_APP to FLASH_END - 8kB
+    // End of FLASH_APP to FLASH_USER_END - 8kB
     rbar = FLASH_APPDATA_START | MPU_REGION_VALID | MPU_REGION_NUMBER_APPDATA_0;
     rasr = MPU_REGION_ENABLE | MPU_REGION_TYPE_NORMAL | MPU_REGION_EXECUTE_NEVER |
            mpu_region_size(FLASH_APPDATA_LEN / 2) | MPU_REGION_READ_WRITE;
@@ -77,7 +77,7 @@ static void _set_mpu_regions(void)
 
     // Bootdata region
     // read-write non-excutable
-    // FLASH_END - 8kB to FLASH_END (overlaps flash region but higher priority)
+    // FLASH_USER_END - 8kB to FLASH_USER_END (overlaps flash region but higher priority)
     rbar = FLASH_BOOTDATA_START | MPU_REGION_VALID | MPU_REGION_NUMBER_BOOTDATA;
     rasr = MPU_REGION_ENABLE | MPU_REGION_TYPE_NORMAL | MPU_REGION_EXECUTE_NEVER |
            mpu_region_size(FLASH_BOOTDATA_LEN) | MPU_REGION_READ_WRITE;

--- a/src/bootloader/mpu_regions.h
+++ b/src/bootloader/mpu_regions.h
@@ -1,0 +1,36 @@
+// Copyright 2019 Shift Cryptosecurity AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _MPU_REGIONS_H_
+#define _MPU_REGIONS_H_
+#ifndef TESTING
+
+/**
+ * Initializes the memory regions for bootloader mode.
+ * The bootloader code is read-only, but the memory
+ * region for the firmware code has full access. Bootdata,
+ * Appdata, and SRAM are non-excutable.
+ */
+void mpu_regions_bootloader_init(void);
+
+/**
+ * Updates the memory regions previously set in bootloader
+ * mode for code run in firmware (app) mode. The memory
+ * region for the firmware code is updated to read-only and
+ * bootdata is updated to no-access.
+ */
+void mpu_regions_firmware_init(void);
+
+#endif
+#endif

--- a/src/bootloader/startup.c
+++ b/src/bootloader/startup.c
@@ -13,9 +13,10 @@
 // limitations under the License.
 
 #include "bootloader.h"
+#include "mpu_regions.h"
 #include "platform_config.h"
 #include "platform_init.h"
-#include <bootloader/mpu.h>
+
 #include <driver_init.h>
 #include <hardfault.h>
 #include <qtouch.h>
@@ -46,7 +47,7 @@ int main(void)
 
     // Order is important
     init_mcu();
-    mpu_bootloader_init();
+    mpu_regions_bootloader_init();
     bootloader_init();
     platform_init();
     __stack_chk_guard = rand_sync_read32(&RAND_0);

--- a/src/common_main.c
+++ b/src/common_main.c
@@ -14,9 +14,11 @@
 
 #include "common_main.h"
 #include "driver_init.h"
+#include "flags.h"
 #include "hardfault.h"
 #include "keystore.h"
 #include "memory.h"
+#include "mpu.h"
 #include "random.h"
 #include "screen.h"
 #include "securechip/securechip.h"
@@ -66,6 +68,7 @@ static bool _setup_wally(void)
 
 void common_main(void)
 {
+    mpu_bitbox02_init();
     if (!_setup_wally()) {
         Abort("_setup_wally failed");
     }

--- a/src/flags.h
+++ b/src/flags.h
@@ -22,9 +22,14 @@
 #else
 #include <samd51j20a.h>
 #endif
+
+// The total size of the flash is 1MB (2048 pages).
+#define FLASH_END (2048 * FLASH_PAGE_SIZE)
+
 // Even though FLASH_SIZE is 1MB (1024*1024 bytes),
-// the total accessible pages are 2000, which is less than 1MB.
-#define FLASH_END (2000 * FLASH_PAGE_SIZE)
+// the portion of flash that we use ends at page 2000.
+#define FLASH_USER_END (2000 * FLASH_PAGE_SIZE)
+
 // Erase granularity is 1 block (8kB; 16 pages)
 // Can (un)lock exactly 64 pages (32kB) at a time,
 // aligned at 16 pages (8kB); app start must be multiple of 8kB.
@@ -45,7 +50,7 @@
 #define FLASH_SHARED_DATA_LEN (FLASH_ERASE_MIN_LEN) // 8kB
 #define FLASH_BOOTDATA_LEN (FLASH_ERASE_MIN_LEN) // 8kB
 #define FLASH_BOOTDATA_START \
-    (FLASH_END -             \
+    (FLASH_USER_END -        \
      FLASH_BOOTDATA_LEN) // Do NOT change! The fixed bootloader needs access to data here
 #define FLASH_BOOTPROTECTION \
     (15 - FLASH_BOOT_LEN / 8192) // Register value for the boot protection size
@@ -57,7 +62,7 @@
 #define FLASH_APPDATA_LEN (0x000010000U)
 // Appdata start: If app length is changed, may need to subtract an offset in order to satisfy
 // the MPU setup conditions tested below.
-#define FLASH_APPDATA_START (FLASH_END - FLASH_BOOTDATA_LEN - FLASH_APPDATA_LEN)
+#define FLASH_APPDATA_START (FLASH_USER_END - FLASH_BOOTDATA_LEN - FLASH_APPDATA_LEN)
 #define FLASH_APP_LEN (FLASH_APPDATA_START - FLASH_APP_START)
 #define FLASH_APP_PAGE_NUM (FLASH_APP_LEN / FLASH_PAGE_SIZE)
 #define FLASH_APP_VERSION_LEN (4) // 4 byte big endian unsigned int

--- a/src/mpu.c
+++ b/src/mpu.c
@@ -50,4 +50,18 @@ void mpu_disable_region(uint32_t region_number)
     MPU->RASR &= 0xfffffffe;
 }
 
+void mpu_bitbox02_init(void)
+{
+    uint32_t rbar;
+    uint32_t rasr;
+    rbar = (FLASH_APPDATA_START + (FLASH_APPDATA_LEN / 2)) | MPU_REGION_VALID |
+           MPU_REGION_NUMBER_APPDATA_1;
+    rasr = MPU_REGION_ENABLE | MPU_REGION_TYPE_NORMAL | MPU_REGION_EXECUTE_NEVER |
+           mpu_region_size(FLASH_APPDATA_LEN) | MPU_REGION_READ_WRITE;
+    /* Remove the current region setting. */
+    mpu_disable_region(MPU_REGION_NUMBER_APPDATA_1);
+    /* Reset the last selected region to the new setting. */
+    mpu_set_region(rbar, rasr);
+}
+
 #endif

--- a/src/mpu.c
+++ b/src/mpu.c
@@ -12,25 +12,42 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _MPU_H_
-#define _MPU_H_
+#include "mpu.h"
+
 #ifndef TESTING
 
-/**
- * Initializes the memory regions for bootloader mode.
- * The bootloader code is read-only, but the memory
- * region for the firmware code has full access. Bootdata,
- * Appdata, and SRAM are non-excutable.
- */
-void mpu_bootloader_init(void);
+/** Order of includes here is important. */
+#include <flags.h>
 
-/**
- * Updates the memory regions previously set in bootloader
- * mode for code run in firmware (app) mode. The memory
- * region for the firmware code is updated to read-only and
- * bootdata is updated to no-access.
- */
-void mpu_firmware_init(void);
+#include <core_cm4.h>
 
-#endif
+#include <stdint.h>
+
+uint32_t mpu_region_size(uint32_t size)
+{
+    uint32_t regionSize = 32;
+    uint32_t ret = 4;
+
+    while (ret < 31) {
+        if (size <= regionSize) {
+            break;
+        }
+        ret++;
+        regionSize <<= 1;
+    }
+    return (ret << MPU_RASR_SIZE_Pos);
+}
+
+void mpu_set_region(uint32_t rbar, uint32_t rasr)
+{
+    MPU->RBAR = rbar;
+    MPU->RASR = rasr;
+}
+
+void mpu_disable_region(uint32_t region_number)
+{
+    MPU->RNR = region_number;
+    MPU->RASR &= 0xfffffffe;
+}
+
 #endif

--- a/src/mpu.h
+++ b/src/mpu.h
@@ -85,5 +85,13 @@ void mpu_set_region(uint32_t rbar, uint32_t rasr);
 /** Disable the region with the given number */
 void mpu_disable_region(uint32_t region_number);
 
+/**
+ * Sets the correct MPU configuration for BitBox firmwares.
+ *
+ * Extends the APPDATA_1 MPU region up to the end of the
+ * flash memory, and sets it to R/W.
+ */
+void mpu_bitbox02_init(void);
+
 #endif
 #endif

--- a/src/mpu.h
+++ b/src/mpu.h
@@ -1,0 +1,89 @@
+// Copyright 2019 Shift Cryptosecurity AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _MPU_H_
+#define _MPU_H_
+#ifndef TESTING
+
+#include <stdint.h>
+
+/**
+ * MPU - Memory Protection Unit
+ */
+#define MPU_ENABLE (0x01)
+#define MPU_DISABLE (0x00)
+
+/**
+ * RBAR - Region Base Address Register (CMSIS: SCB->RBAR)
+ *
+ * Bit 0..3   - Region number. `0` is lowest priority. `7` is highest priority (see below)
+ * Bit 4      - Region valid
+ * Bit 5..31  - Base address of the region. Bottom 5 bits ignored. Base address must be a multiple
+ * of its region size. Regions can overlap.
+ */
+
+/**
+ * Region numbers - as set in the MPU_RNR register (0-7).
+ * MPU rules will be evaluated using the order of the region number.
+ * The last match for a region will be the one that is enforced; so
+ * regions with the higher number have higher priority.
+ */
+#define MPU_REGION_NUMBER_FLASH (0u)
+#define MPU_REGION_NUMBER_SRAM (1u)
+#define MPU_REGION_NUMBER_BOOTLOADER (2u)
+#define MPU_REGION_NUMBER_SHARED_DATA (3u)
+#define MPU_REGION_NUMBER_APPDATA_0 (4u)
+#define MPU_REGION_NUMBER_APPDATA_1 (5u)
+#define MPU_REGION_NUMBER_BOOTDATA (6u)
+#define MPU_REGION_VALID (0x01 << MPU_RBAR_VALID_Pos)
+
+/**
+ * RASR - MPU Region Attribute and Size Register (CMSIS: SCB->RASR)
+ *
+ * Bit 0      – Enable region
+ * Bit 1..5   – Region size; 2^(flash_size + 1)
+ * Bit 16..21 – Memory type; TEX | Shareable | Cacheable | Bufferable
+ * Bit 24..26 – Access Privilege
+ * Bit 28     – Non-excutable region (XN)
+ */
+#define MPU_REGION_DISABLE (0x00 << MPU_RASR_ENABLE_Pos)
+#define MPU_REGION_ENABLE (0x01 << MPU_RASR_ENABLE_Pos)
+#define MPU_REGION_TYPE_NORMAL \
+    (0x08 << MPU_RASR_ATTRS_Pos) // TEX:b001 S:b0 C:b0 B:b0 - non-shareable, non-cacheable
+#define MPU_REGION_TYPE_STRONGLY_ORDERED (0x04 << MPU_RASR_ATTRS_Pos) // TEX:b000 S:b1 C:b0 B:b0
+#define MPU_REGION_TYPE_DEVICE (0x05 << MPU_RASR_ATTRS_Pos) // TEX:b000 S:b1 C:b0 B:b1
+#define MPU_REGION_NO_ACCESS (0x00 << MPU_RASR_AP_Pos)
+#define MPU_REGION_PRIVILEGED_READ_WRITE (0x01 << MPU_RASR_AP_Pos) // No user-mode access
+#define MPU_REGION_PRIVILEGED_RW_USER_RO (0x02 << MPU_RASR_AP_Pos) // No user-mode access
+#define MPU_REGION_READ_WRITE (0x03 << MPU_RASR_AP_Pos)
+#define MPU_REGION_PRIVILEGED_READ_ONLY (0x05 << MPU_RASR_AP_Pos) // No user-mode access
+#define MPU_REGION_READ_ONLY (0x06 << MPU_RASR_AP_Pos)
+#define MPU_REGION_EXECUTE_NEVER (0x01 << MPU_RASR_XN_Pos)
+
+/**
+ * Computes the "Region size" (bits 1..5) field of the RASR (see above),
+ * given the desired value.
+ * @param[in] size Value of the field
+ * @return Value of the register.
+ */
+uint32_t mpu_region_size(uint32_t size);
+
+/** Set region properties and enable region */
+void mpu_set_region(uint32_t rbar, uint32_t rasr);
+
+/** Disable the region with the given number */
+void mpu_disable_region(uint32_t region_number);
+
+#endif
+#endif

--- a/test/device-test/CMakeLists.txt
+++ b/test/device-test/CMakeLists.txt
@@ -85,6 +85,7 @@ set(BB02_TEST_LIST
   button_tap
   confirm_bip39
   entry_screen
+  mpu
   scroll_menu
   scroll_menu_2
   simple_slide
@@ -221,3 +222,6 @@ foreach(name ${BBB_TEST_LIST})
   add_dependencies(device-tests ${elf})
   endif()
 endforeach()
+
+# We need the "asm" extension for the MPU test.
+set_target_properties(fw_test_mpu.elf PROPERTIES COMPILE_FLAGS "-std=gnu99")

--- a/test/device-test/src/test_mpu.c
+++ b/test/device-test/src/test_mpu.c
@@ -1,0 +1,227 @@
+// Copyright 2019 Shift Cryptosecurity AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "driver_init.h"
+#include "flags.h"
+#include "hardfault.h"
+#include "inttypes.h"
+#include "mpu.h"
+#include "qtouch.h"
+#include "screen.h"
+#include "ui/oled/oled.h"
+
+#include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ui/fonts/arial_fonts.h>
+
+uint32_t __stack_chk_guard = 0;
+
+static void _screen_print_debug(const char* message, int duration)
+{
+    char print[300];
+    snprintf(print, sizeof(print), "%s", message);
+    UG_ClearBuffer();
+    UG_FontSelect(&font_font_a_9X9);
+    UG_PutString(0, 0, print, false);
+    UG_SendBuffer();
+    delay_ms(duration);
+}
+
+static void _screen_sprintf_debug(int duration, const char* fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    char print[300];
+    // There is a bug in clang-tidy
+    // See https://bugs.llvm.org/show_bug.cgi?id=41311
+    vsnprintf(print, sizeof(print), fmt, args); // NOLINT
+    va_end(args);
+    _screen_print_debug(print, duration);
+}
+
+/**
+ * This flag will be set to 0
+ * before performing a risky memory access.
+ * MemManage_Handler will set it to one if invoked.
+ */
+__attribute__((aligned(4))) static volatile bool _memmanage_called;
+
+/**
+ * This flag will be set to 0
+ * before performing a risky memory access.
+ * MemManage_Handler will set it to one if invoked.
+ */
+__attribute__((aligned(4))) static volatile bool _hardfault_called;
+
+extern void __attribute__((noreturn)) __stack_chk_fail(void);
+void __attribute__((noreturn)) __stack_chk_fail(void)
+{
+    _screen_print_debug("Stack smashing detected", 0);
+    while (1)
+        ;
+}
+
+static UG_GUI guioled; // Global GUI structure for OLED screen
+
+/** Prints a list of blocks/pages to a string. */
+static void list_to_string(char* buf, size_t buf_size, uint8_t* numbers, size_t n_numbers)
+{
+    if (n_numbers == 0) {
+        snprintf(buf, buf_size, "<empty>");
+        return;
+    }
+    size_t pos = 0;
+    // Compose the list of memory errors.
+    for (size_t i = 0; i < n_numbers; ++i) {
+        size_t this_chunk = snprintf(
+            buf + pos, buf_size - pos, "%u (%u),", numbers[i], numbers[i] * FLASH_ERASE_PAGE_NUM);
+        if (this_chunk + pos >= buf_size) {
+            memcpy(buf + buf_size - 4, "...", 4);
+            break;
+        }
+        pos += this_chunk;
+    }
+}
+
+/** Keep track of which blocks have generated a MPU violation. */
+#define N_FLASH_PAGES (2048)
+#define N_BLOCKS (N_FLASH_PAGES / FLASH_ERASE_PAGE_NUM)
+
+int main(void)
+{
+    init_mcu();
+    system_init();
+    oled_init();
+    UG_Init(
+        &guioled,
+        (void (*)(UG_S16, UG_S16, UG_COLOR))oled_set_pixel,
+        &font_font_a_9X9,
+        SCREEN_WIDTH,
+        SCREEN_HEIGHT);
+    UG_ClearBuffer();
+    UG_SendBuffer();
+
+    mpu_bitbox02_init();
+
+    /* Dummy variable in which to load our data. */
+    volatile uint64_t read_value;
+
+    uint8_t mem_errors[N_BLOCKS];
+    size_t n_mem_errors = 0;
+
+    /** Keep track of which blocks have generated a hard fault. */
+    uint8_t hardfault_errors[N_BLOCKS];
+    size_t n_hardfault_errors = 0;
+
+    for (uint8_t i = 0; i < N_BLOCKS; ++i) {
+        _screen_sprintf_debug(
+            1, "Attempting to access:\n - Block #%u\n - Page #%u)", i, i * FLASH_ERASE_PAGE_NUM);
+
+        /* The flags will be left to 0 on success. */
+        _memmanage_called = 0;
+        _hardfault_called = 0;
+        uintptr_t base_addr = i * FLASH_PAGE_SIZE * FLASH_ERASE_PAGE_NUM;
+        uint64_t* base_addr_ptr = (uint64_t*)base_addr;
+
+// Avoid linting this, clang cries at what we're doing.
+#ifndef __clang_analyzer__
+        read_value = *base_addr_ptr;
+        (void)read_value;
+#else
+        (void)base_addr_ptr;
+#endif
+
+        if (_memmanage_called) {
+            mem_errors[n_mem_errors] = i;
+            n_mem_errors++;
+        } else if (_hardfault_called) {
+            hardfault_errors[n_hardfault_errors] = i;
+            n_hardfault_errors++;
+        }
+    }
+
+    /* Format the errors we've found. */
+    char mem_err_list[100];
+    char hard_err_list[100];
+    list_to_string(mem_err_list, 100, mem_errors, n_mem_errors);
+    list_to_string(hard_err_list, 100, hardfault_errors, n_hardfault_errors);
+    _screen_sprintf_debug(
+        0, "Failed reads: %s\nHard faults: %s\nHave a nice day :)", mem_err_list, hard_err_list);
+    while (1)
+        ;
+}
+
+/**
+ * MPU fault handler.
+ *
+ * This function will set the _memmanage_called variable
+ * to 1, and then return to the instruction following the one
+ * that causes the MPU fault.
+ *
+ * This is done by modifying (+4 - i.e. +1 instruction)
+ * the return value stored in the stack (at SP+24).
+ *
+ * See Cortex-M3 Devices Generic User Guide, Section 2.3.7,
+ * for details of how the stack is filled on exception entrance.
+ *
+ * Note that __attribute__((naked)) will remove all boilerplate
+ * from the function code, so we are sure of how the stack looks
+ * like for our code, but at the same time we have to handle returning
+ * from the function manually.
+ */
+__attribute__((naked)) void MemManage_Handler(void)
+{
+    asm volatile(
+        "push {r1}\n"
+        /*
+         * Use 28 as the stack offset as we've pushed R1
+         * on top of it.
+         */
+        "ldr r1, [sp, #28]\n"
+        "add r1, r1, #4\n"
+        "str r1, [sp, #28]\n"
+        /* Now set the _memmanage_called flag. */
+        "mov r1, #1\n"
+        "push {r2}\n"
+        "ldr r2, =_memmanage_called\n"
+        "strb r1, [r2]\n"
+        /* Return */
+        "pop {r2}\n"
+        "pop {r1}\n"
+        "bx lr\n");
+}
+
+/**
+ * Hard fault handler.
+ *
+ * This function will set the _hardfault_called flag.
+ *
+ * See comments in MemManage_Handler for the details.
+ */
+__attribute__((naked)) void HardFault_Handler(void)
+{
+    asm volatile(
+        "push {r1}\n"
+        "ldr r1, [sp, #28]\n"
+        "add r1, r1, #4\n"
+        "str r1, [sp, #28]\n"
+        "mov r1, #1\n"
+        "push {r2}\n"
+        "ldr r2, =_hardfault_called\n"
+        "strb r1, [r2]\n"
+        "pop {r2}\n"
+        "pop {r1}\n"
+        "bx lr\n");
+}


### PR DESCRIPTION
The default MPU configuration left by the bootloader disables
pages 2000-2047. This is pointless as it means losing 48 pages
at the end of the NVM main address space to no real benefit.

Extend the APP_DATA_1 MPU region until the end of the flash address
space; the protected bootloader section will remain R/W blocked for
the firmware as it has higher priority in the MPU table.