### PR TITLE
py: add pyserial to requirements.txt (cherry-pick for the HSM branch)

### DIFF
--- a/.ci/travis-ci
+++ b/.ci/travis-ci
@@ -3,7 +3,7 @@
 set -e
 set -x
 
-CONTAINER=shiftcrypto/firmware_v2:7
+CONTAINER=shiftcrypto/firmware_v2:8
 
 if [ "$1" == "pull" ] ; then
 	docker pull "$CONTAINER"

--- a/py/requirements.txt
+++ b/py/requirements.txt
@@ -2,3 +2,5 @@
 tzlocal>=1.5,<2.0
 # until bitbox02 is released it must be installed from py/bitbox02
 bitbox02
+# Serial module
+pyserial


### PR DESCRIPTION
Cherry-pick of https://github.com/digitalbitbox/bitbox02-firmware/pull/210 on top of `hsm` to allow for separate HSM development.