### PR TITLE
bitboxbase: enable qtouch

### DIFF
--- a/src/bitboxbase/bitboxbase.c
+++ b/src/bitboxbase/bitboxbase.c
@@ -40,7 +40,7 @@ int main(void)
     __stack_chk_guard = common_stack_chk_guard();
     screen_init();
     screen_splash();
-    // qtouch_init();
+    qtouch_init();
     usart_start();
     hww_setup();
     common_main();


### PR DESCRIPTION
I must have missed this when merging the qtouch stuff.