### PR TITLE
bootloader: OP_VERSIONS returns wrong length

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,7 @@ endif()
 # Example 'v1.0.0'. They MUST not contain a pre-release label such as '-beta'.
 set(FIRMWARE_VERSION "v4.3.0")
 set(FIRMWARE_BTC_ONLY_VERSION "v4.3.0")
-set(BOOTLOADER_VERSION "v1.0.1")
+set(BOOTLOADER_VERSION "v2.0.0")
 
 find_package(PythonInterp 3.6 REQUIRED)
 

--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -1,0 +1,3 @@
+# bootloader v2.0.0 - (Not released yet; release notes are incomplete)
+
+* OP_INFO: return 8 bytes instead of 12 (the last four were unused and always zero)

--- a/src/bootloader/bootloader.c
+++ b/src/bootloader/bootloader.c
@@ -702,7 +702,7 @@ static size_t _api_set_show_firmware_hash(const uint8_t* input, uint8_t* output)
 }
 
 /*
- * output filled with bootloader version | firmware version | signing pubkeys version
+ * output filled with firmware version | signing pubkeys version
  */
 static size_t _api_versions(uint8_t* output)
 {
@@ -713,7 +713,7 @@ static size_t _api_versions(uint8_t* output)
         (const uint8_t*)&data->fields.signing_pubkeys_version,
         sizeof(version_t));
     _report_status(OP_STATUS_OK, output);
-    return BOOT_OP_LEN + sizeof(version_t) * 3;
+    return BOOT_OP_LEN + sizeof(version_t) * 2;
 }
 
 static void _api_reboot(void)


### PR DESCRIPTION
Judging by the out of date comment, it returns 12 bytes instead of 8
bytes by mistake from a previous iteration.