### PR TITLE
py: add pyserial to requirements.txt

### DIFF
--- a/.ci/travis-ci
+++ b/.ci/travis-ci
@@ -2,7 +2,7 @@
 
 set -e
 
-CONTAINER=shiftcrypto/firmware_v2:7
+CONTAINER=shiftcrypto/firmware_v2:8
 
 # Fetch origin/master so that we can diff when checking coding style.
 git remote set-branches --add origin master

--- a/py/requirements.txt
+++ b/py/requirements.txt
@@ -2,3 +2,5 @@
 tzlocal>=1.5,<2.0
 # until bitbox02 is released it must be installed from py/bitbox02
 bitbox02
+# Serial module
+pyserial


### PR DESCRIPTION
Needed for the UART connection to the BitBoxBase HSM.

Dockerfile including this was build and pushed with :8.