### PR TITLE
U2F-over-USART: format error frames correctly.

### DIFF
--- a/src/u2f/u2f_packet.c
+++ b/src/u2f/u2f_packet.c
@@ -82,9 +82,8 @@ static bool _need_more_data(void)
     return (_in_state.buf_ptr - _in_state.data) < (signed)_in_state.len;
 }
 
-void u2f_invalid_endpoint(struct queue* queue, uint32_t cmd, uint32_t cid)
+void u2f_invalid_endpoint(struct queue* queue, uint32_t cid)
 {
-    (void)cmd;
     // TODO: if U2F is disabled, we used to return a 'channel busy' command.
     // now we return an invalid cmd, because there is not going to be a matching
     // cmd in '_registered_cmds' if the U2F bit it not set (== U2F disabled).

--- a/src/u2f/u2f_packet.h
+++ b/src/u2f/u2f_packet.h
@@ -52,6 +52,6 @@ void u2f_packet_timeout_enable(uint32_t cid);
  * Called when a message has been received, but there is no
  * API registered to handle the requested U2F Command (endpoint) byte.
  */
-void u2f_invalid_endpoint(struct queue* queue, uint32_t cmd, uint32_t cid);
+void u2f_invalid_endpoint(struct queue* queue, uint32_t cid);
 
 #endif

--- a/src/usart/usart_frame.c
+++ b/src/usart/usart_frame.c
@@ -137,10 +137,10 @@ static uint16_t _compute_send_checksum(
     return cs;
 }
 
-static void _usart_send_frame_error(uint8_t error_code, uint32_t endpoint, struct queue* queue)
+static void _usart_send_frame_error(uint8_t error_code, struct queue* queue)
 {
-    uint8_t error_payload = endpoint;
-    usart_format_frame(error_code, &error_payload, 1, 0xFF, queue);
+    uint8_t error_payload = error_code;
+    usart_format_frame(0xFF, &error_payload, 1, 0x42 /* Unused */, queue);
 }
 
 /**
@@ -167,14 +167,14 @@ static void _usart_manage_frame_v1(const uint8_t* buf, size_t packet_len)
         dst_endpoint,
         /* We don't really have a CID... */ 0x42);
     if (!can_process) {
-        _usart_send_frame_error(USART_FRAME_ERROR_ENDPOINT_BUSY, dst_endpoint, queue_hww_queue());
+        _usart_send_frame_error(USART_FRAME_ERROR_ENDPOINT_BUSY, queue_hww_queue());
     }
 }
 
-void usart_invalid_endpoint(struct queue* queue, uint32_t src_endpoint, uint32_t cid)
+void usart_invalid_endpoint(struct queue* queue, uint32_t cid)
 {
     (void)cid;
-    _usart_send_frame_error(USART_FRAME_ERROR_ENDPOINT_UNAVAILABLE, src_endpoint, queue);
+    _usart_send_frame_error(USART_FRAME_ERROR_ENDPOINT_UNAVAILABLE, queue);
 }
 
 static void _usart_manage_full_rx_frame(void)

--- a/src/usart/usart_frame.h
+++ b/src/usart/usart_frame.h
@@ -49,7 +49,7 @@ void usart_frame_init(void);
 /**
  * Called when a message has been sent to a non-registered endpoint.
  */
-void usart_invalid_endpoint(struct queue* queue, uint32_t src_endpoint, uint32_t cid);
+void usart_invalid_endpoint(struct queue* queue, uint32_t cid);
 
 /**
  * Creates a data frame for sending over USART.

--- a/src/usb/usb_packet.c
+++ b/src/usb/usb_packet.c
@@ -51,9 +51,8 @@ static bool _need_more_data(void)
     return (_in_state.buf_ptr - _in_state.data) < (signed)_in_state.len;
 }
 
-void usb_invalid_endpoint(struct queue* queue, uint32_t cmd, uint32_t cid)
+void usb_invalid_endpoint(struct queue* queue, uint32_t cid)
 {
-    (void)cmd;
     // TODO: if U2F is disabled, we used to return a 'channel busy' command.
     // now we return an invalid cmd, because there is not going to be a matching
     // cmd in '_registered_cmds' if the U2F bit it not set (== U2F disabled).

--- a/src/usb/usb_packet.h
+++ b/src/usb/usb_packet.h
@@ -46,6 +46,6 @@ typedef struct {
  */
 bool usb_packet_process(const USB_FRAME* frame);
 
-void usb_invalid_endpoint(struct queue* queue, uint32_t cmd, uint32_t cid);
+void usb_invalid_endpoint(struct queue* queue, uint32_t cid);
 
 #endif

--- a/src/usb/usb_processing.c
+++ b/src/usb/usb_processing.c
@@ -37,7 +37,7 @@ struct usb_processing {
      * Function to call when a message has been received,
      * but there is no registered API set to manage it.
      */
-    void (*manage_invalid_endpoint)(struct queue* queue, uint32_t cmd, uint32_t cid);
+    void (*manage_invalid_endpoint)(struct queue* queue, uint32_t cid);
 };
 
 /*
@@ -187,7 +187,7 @@ static void _usb_process_incoming_packet(struct usb_processing* ctx)
     }
 
     if (!cmd_valid) {
-        ctx->manage_invalid_endpoint(ctx->out_queue(), _in_packet.cmd, _in_packet.cid);
+        ctx->manage_invalid_endpoint(ctx->out_queue(), _in_packet.cid);
     }
     _usb_processing_drop_received(ctx);
 }


### PR DESCRIPTION
Use the proper format for U2F-over-UART errors:
endpoint == 0xFF, 1 byte payload containing the error code.