### PR TITLE
Base api

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -156,6 +156,14 @@ set(PLATFORM-BITBOXBASE-SOURCES
 )
 set(PLATFORM-BITBOXBASE-SOURCES ${PLATFORM-BITBOXBASE-SOURCES} PARENT_SCOPE)
 
+set(BITBOXBASE-FIRMWARE-SOURCES
+  ${CMAKE_SOURCE_DIR}/src/bitboxbase/bitboxbase_background.c
+  ${CMAKE_SOURCE_DIR}/src/bitboxbase/bitboxbase_watchdog.c
+  ${CMAKE_SOURCE_DIR}/src/bitboxbase/bitboxbase_screensaver.c
+  ${CMAKE_SOURCE_DIR}/src/bitboxbase/bitboxbase_status.c
+)
+set(BITBOXBASE-FIRMWARE-SOURCES ${BITBOXBASE-FIRMWARE-SOURCES} PARENT_SCOPE)
+
 set(CRYPTOAUTHLIB-SOURCES
   ${CMAKE_SOURCE_DIR}/src/securechip/securechip.c
 )
@@ -239,8 +247,9 @@ if(CMAKE_CROSSCOMPILING)
   get_property(ASF4_MIN_INCLUDES TARGET asf4-drivers-min PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
   get_property(ASF4_INCLUDES TARGET asf4-drivers PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
   get_property(CMSIS_INCLUDES TARGET CMSIS PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
+  get_property(WALLY_INCLUDES TARGET wallycore PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
 
-  set(RUST_INCLUDES ${INCLUDES} ${SAMD51A_INCLUDES} ${ASF4_INCLUDES} ${ASF4_MIN_INCLUDES} ${CMSIS_INCLUDES})
+  set(RUST_INCLUDES ${INCLUDES} ${SYSTEMINCLUDES} ${SAMD51A_INCLUDES} ${ASF4_INCLUDES} ${ASF4_MIN_INCLUDES} ${CMSIS_INCLUDES} ${NANOPB_INCLUDE_DIRS} ${WALLY_INCLUDES})
 
   if(CMAKE_BUILD_TYPE STREQUAL "DEBUG")
     set(RUST_PROFILE "debug")
@@ -454,13 +463,13 @@ if(CMAKE_CROSSCOMPILING)
   target_compile_definitions(firmware-btc.elf PRIVATE PRODUCT_BITBOX_BTCONLY APP_BTC)
   target_sources(firmware-btc.elf PRIVATE ${PLATFORM-BITBOX02-SOURCES})
 
-  target_sources(firmware-bitboxbase.elf PRIVATE bitboxbase/bitboxbase.c)
+  target_sources(firmware-bitboxbase.elf PRIVATE bitboxbase/bitboxbase.c commander/commander_bitboxbase.c)
   target_compile_definitions(firmware-bitboxbase.elf PRIVATE PRODUCT_BITBOX_BASE)
-  target_sources(firmware-bitboxbase.elf PRIVATE ${PLATFORM-BITBOXBASE-SOURCES})
+  target_sources(firmware-bitboxbase.elf PRIVATE ${PLATFORM-BITBOXBASE-SOURCES} ${BITBOXBASE-FIRMWARE-SOURCES})
 
   target_sources(firmware-bitboxbase-semihosting.elf PRIVATE bitboxbase/bitboxbase.c)
   target_compile_definitions(firmware-bitboxbase-semihosting.elf PRIVATE PRODUCT_BITBOX_BASE SEMIHOSTING)
-  target_sources(firmware-bitboxbase-semihosting.elf PRIVATE ${PLATFORM-BITBOXBASE-SOURCES})
+  target_sources(firmware-bitboxbase-semihosting.elf PRIVATE ${PLATFORM-BITBOXBASE-SOURCES} ${BITBOXBASE-FIRMWARE-SOURCES})
 
   target_link_libraries(firmware-bitboxbase.elf PRIVATE bitbox02_rust)
   add_dependencies(firmware-bitboxbase.elf rust rust-bindgen)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -296,7 +296,7 @@ if(CMAKE_CROSSCOMPILING)
   # TODO(nc): Add dependency on global "doc" target on this when api-docs branch is merged
   add_custom_target(rust-docs
     COMMAND
-      ${CMAKE_COMMAND} -E env SYSROOT=${CMAKE_SYSROOT} INCLUDES="${RUST_INCLUDES}" ${CARGO} doc --manifest-path ${LIBBITBOX02_RUST_SOURCE_DIR}/Cargo.toml --target-dir ${CMAKE_BINARY_DIR}/docs-rust ${RUST_CARGO_FLAG} --target thumbv7em-none-eabi
+      ${CMAKE_COMMAND} -E env SYSROOT=${CMAKE_SYSROOT} INCLUDES="${RUST_INCLUDES}" ${CARGO} doc --document-private-items --manifest-path ${LIBBITBOX02_RUST_SOURCE_DIR}/Cargo.toml --target-dir ${CMAKE_BINARY_DIR}/docs-rust ${RUST_CARGO_FLAG} --target thumbv7em-none-eabi
     COMMAND
       ${CMAKE_COMMAND} -E echo "See docs at file://${CMAKE_BINARY_DIR}/docs-rust/thumbv7em-none-eabi/doc/bitbox02_rust/index.html"
   )

--- a/src/bitboxbase/bitboxbase_background.c
+++ b/src/bitboxbase/bitboxbase_background.c
@@ -1,0 +1,125 @@
+// Copyright 2019 Shift Cryptosecurity AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bitboxbase_background.h"
+#include "bitboxbase_screensaver.h"
+#include "bitboxbase_status.h"
+#include "screen.h"
+#include <hardfault.h>
+#include <leds.h>
+#include <rust/bitbox02_rust.h>
+#include <string.h>
+#include <ui/component.h>
+#include <ui/components/image.h>
+#include <ui/components/label.h>
+#include <ui/components/ui_images.h>
+#include <ui/event.h>
+#include <ui/oled/oled.h>
+#include <ui/screen_stack.h>
+#include <ui/ui_util.h>
+
+static void _render(component_t* component);
+static void _on_event(const event_t* event, component_t* component);
+
+static component_functions_t _component_functions = {
+    .cleanup = ui_util_component_cleanup,
+    .render = _render,
+    .on_event = _on_event,
+};
+
+void _render(component_t* component)
+{
+    component_t* label = component->sub_components.sub_components[1];
+    char buf[100];
+    bitboxbase_state_get_description(buf, sizeof(buf));
+    switch (bitboxbase_state_get()) {
+    case BBBNotAlive:
+        leds_turn_big_led(0, LED_COLOR_RED);
+        label_update(label, "Dead");
+        break;
+    case BBBWaiting:
+        leds_turn_big_led(0, LED_COLOR_GREEN);
+        label_update(label, "System starting...");
+        break;
+    case BBBIdle:
+        if (bitboxbase_config_led_mode_get() < OnWarning) {
+            leds_turn_big_led(0, LED_COLOR_GREEN);
+        } else {
+            leds_turn_big_led(0, LED_COLOR_NONE);
+        }
+        label_update(label, buf);
+        break;
+    case BBBWorking:
+        leds_turn_big_led(0, LED_COLOR_BLUE);
+        label_update(label, buf);
+        break;
+    case BBBWarning:
+        if (bitboxbase_config_led_mode_get() < OnError) {
+            leds_turn_big_led(0, LED_COLOR_YELLOW);
+        } else {
+            leds_turn_big_led(0, LED_COLOR_NONE);
+        }
+        label_update(label, buf);
+        break;
+    case BBBError:
+        leds_turn_big_led(0, LED_COLOR_RED);
+        label_update(label, buf);
+        break;
+    default:
+        Abort("Internal error");
+        break;
+    }
+    ui_util_component_render_subcomponents(component);
+}
+
+void _on_event(const event_t* event, component_t* component)
+{
+    (void)component;
+    bitboxbase_screensaver_reset();
+    oled_init();
+    if (event->id == EVENT_BUTTON_SHORT_TAP) {
+        bitboxbase_status();
+    }
+}
+
+static component_t* _create(void)
+{
+    component_t* show_logo = malloc(sizeof(component_t));
+    if (!show_logo) {
+        Abort("Error: malloc show_logo");
+    }
+    memset(show_logo, 0, sizeof(component_t));
+    show_logo->f = &_component_functions;
+    show_logo->dimension.width = 128;
+    show_logo->dimension.height = 64;
+    component_t* bb2_logo = image_create(
+        IMAGE_BB2_LOGO,
+        sizeof(IMAGE_BB2_LOGO),
+        IMAGE_BB2_LOGO_W,
+        IMAGE_BB2_LOGO_H,
+        CENTER,
+        show_logo);
+    component_t* loading_label = label_create("Booting...", NULL, RIGHT_BOTTOM, show_logo);
+    ui_util_add_sub_component(show_logo, bb2_logo);
+    ui_util_add_sub_component(show_logo, loading_label);
+    return show_logo;
+}
+
+void bitboxbase_background(void)
+{
+    leds_turn_big_led(0, LED_COLOR_NONE);
+    leds_turn_big_led(1, LED_COLOR_NONE);
+    component_t* b = _create();
+    ui_screen_stack_push(b);
+}

--- a/src/bitboxbase/bitboxbase_background.c
+++ b/src/bitboxbase/bitboxbase_background.c
@@ -46,7 +46,7 @@ void _render(component_t* component)
     switch (bitboxbase_state_get()) {
     case BBBNotAlive:
         leds_turn_big_led(0, LED_COLOR_RED);
-        label_update(label, "Dead");
+        label_update(label, "Error, please restart");
         break;
     case BBBWaiting:
         leds_turn_big_led(0, LED_COLOR_GREEN);

--- a/src/bitboxbase/bitboxbase_background.h
+++ b/src/bitboxbase/bitboxbase_background.h
@@ -12,20 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <bitboxbase.pb.h>
-#include <bitboxbase/bitboxbase_watchdog.h>
-#include <platform/bitboxbase/leds.h>
-#include <ui/components/label.h>
-#include <ui/fonts/arial_fonts.h>
-#include <ui/oled/oled.h>
-#include <ui/screen_stack.h>
-#include <ui/ugui/ugui.h>
-#include <wally_crypto.h>
-#include <workflow/confirm.h>
-
-#if !defined(TESTING)
-#include <hal_delay.h>
-#else
-void delay_us(const uint16_t us);
-void delay_ms(const uint16_t ms);
-#endif
+void bitboxbase_background(void);

--- a/src/bitboxbase/bitboxbase_screensaver.c
+++ b/src/bitboxbase/bitboxbase_screensaver.c
@@ -1,0 +1,68 @@
+// Copyright 2019 Shift Cryptosecurity AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bitboxbase_screensaver.h"
+#include <hal_timer.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+// The periodicity to increment the timeout counter
+#define INTERVAL_MS 1000
+// Number of periods we wait until we raise an alarm.
+#define TIMEOUT 120
+
+extern struct timer_descriptor TIMER_0;
+
+static volatile uint32_t timeout_counter;
+
+static void _timer_task_cb(const struct timer_task* const timer_task)
+{
+    (void)timer_task;
+    timeout_counter++;
+}
+
+static void _timer_config(void)
+{
+    static struct timer_task Timer_task;
+    Timer_task.interval = INTERVAL_MS;
+    Timer_task.cb = _timer_task_cb;
+    Timer_task.mode = TIMER_TASK_REPEAT;
+
+    timer_stop(&TIMER_0);
+    timer_add_task(&TIMER_0, &Timer_task);
+    timer_start(&TIMER_0);
+}
+
+// Initialize screensaver
+void bitboxbase_screensaver_init(void)
+{
+    bitboxbase_screensaver_reset();
+    _timer_config();
+}
+
+// Checks the timer
+bool bitboxbase_screensaver_check(void)
+{
+    if (timeout_counter > TIMEOUT) {
+        return true;
+    }
+    return false;
+}
+
+// Resets the screensaver
+void bitboxbase_screensaver_reset(void)
+{
+    timeout_counter = 0;
+}

--- a/src/bitboxbase/bitboxbase_screensaver.h
+++ b/src/bitboxbase/bitboxbase_screensaver.h
@@ -12,20 +12,30 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <bitboxbase.pb.h>
-#include <bitboxbase/bitboxbase_watchdog.h>
-#include <platform/bitboxbase/leds.h>
-#include <ui/components/label.h>
-#include <ui/fonts/arial_fonts.h>
-#include <ui/oled/oled.h>
-#include <ui/screen_stack.h>
-#include <ui/ugui/ugui.h>
-#include <wally_crypto.h>
-#include <workflow/confirm.h>
+#ifndef _BITBOXBASE_SCREENSAVER_H
+#define _BITBOXBASE_SCREENSAVER_H
 
-#if !defined(TESTING)
-#include <hal_delay.h>
-#else
-void delay_us(const uint16_t us);
-void delay_ms(const uint16_t ms);
+#include <stdbool.h>
+
+/**
+ * @file
+ *
+ * bitboxbase screensaver is a timer that keeps track of whether to turn off the display or not.
+ */
+
+/**
+ * Initialize counter
+ */
+void bitboxbase_screensaver_init(void);
+
+/**
+ * Check if screensaver should be enabled
+ */
+bool bitboxbase_screensaver_check(void);
+
+/**
+ * Reset counter
+ */
+void bitboxbase_screensaver_reset(void);
+
 #endif

--- a/src/bitboxbase/bitboxbase_status.c
+++ b/src/bitboxbase/bitboxbase_status.c
@@ -1,0 +1,77 @@
+// Copyright 2019 Shift Cryptosecurity AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bitboxbase_status.h"
+#include <hardfault.h>
+#include <leds.h>
+#include <rust/bitbox02_rust.h>
+#include <string.h>
+#include <ui/component.h>
+#include <ui/components/image.h>
+#include <ui/components/label.h>
+#include <ui/components/ui_images.h>
+#include <ui/event.h>
+#include <ui/oled/oled.h>
+#include <ui/screen_stack.h>
+#include <ui/ui_util.h>
+
+uint32_t frames = 0;
+char msg[250];
+
+static void _render(component_t* component);
+static void _on_event(const event_t* event, component_t* component);
+
+static component_functions_t _component_functions = {
+    .cleanup = ui_util_component_cleanup,
+    .render = _render,
+    .on_event = _on_event,
+};
+
+void _render(component_t* component)
+{
+    (void)component;
+    if (frames++ > 1000) {
+        ui_screen_stack_pop();
+    }
+    UG_ClearBuffer();
+    UG_PutString(10, 10, msg, false);
+    UG_SendBuffer();
+}
+
+void _on_event(const event_t* event, component_t* component)
+{
+    (void)event;
+    (void)component;
+}
+
+static component_t* _create(void)
+{
+    component_t* status = malloc(sizeof(component_t));
+    if (!status) {
+        Abort("Error: malloc show_logo");
+    }
+    memset(status, 0, sizeof(component_t));
+    status->f = &_component_functions;
+    status->dimension.width = 128;
+    status->dimension.height = 64;
+    return status;
+}
+
+void bitboxbase_status(void)
+{
+    memset(msg, 0, sizeof(msg));
+    frames = 0;
+    bitboxbase_status_get(msg, sizeof(msg));
+    ui_screen_stack_push(_create());
+}

--- a/src/bitboxbase/bitboxbase_status.h
+++ b/src/bitboxbase/bitboxbase_status.h
@@ -12,20 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <bitboxbase.pb.h>
-#include <bitboxbase/bitboxbase_watchdog.h>
-#include <platform/bitboxbase/leds.h>
-#include <ui/components/label.h>
-#include <ui/fonts/arial_fonts.h>
-#include <ui/oled/oled.h>
-#include <ui/screen_stack.h>
-#include <ui/ugui/ugui.h>
-#include <wally_crypto.h>
-#include <workflow/confirm.h>
-
-#if !defined(TESTING)
-#include <hal_delay.h>
-#else
-void delay_us(const uint16_t us);
-void delay_ms(const uint16_t ms);
-#endif
+/**
+ * Create a bitboxbase status screen
+ */
+void bitboxbase_status(void);

--- a/src/bitboxbase/bitboxbase_watchdog.c
+++ b/src/bitboxbase/bitboxbase_watchdog.c
@@ -21,7 +21,7 @@
 // The periodicity to increment the timeout counter
 #define INTERVAL_MS 1000
 // Number of periods we wait until we raise an alarm.
-#define TIMEOUT 15
+#define TIMEOUT 300
 
 extern struct timer_descriptor TIMER_0;
 

--- a/src/bitboxbase/bitboxbase_watchdog.c
+++ b/src/bitboxbase/bitboxbase_watchdog.c
@@ -1,0 +1,68 @@
+// Copyright 2019 Shift Cryptosecurity AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bitboxbase_watchdog.h"
+#include <hal_timer.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+// The periodicity to increment the timeout counter
+#define INTERVAL_MS 1000
+// Number of periods we wait until we raise an alarm.
+#define TIMEOUT 15
+
+extern struct timer_descriptor TIMER_0;
+
+static volatile uint32_t timeout_counter;
+
+static void _timer_task_cb(const struct timer_task* const timer_task)
+{
+    (void)timer_task;
+    timeout_counter++;
+}
+
+static void _timer_config(void)
+{
+    static struct timer_task Timer_task;
+    Timer_task.interval = INTERVAL_MS;
+    Timer_task.cb = _timer_task_cb;
+    Timer_task.mode = TIMER_TASK_REPEAT;
+
+    timer_stop(&TIMER_0);
+    timer_add_task(&TIMER_0, &Timer_task);
+    timer_start(&TIMER_0);
+}
+
+// Initialize watchdog
+void bitboxbase_watchdog_init(void)
+{
+    bitboxbase_watchdog_reset();
+    _timer_config();
+}
+
+// Checks the timer
+bool bitboxbase_watchdog_check(void)
+{
+    if (timeout_counter > TIMEOUT) {
+        return true;
+    }
+    return false;
+}
+
+// Resets the watchdog
+void bitboxbase_watchdog_reset(void)
+{
+    timeout_counter = 0;
+}

--- a/src/bitboxbase/bitboxbase_watchdog.h
+++ b/src/bitboxbase/bitboxbase_watchdog.h
@@ -1,0 +1,36 @@
+// Copyright 2019 Shift Cryptosecurity AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdbool.h>
+
+// The watchdog creates a timer which increases a counter every second.
+// If the counter is a bove a certain threshold, the `check` function will return true.
+// Whenever the `reset` function is called the counter is reset to 0.
+// This is used by the bitboxbase heartbeat. Every time there is an heartbeat the watchdog is reset
+// and in every iteration of the main loop the watchdog is checked.
+
+/**
+ * Initialize watchdog
+ */
+void bitboxbase_watchdog_init(void);
+
+/**
+ * Check if watchdog counter has elapsed
+ */
+bool bitboxbase_watchdog_check(void);
+
+/**
+ * Reset the watchdog counter
+ */
+void bitboxbase_watchdog_reset(void);

--- a/src/commander/commander.c
+++ b/src/commander/commander.c
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <platform_config.h>
+
 #include "commander.h"
 #if defined(APP_BTC) || defined(APP_LTC)
 #include "commander/commander_btc.h"
@@ -20,11 +22,13 @@
 #include "commander/commander_eth.h"
 #endif
 #include "commander/commander_states.h"
+#if PRODUCT_BITBOX_BASE == 1
+#include "commander/commander_bitboxbase.h"
+#endif
 
 #include <flags.h>
 #include <hardfault.h>
 #include <memory.h>
-#include <platform_config.h>
 #include <random.h>
 #include <screen.h>
 #include <sd.h>
@@ -319,6 +323,11 @@ static commander_error_t _api_process(const Request* request, Response* response
     case Request_restore_from_mnemonic_tag:
         response->which_response = Response_success_tag;
         return _api_restore_from_mnemonic(&(request->request.restore_from_mnemonic));
+#endif
+#if PRODUCT_BITBOX_BASE == 1
+    case Request_bitboxbase_tag:
+        response->which_response = Response_success_tag;
+        return commander_bitboxbase(&(request->request.bitboxbase));
 #endif
     case Request_reboot_tag:
         response->which_response = Response_success_tag;

--- a/src/commander/commander_bitboxbase.c
+++ b/src/commander/commander_bitboxbase.c
@@ -1,0 +1,68 @@
+// Copyright 2019 Shift Cryptosecurity AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "commander_bitboxbase.h"
+#include "commander.h"
+
+#include "rust/bitbox02_rust.h"
+
+#include "hww.pb.h"
+#include <pb_decode.h>
+#include <pb_encode.h>
+
+static commander_error_t _api_heartbeat(const BitBoxBaseHeartbeatRequest* request)
+{
+    if (!bitboxbase_heartbeat(request)) {
+        return COMMANDER_ERR_GENERIC;
+    }
+    return COMMANDER_OK;
+}
+
+static commander_error_t _api_confirm_pairing(const BitBoxBaseConfirmPairingRequest* request)
+{
+    if (!bitboxbase_workflow_confirm_pairing(request->msg, sizeof(request->msg))) {
+        return COMMANDER_ERR_USER_ABORT;
+    }
+    return COMMANDER_OK;
+}
+
+static commander_error_t _api_base_set_config(const BitBoxBaseSetConfigRequest* request)
+{
+    if (!bitboxbase_config_set(request)) {
+        return COMMANDER_ERR_GENERIC;
+    }
+    return COMMANDER_OK;
+}
+
+static commander_error_t _api_display_status(const BitBoxBaseDisplayStatusRequest* request)
+{
+    bitboxbase_display_status(request->duration);
+    return COMMANDER_OK;
+}
+
+commander_error_t commander_bitboxbase(const BitBoxBaseRequest* request)
+{
+    switch (request->which_request) {
+    case BitBoxBaseRequest_heartbeat_tag:
+        return _api_heartbeat(&(request->request.heartbeat));
+    case BitBoxBaseRequest_confirm_pairing_tag:
+        return _api_confirm_pairing(&(request->request.confirm_pairing));
+    case BitBoxBaseRequest_set_config_tag:
+        return _api_base_set_config(&(request->request.set_config));
+    case BitBoxBaseRequest_display_status_tag:
+        return _api_display_status(&(request->request.display_status));
+    default:
+        return COMMANDER_ERR_GENERIC;
+    }
+}

--- a/src/commander/commander_bitboxbase.h
+++ b/src/commander/commander_bitboxbase.h
@@ -12,20 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <bitboxbase.pb.h>
-#include <bitboxbase/bitboxbase_watchdog.h>
-#include <platform/bitboxbase/leds.h>
-#include <ui/components/label.h>
-#include <ui/fonts/arial_fonts.h>
-#include <ui/oled/oled.h>
-#include <ui/screen_stack.h>
-#include <ui/ugui/ugui.h>
-#include <wally_crypto.h>
-#include <workflow/confirm.h>
+#include "commander.h"
+#include "hww.pb.h"
 
-#if !defined(TESTING)
-#include <hal_delay.h>
-#else
-void delay_us(const uint16_t us);
-void delay_ms(const uint16_t ms);
-#endif
+commander_error_t commander_bitboxbase(const BitBoxBaseRequest* request);

--- a/src/commander/commander_states.c
+++ b/src/commander/commander_states.c
@@ -32,6 +32,7 @@ static commander_states_endpoint_id _commands_anytime[] = {
     Request_check_sdcard_tag,
     Request_insert_remove_sdcard_tag,
     Request_list_backups_tag,
+    Request_bitboxbase_tag,
 };
 
 // api commands the host can invoke when the device is uninitialized.

--- a/src/rust/bitbox02-rust/Cargo.lock
+++ b/src/rust/bitbox02-rust/Cargo.lock
@@ -51,6 +51,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "binascii"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "bindgen"
 version = "0.49.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -84,6 +89,7 @@ name = "bitbox02-rust"
 version = "0.1.0"
 dependencies = [
  "arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "binascii 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitbox02 0.1.0",
 ]
 
@@ -381,6 +387,7 @@ dependencies = [
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 "checksum backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)" = "924c76597f0d9ca25d762c25a4d369d51267536465dc5064bdf0eb073ed477ea"
 "checksum backtrace-sys 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491"
+"checksum binascii 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bc52f59483d6f69fb024e61ac9f75b4bcfa4ef52ad0ae67ad4a3bbf257ddeef6"
 "checksum bindgen 0.49.2 (registry+https://github.com/rust-lang/crates.io-index)" = "846a1fba6535362a01487ef6b10f0275faa12e5c5d835c5c1c627aabc46ccbd6"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"

--- a/src/rust/bitbox02-rust/Cargo.toml
+++ b/src/rust/bitbox02-rust/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["staticlib"]
 
 [dependencies]
 bitbox02 = {path = "../bitbox02"}
+binascii = "0.1"
 
 # For stack allocated strings
 [dependencies.arrayvec]

--- a/src/rust/bitbox02-rust/src/commander/bitboxbase.rs
+++ b/src/rust/bitbox02-rust/src/commander/bitboxbase.rs
@@ -1,0 +1,120 @@
+// Copyright 2019 Shift Cryptosecurity AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bitbox02;
+use core::time::Duration;
+
+use crate::platform::bitboxbase::config::Config;
+use crate::platform::bitboxbase::display::display_status;
+use crate::platform::bitboxbase::state::State;
+use crate::util::Ipv4Addr;
+use crate::workflow::pairing;
+
+#[no_mangle]
+pub extern "C" fn bitboxbase_workflow_confirm_pairing(bytes: *const u8, bytes_len: usize) -> bool {
+    assert!(!bytes.is_null());
+    assert!(bytes_len > 0 && bytes_len <= 32);
+    let bytes = unsafe { core::slice::from_raw_parts(bytes, bytes_len) };
+    bitbox02::leds_turn_small_led(0, true);
+    bitbox02::leds_turn_small_led(4, true);
+    bitbox02::leds_turn_big_led(0, None);
+    bitbox02::leds_turn_big_led(1, None);
+
+    let res = pairing::extra_hash_create(bytes);
+    bitbox02::leds_turn_small_led(0, false);
+    bitbox02::leds_turn_small_led(4, false);
+    res
+}
+
+#[no_mangle]
+pub extern "C" fn bitboxbase_heartbeat(
+    request: *const bitbox02::BitBoxBaseHeartbeatRequest,
+) -> bool {
+    // Accessing a mutable static is unsafe
+    let state = unsafe { State::get_singleton_mut() };
+    // Accessing raw pointers are unsafe
+    let request = match unsafe { request.as_ref() } {
+        Some(request) => request,
+        None => return false,
+    };
+    // Transmute uint32 to BitBoxBaseBackgroundState
+    // This is safe for values 0 to 3.
+    if request.state_code > 3 {
+        return false;
+    }
+    state.state = unsafe { core::mem::transmute(request.state_code + 2) };
+    if request.description_code > 3 {
+        return false;
+    }
+    state.description_code = unsafe { core::mem::transmute(request.description_code) };
+    bitbox02::bitboxbase_watchdog_reset();
+
+    true
+}
+
+#[no_mangle]
+pub extern "C" fn bitboxbase_config_set(
+    request: *const bitbox02::BitBoxBaseSetConfigRequest,
+) -> bool {
+    // Accessing a mutable static is unsafe
+    let config = unsafe { Config::get_singleton_mut() };
+    // Accessing raw pointers are unsafe
+    let request = match unsafe { request.as_ref() } {
+        Some(request) => request,
+        None => return false,
+    };
+    let hostname =
+        bitbox02::util::str_from_null_terminated(&request.hostname[..]).expect("Invalid utf-8");
+    match &hostname {
+        &"" => (),
+        hostname => match config.set_hostname(hostname) {
+            Err(_) => return false,
+            _ => (),
+        },
+    }
+
+    match request.which_ip_option {
+        bitbox02::BitBoxBaseSetConfigRequest_ip_tag => {
+            // Accessing c union types is unsafe
+            let ip: Ipv4Addr = unsafe { request.ip_option.ip }.into();
+            config.set_ip(ip);
+        }
+        _ => (), // ip not set
+    }
+
+    if request.status_led_mode > 3 {
+        return false;
+    }
+    let status_led_mode = unsafe { core::mem::transmute(request.status_led_mode) };
+    config.set_status_led_mode(status_led_mode);
+
+    if request.status_screen_mode > 3 {
+        return false;
+    }
+    let status_screen_mode = unsafe { core::mem::transmute(request.status_screen_mode) };
+    config.set_status_screen_mode(status_screen_mode);
+
+    true
+}
+
+#[no_mangle]
+pub extern "C" fn bitboxbase_display_status(duration: u64) {
+    let duration = if duration > 0 {
+        Some(Duration::from_millis(duration))
+    } else {
+        None
+    };
+    // Accessing a mutable static is unsafe
+    display_status(unsafe { Config::get_singleton() }, duration);
+}

--- a/src/rust/bitbox02-rust/src/commander/mod.rs
+++ b/src/rust/bitbox02-rust/src/commander/mod.rs
@@ -12,20 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <bitboxbase.pb.h>
-#include <bitboxbase/bitboxbase_watchdog.h>
-#include <platform/bitboxbase/leds.h>
-#include <ui/components/label.h>
-#include <ui/fonts/arial_fonts.h>
-#include <ui/oled/oled.h>
-#include <ui/screen_stack.h>
-#include <ui/ugui/ugui.h>
-#include <wally_crypto.h>
-#include <workflow/confirm.h>
-
-#if !defined(TESTING)
-#include <hal_delay.h>
-#else
-void delay_us(const uint16_t us);
-void delay_ms(const uint16_t ms);
-#endif
+pub mod bitboxbase;

--- a/src/rust/bitbox02-rust/src/error.rs
+++ b/src/rust/bitbox02-rust/src/error.rs
@@ -12,20 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <bitboxbase.pb.h>
-#include <bitboxbase/bitboxbase_watchdog.h>
-#include <platform/bitboxbase/leds.h>
-#include <ui/components/label.h>
-#include <ui/fonts/arial_fonts.h>
-#include <ui/oled/oled.h>
-#include <ui/screen_stack.h>
-#include <ui/ugui/ugui.h>
-#include <wally_crypto.h>
-#include <workflow/confirm.h>
-
-#if !defined(TESTING)
-#include <hal_delay.h>
-#else
-void delay_us(const uint16_t us);
-void delay_ms(const uint16_t ms);
-#endif
+#[derive(Debug)]
+pub enum Error {
+    InvalidHostname,
+}

--- a/src/rust/bitbox02-rust/src/lib.rs
+++ b/src/rust/bitbox02-rust/src/lib.rs
@@ -19,8 +19,19 @@
 
 use core::panic::PanicInfo;
 
+mod error;
 #[macro_use]
 mod general;
+mod commander;
+mod platform;
+mod util;
+mod workflow;
+
+// A trick to convince cbindgen that an u8 is char.
+// cbindgen will convert `u8` to `uint8_t` and `i8` to `int8_t` which are `unsigned char` and
+// `signed char` respectively. `c_char` is converted to `char` without `signed` or `unsigned`.
+#[allow(non_camel_case_types)]
+type c_char = u8;
 
 // Whenever execution reaches somewhere it isn't supposed to rust code will "panic". Our panic
 // handler will print the available information on the screen. If we compile with `panic=abort`

--- a/src/rust/bitbox02-rust/src/platform/bitboxbase/config.rs
+++ b/src/rust/bitbox02-rust/src/platform/bitboxbase/config.rs
@@ -1,0 +1,136 @@
+// Copyright 2019 Shift Cryptosecurity AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use core::fmt::Write;
+use core::time::Duration;
+
+use arrayvec::ArrayString;
+
+use crate::c_char;
+use crate::error::Error;
+use crate::util::{FixedCString, Ipv4Addr};
+
+/// This determines if the LED should be turned off in some states.
+#[derive(Debug, Clone)]
+#[repr(u8)]
+#[allow(dead_code)] // We are setting this with transmute
+pub enum StatusLedMode {
+    /// Always show the LED
+    Always,
+    /// Only show the led in the Working, Warning and Error states
+    OnWorking,
+    /// Only show the led in the Warning and Error states
+    OnWarning,
+    /// Only show the led in the Error state
+    OnError,
+}
+
+#[derive(Debug, Clone)]
+#[repr(u8)]
+#[allow(dead_code)] // We are setting this with transmute
+pub enum StatusScreenMode {
+    /// Always show the screen
+    Always,
+    /// Only show the screen in the Working, Warning and Error states
+    OnWorking,
+    /// Only show the screen in the Warning and Error states
+    OnWarning,
+    /// Only show the screen in the Error state
+    OnError,
+}
+
+pub struct Config {
+    pub(crate) status_led_mode: StatusLedMode,
+    pub(crate) status_screen_mode: StatusScreenMode,
+    pub(crate) default_display_duration: Duration,
+    pub(crate) hostname: Option<ArrayString<[u8; 64]>>,
+    pub(crate) ip: Option<Ipv4Addr>,
+}
+
+impl Config {
+    pub const fn new() -> Config {
+        Config {
+            status_led_mode: StatusLedMode::Always,
+            status_screen_mode: StatusScreenMode::OnWarning,
+            default_display_duration: Duration::from_secs(10),
+            hostname: None,
+            ip: None,
+        }
+    }
+
+    pub fn set_status_led_mode(&mut self, mode: StatusLedMode) {
+        self.status_led_mode = mode;
+    }
+
+    pub fn set_status_screen_mode(&mut self, mode: StatusScreenMode) {
+        self.status_screen_mode = mode;
+    }
+
+    pub fn set_hostname(&mut self, hostname: &str) -> Result<(), Error> {
+        if !hostname.is_ascii() {
+            return Err(Error::InvalidHostname);
+        }
+        if hostname.len() < 1 || hostname.len() > 63 {
+            return Err(Error::InvalidHostname);
+        }
+        // Since we checked that the string contains at least one character we can safely unwrap
+        if hostname.chars().nth(0).unwrap() == '-' || hostname.chars().last().unwrap() == '-' {
+            return Err(Error::InvalidHostname);
+        }
+        if hostname.chars().any(|c| !c.is_alphanumeric() && c != '-') {
+            return Err(Error::InvalidHostname);
+        }
+        self.hostname = Some(ArrayString::from(hostname).expect("Buffer to short"));
+        Ok(())
+    }
+
+    pub fn set_ip(&mut self, ip: Ipv4Addr) {
+        self.ip = Some(ip);
+    }
+
+    pub unsafe fn get_singleton() -> &'static Config {
+        &CONFIG
+    }
+
+    pub unsafe fn get_singleton_mut() -> &'static mut Config {
+        &mut CONFIG
+    }
+}
+
+//
+// C-API
+//
+
+// aaaah, global!
+static mut CONFIG: Config = Config::new();
+
+#[no_mangle]
+pub extern "C" fn bitboxbase_config_led_mode_get() -> StatusLedMode {
+    let config = unsafe { Config::get_singleton() };
+    config.status_led_mode.clone()
+}
+
+#[no_mangle]
+pub extern "C" fn bitboxbase_config_ip_get(res: *mut c_char, res_len: usize) {
+    // It is not safe to call any functions that also touch CONFIG at the same time
+    let config = unsafe { Config::get_singleton() };
+    let buf = unsafe { core::slice::from_raw_parts_mut(res, res_len) };
+    let mut fcstring = FixedCString::new(buf);
+
+    if let Some(ip) = &config.ip {
+        let _ = write!(fcstring, "{}", ip);
+    } else {
+        let _ = write!(fcstring, "unknown");
+    }
+}

--- a/src/rust/bitbox02-rust/src/platform/bitboxbase/display.rs
+++ b/src/rust/bitbox02-rust/src/platform/bitboxbase/display.rs
@@ -1,0 +1,63 @@
+// Copyright 2019 Shift Cryptosecurity AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use core::fmt::Write;
+use core::time::Duration;
+
+use arrayvec::ArrayString;
+use bitbox02::{delay, ug_clear_buffer, ug_font_select, ug_put_string, ug_send_buffer};
+
+use super::config::Config;
+use crate::c_char;
+use crate::util::FixedCString;
+
+fn write_status<W: Write>(w: &mut W, config: &Config) {
+    let _ = write!(w, "hostname: ");
+    if let Some(hostname) = &config.hostname {
+        let _ = write!(w, "{}", hostname);
+    } else {
+        let _ = write!(w, "<unnamed>");
+    }
+    let _ = write!(w, "\n");
+    let _ = write!(w, "ip: ");
+    if let Some(ip) = &config.ip {
+        let _ = write!(w, "{}", ip);
+    } else {
+        let _ = write!(w, "<unassigned>");
+    }
+    let _ = write!(w, "\n");
+    let _ = write!(w, "status: OK\n");
+    let _ = write!(w, "mode: {:?}\n", config.status_led_mode);
+}
+
+pub fn display_status(config: &Config, duration: Option<Duration>) {
+    ug_clear_buffer();
+    ug_font_select();
+    let mut buf = ArrayString::<[_; 256]>::new();
+    write_status(&mut buf, config);
+    ug_put_string(10, 10, &buf, false);
+    ug_send_buffer();
+    if let Some(duration) = duration {
+        delay(duration)
+    } else {
+        delay(config.default_display_duration)
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn bitboxbase_status_get(ptr: *mut c_char, ptr_len: usize) {
+    let buf = unsafe { core::slice::from_raw_parts_mut(ptr, ptr_len) };
+    let mut wrapper = FixedCString::new(buf);
+    write_status(&mut wrapper, unsafe { Config::get_singleton() });
+}

--- a/src/rust/bitbox02-rust/src/platform/bitboxbase/mod.rs
+++ b/src/rust/bitbox02-rust/src/platform/bitboxbase/mod.rs
@@ -12,20 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <bitboxbase.pb.h>
-#include <bitboxbase/bitboxbase_watchdog.h>
-#include <platform/bitboxbase/leds.h>
-#include <ui/components/label.h>
-#include <ui/fonts/arial_fonts.h>
-#include <ui/oled/oled.h>
-#include <ui/screen_stack.h>
-#include <ui/ugui/ugui.h>
-#include <wally_crypto.h>
-#include <workflow/confirm.h>
-
-#if !defined(TESTING)
-#include <hal_delay.h>
-#else
-void delay_us(const uint16_t us);
-void delay_ms(const uint16_t ms);
-#endif
+pub mod config;
+pub mod display;
+pub mod state;

--- a/src/rust/bitbox02-rust/src/platform/bitboxbase/state.rs
+++ b/src/rust/bitbox02-rust/src/platform/bitboxbase/state.rs
@@ -1,0 +1,107 @@
+// Copyright 2019 Shift Cryptosecurity AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::c_char;
+use crate::util::FixedCString;
+use core::fmt::Write;
+
+pub struct State {
+    pub(crate) state: BitBoxBaseBackgroundState,
+    pub(crate) description_code: BitBoxBaseBackgroundDescription,
+}
+
+/// Global state of bitboxbase background. As long as we export this to C code it has to be repr(C)
+/// and have a long name.
+/// TODO: Shorten name when not used in C anymore.
+#[allow(dead_code)]
+#[derive(Copy, Clone)]
+#[repr(u8)]
+pub enum BitBoxBaseBackgroundState {
+    /// Waiting is the initial state before any heartbeat after power on.
+    BBBWaiting,
+    /// NotAlive is the error state when heartbeats stop coming
+    BBBNotAlive,
+    /// State given by the MW
+    BBBIdle,
+    /// State given by the MW
+    BBBWorking,
+    /// State given by the MW
+    BBBWarning,
+    /// State given by the MW
+    BBBError,
+}
+
+/// Strings that the MW can set
+#[allow(dead_code)]
+#[derive(Copy, Clone)]
+#[repr(u8)]
+pub enum BitBoxBaseBackgroundDescription {
+    Empty,
+    InitialBlockDownload,
+    UpdateDownload,
+    OutOfDiskSpace,
+}
+
+const DESCRIPTIONS: &[&str] = &[
+    "",
+    "Initial block download",
+    "Downloading update",
+    "Out of disk space",
+];
+
+impl State {
+    pub unsafe fn get_singleton() -> &'static State {
+        &STATE
+    }
+
+    pub unsafe fn get_singleton_mut() -> &'static mut State {
+        &mut STATE
+    }
+}
+
+//
+// C-API
+//
+
+static mut STATE: State = State {
+    state: BitBoxBaseBackgroundState::BBBWaiting,
+    description_code: BitBoxBaseBackgroundDescription::Empty,
+};
+
+#[no_mangle]
+pub extern "C" fn bitboxbase_state_set_not_alive() {
+    let state = unsafe { State::get_singleton_mut() };
+    (*state).state = BitBoxBaseBackgroundState::BBBNotAlive;
+}
+
+#[no_mangle]
+pub extern "C" fn bitboxbase_state_get() -> BitBoxBaseBackgroundState {
+    let state = unsafe { State::get_singleton() };
+    state.state.clone()
+}
+
+#[no_mangle]
+pub extern "C" fn bitboxbase_state_get_description(buf: *mut c_char, buf_len: usize) {
+    assert!(!buf.is_null());
+    let state = unsafe { State::get_singleton() };
+    let buf = unsafe { core::slice::from_raw_parts_mut(buf, buf_len) };
+    let mut buf = FixedCString::new(buf);
+    let _ = write!(
+        buf,
+        "{}",
+        DESCRIPTIONS
+            .get(state.description_code as usize)
+            .unwrap_or(&"<Unknown>")
+    );
+}

--- a/src/rust/bitbox02-rust/src/platform/mod.rs
+++ b/src/rust/bitbox02-rust/src/platform/mod.rs
@@ -12,20 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <bitboxbase.pb.h>
-#include <bitboxbase/bitboxbase_watchdog.h>
-#include <platform/bitboxbase/leds.h>
-#include <ui/components/label.h>
-#include <ui/fonts/arial_fonts.h>
-#include <ui/oled/oled.h>
-#include <ui/screen_stack.h>
-#include <ui/ugui/ugui.h>
-#include <wally_crypto.h>
-#include <workflow/confirm.h>
-
-#if !defined(TESTING)
-#include <hal_delay.h>
-#else
-void delay_us(const uint16_t us);
-void delay_ms(const uint16_t ms);
-#endif
+pub mod bitboxbase;

--- a/src/rust/bitbox02-rust/src/util.rs
+++ b/src/rust/bitbox02-rust/src/util.rs
@@ -1,0 +1,143 @@
+// Copyright 2019 Shift Cryptosecurity AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use core::fmt;
+
+pub struct Ipv4Addr {
+    a: u8,
+    b: u8,
+    c: u8,
+    d: u8,
+}
+
+impl From<[u8; 4]> for Ipv4Addr {
+    fn from(octets: [u8; 4]) -> Self {
+        Ipv4Addr {
+            a: octets[0],
+            b: octets[1],
+            c: octets[2],
+            d: octets[3],
+        }
+    }
+}
+
+impl fmt::Display for Ipv4Addr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}.{}.{}.{}", self.a, self.b, self.c, self.d)
+    }
+}
+
+/// FixedCString is always null terminated when other things are written to it. Useful for communicating with C code.
+pub struct FixedCString<'a> {
+    buf: &'a mut [u8],
+    offset: usize,
+}
+
+impl<'a> FixedCString<'a> {
+    pub fn new(buf: &'a mut [u8]) -> Self {
+        FixedCString {
+            buf: buf,
+            offset: 0,
+        }
+    }
+}
+
+impl<'a> fmt::Write for FixedCString<'a> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        let bytes = s.as_bytes();
+
+        // Skip over already-copied data
+        let remainder = &mut self.buf[self.offset..];
+        // Check if there is space remaining (return error instead of panicking)
+        if remainder.len() < bytes.len() + 1 {
+            return Err(fmt::Error);
+        }
+        // Make the two slices the same length
+        let remainder = &mut remainder[..bytes.len()];
+        // Copy
+        remainder.copy_from_slice(bytes);
+
+        // Update offset to avoid overwriting
+        self.offset += bytes.len();
+
+        // Set last character to null
+        self.buf[self.offset] = 0;
+
+        Ok(())
+    }
+}
+
+impl<'a> fmt::Debug for FixedCString<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(core::str::from_utf8(&self.buf[..self.offset]).unwrap(), f)
+    }
+}
+
+impl<'a> fmt::Display for FixedCString<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(core::str::from_utf8(&self.buf[..self.offset]).unwrap(), f)
+    }
+}
+
+///// FixedString is a fixed capacity string which is backed by a mutable [u8] slice.
+///// It is useful for printing formatted strings into the buffer
+///// If we had std::io in core this wouldn't have been needed bacause &mut [u8] implements
+///// std::io::Write.
+//pub struct FixedString<'a> {
+//    buf: &'a mut [u8],
+//    offset: usize,
+//}
+//
+//impl<'a> FixedString<'a> {
+//    pub fn new(buf: &'a mut [u8]) -> Self {
+//        FixedString {
+//            buf: buf,
+//            offset: 0,
+//        }
+//    }
+//}
+//
+//impl<'a> fmt::Write for FixedString<'a> {
+//    fn write_str(&mut self, s: &str) -> fmt::Result {
+//        let bytes = s.as_bytes();
+//
+//        // Skip over already-copied data
+//        let remainder = &mut self.buf[self.offset..];
+//        // Check if there is space remaining (return error instead of panicking)
+//        if remainder.len() < bytes.len() {
+//            return Err(fmt::Error);
+//        }
+//        // Make the two slices the same length
+//        let remainder = &mut remainder[..bytes.len()];
+//        // Copy
+//        remainder.copy_from_slice(bytes);
+//
+//        // Update offset to avoid overwriting
+//        self.offset += bytes.len();
+//
+//        Ok(())
+//    }
+//}
+//
+//impl<'a> fmt::Debug for FixedString<'a> {
+//    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+//        fmt::Debug::fmt(core::str::from_utf8(&self.buf[..self.offset]).unwrap(), f)
+//    }
+//}
+//
+//impl<'a> fmt::Display for FixedString<'a> {
+//    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+//        fmt::Display::fmt(core::str::from_utf8(&self.buf[..self.offset]).unwrap(), f)
+//    }
+//}

--- a/src/rust/bitbox02-rust/src/workflow/confirm.rs
+++ b/src/rust/bitbox02-rust/src/workflow/confirm.rs
@@ -1,0 +1,36 @@
+// Copyright 2019 Shift Cryptosecurity AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// This function takes a slice of bytes that must be at most 60 characters when base32
+/// encoded.
+pub fn pairing(bytes: &[u8]) -> bool {
+    let mut encoded = [0u8; 60];
+    binascii::b32encode(bytes, &mut encoded).unwrap_or_else(|_| panic!("Too short buffer"));
+
+    // Base32 contains only utf-8 valid chars. unwrap is safe
+    let encoded = core::str::from_utf8(&encoded).expect("invalid utf-8");
+    let mut formatted = ArrayString::<[_; 23]>::new();
+
+    write!(
+        formatted,
+        "{} {}\n{} {}",
+        &encoded[0..5],
+        &encoded[5..10],
+        &encoded[10..15],
+        &encoded[15..20]
+    )
+    .expect("failed to format");
+
+    bitbox02::workflow_confirm("Base pairing code", &formatted, false, false)
+}

--- a/src/rust/bitbox02-rust/src/workflow/mod.rs
+++ b/src/rust/bitbox02-rust/src/workflow/mod.rs
@@ -12,20 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <bitboxbase.pb.h>
-#include <bitboxbase/bitboxbase_watchdog.h>
-#include <platform/bitboxbase/leds.h>
-#include <ui/components/label.h>
-#include <ui/fonts/arial_fonts.h>
-#include <ui/oled/oled.h>
-#include <ui/screen_stack.h>
-#include <ui/ugui/ugui.h>
-#include <wally_crypto.h>
-#include <workflow/confirm.h>
-
-#if !defined(TESTING)
-#include <hal_delay.h>
-#else
-void delay_us(const uint16_t us);
-void delay_ms(const uint16_t ms);
-#endif
+pub mod pairing;

--- a/src/rust/bitbox02-rust/src/workflow/pairing.rs
+++ b/src/rust/bitbox02-rust/src/workflow/pairing.rs
@@ -1,0 +1,47 @@
+// Copyright 2019 Shift Cryptosecurity AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use arrayvec::ArrayString;
+use binascii;
+use bitbox02;
+use core::fmt::Write;
+
+/// This function takes a slice of bytes that must be at most 60 characters when base32
+/// encoded.
+pub fn create(bytes: &[u8]) -> bool {
+    let mut encoded = [0u8; 60];
+    binascii::b32encode(bytes, &mut encoded).unwrap_or_else(|_| panic!("Too short buffer"));
+
+    // Base32 contains only utf-8 valid chars. unwrap is safe
+    let encoded = core::str::from_utf8(&encoded).expect("invalid utf-8");
+    let mut formatted = ArrayString::<[_; 23]>::new();
+
+    write!(
+        formatted,
+        "{} {}\n{} {}",
+        &encoded[0..5],
+        &encoded[5..10],
+        &encoded[10..15],
+        &encoded[15..20]
+    )
+    .expect("failed to format");
+
+    bitbox02::workflow_confirm("Base pairing code", &formatted, false, false)
+}
+
+pub fn extra_hash_create(bytes: &[u8]) -> bool {
+    let mut buf = [0u8; 32];
+    bitbox02::sha256(bytes, &mut buf).expect("sha256 failed");
+    create(&buf[..])
+}

--- a/src/rust/bitbox02-sys/build.rs
+++ b/src/rust/bitbox02-sys/build.rs
@@ -32,6 +32,7 @@ fn main() {
         .whitelist_function("UG_ClearBuffer")
         .whitelist_function("UG_SendBuffer")
         .whitelist_function("workflow_confirm")
+        .whitelist_function("screen_print_debug")
         .whitelist_function("ui_screen_stack_push")
         .whitelist_function("ui_screen_stack_pop")
         .whitelist_function("label_create")

--- a/src/rust/bitbox02-sys/build.rs
+++ b/src/rust/bitbox02-sys/build.rs
@@ -32,12 +32,24 @@ fn main() {
         .whitelist_function("UG_ClearBuffer")
         .whitelist_function("UG_SendBuffer")
         .whitelist_function("workflow_confirm")
+        .whitelist_function("ui_screen_stack_push")
+        .whitelist_function("ui_screen_stack_pop")
+        .whitelist_function("label_create")
+        .whitelist_function("bitboxbase_watchdog_reset")
+        .whitelist_function("leds_turn_small_led")
+        .whitelist_function("leds_turn_big_led")
+        .whitelist_function("wally_sha256")
+        .whitelist_type("component_t")
+        .whitelist_type("BitBoxBaseRequest")
+        .whitelist_var(".*_tag")
         .whitelist_var("font_font_a_9X9")
+        .whitelist_var("WALLY_OK")
         .use_core()
         .ctypes_prefix("c_types")
         .clang_arg("-D__SAMD51J20A__")
         .clang_arg("-DPB_NO_PACKED_STRUCTS=1")
-        .clang_arg("-DPB_FIELD_16BIT=1");
+        .clang_arg("-DPB_FIELD_16BIT=1")
+        .clang_arg("-fshort-enums");
 
     // Fetch sysroot from the environment. If there isn't any sysroot assume we are building for
     // testing
@@ -53,7 +65,6 @@ fn main() {
             "-mcpu=cortex-m4",
             "-mthumb",
             "-mfloat-abi=soft",
-            "-fshort-enums",
         ]);
     } else {
         bindings = bindings.clang_arg("-DTESTING")

--- a/src/rust/bitbox02-sys/wrapper.h
+++ b/src/rust/bitbox02-sys/wrapper.h
@@ -15,6 +15,7 @@
 #include <bitboxbase.pb.h>
 #include <bitboxbase/bitboxbase_watchdog.h>
 #include <platform/bitboxbase/leds.h>
+#include <screen.h>
 #include <ui/components/label.h>
 #include <ui/fonts/arial_fonts.h>
 #include <ui/oled/oled.h>

--- a/src/rust/bitbox02/src/util.rs
+++ b/src/rust/bitbox02/src/util.rs
@@ -1,3 +1,17 @@
+// Copyright 2019 Shift Cryptosecurity AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /// Must be given a null-terminated string
 pub unsafe fn strlen_ptr(ptr: *const u8) -> isize {
     let mut end = ptr;
@@ -22,4 +36,40 @@ pub fn strlen_slice(input: &[u8]) -> usize {
 pub fn str_from_null_terminated(input: &[u8]) -> Result<&str, core::str::Utf8Error> {
     let len = strlen_slice(input);
     core::str::from_utf8(&input[0..len])
+}
+
+/// Macro for creating a stack allocated buffer with the content of a string and a null-terminator
+///
+/// Example usage:
+///
+/// ```
+/// # #[macro_use] extern crate bitbox02;
+/// let name = "sample_string";
+/// let buf = match str_to_cstr!(name, 50) {
+///     Ok(buf) => buf,
+///     Err(_) => panic!("to short"),
+/// };
+/// ```
+#[macro_export]
+macro_rules! str_to_cstr {
+    ($input:expr, $len:literal) => {{
+        let mut buf = [0u8; $len + 1];
+        if !$input.is_ascii() {
+            Err(buf)
+        } else {
+            let len = core::cmp::min($len, $input.len());
+            {
+                // Take a slice of buf of the correct length
+                let buf = &mut buf[..len];
+                // Take a slice of input of the correct length
+                let input = &$input.as_bytes()[..len];
+                buf.copy_from_slice(input);
+            }
+            if $input.len() > len {
+                Err(buf)
+            } else {
+                Ok(buf)
+            }
+        }
+    }};
 }

--- a/src/rust/bitbox02/src/util.rs
+++ b/src/rust/bitbox02/src/util.rs
@@ -1,0 +1,25 @@
+/// Must be given a null-terminated string
+pub unsafe fn strlen_ptr(ptr: *const u8) -> isize {
+    let mut end = ptr;
+    loop {
+        if *end == 0 {
+            // Can be changed to (*const u8).offset_from() when stabilized
+            return isize::wrapping_sub(end as _, ptr as _);
+        }
+        end = end.offset(1);
+    }
+}
+
+pub fn strlen_slice(input: &[u8]) -> usize {
+    if let Some(nullidx) = input.iter().position(|&c| c == 0) {
+        nullidx
+    } else {
+        input.len()
+    }
+}
+
+/// Parses a utf-8 string out of a null terminated fixed length array
+pub fn str_from_null_terminated(input: &[u8]) -> Result<&str, core::str::Utf8Error> {
+    let len = strlen_slice(input);
+    core::str::from_utf8(&input[0..len])
+}

--- a/src/rust/cbindgen.toml
+++ b/src/rust/cbindgen.toml
@@ -3,3 +3,5 @@ language = "C"
 include_guard = "rust_h"
 
 include_version = true
+
+includes = ["bitboxbase.pb.h"]

--- a/src/ui/components/label.c
+++ b/src/ui/components/label.c
@@ -43,6 +43,45 @@ void label_update(component_t* component, const char* text)
 {
     data_t* data = (data_t*)component->data;
     snprintf(data->text, sizeof(data->text), "%s", text);
+    UG_MeasureString(&(component->dimension.width), &(component->dimension.height), text);
+    if (component->parent == NULL) {
+        return;
+    }
+    component_t* parent = component->parent;
+    switch (data->position) {
+    case CENTER:
+        ui_util_position_center(parent, component);
+        break;
+    case CENTER_TOP:
+        ui_util_position_center_top(parent, component);
+        break;
+    case CENTER_BOTTOM:
+        ui_util_position_center_bottom(parent, component);
+        break;
+    case LEFT_TOP:
+        ui_util_position_left_top(parent, component);
+        break;
+    case LEFT_BOTTOM:
+        ui_util_position_left_bottom(parent, component);
+        break;
+    case LEFT_CENTER:
+        ui_util_position_left_center(parent, component);
+        break;
+    case CUSTOM_OFFSET:
+        //ui_util_position_left_center_offset(parent, component, data->offset);
+        break;
+    case RIGHT_CENTER:
+        ui_util_position_right_center(parent, component);
+        break;
+    case RIGHT_TOP:
+        ui_util_position_right_top(parent, component);
+        break;
+    case RIGHT_BOTTOM:
+        ui_util_position_right_bottom(parent, component);
+        break;
+    default:
+        Abort("position undefined or currently not implemented");
+    }
 }
 
 static void _render(component_t* component)

--- a/src/ui/components/label.c
+++ b/src/ui/components/label.c
@@ -68,7 +68,7 @@ void label_update(component_t* component, const char* text)
         ui_util_position_left_center(parent, component);
         break;
     case CUSTOM_OFFSET:
-        //ui_util_position_left_center_offset(parent, component, data->offset);
+        // ui_util_position_left_center_offset(parent, component, data->offset);
         break;
     case RIGHT_CENTER:
         ui_util_position_right_center(parent, component);

--- a/src/ui/oled/oled.c
+++ b/src/ui/oled/oled.c
@@ -116,6 +116,8 @@ enum _interface_t {
     INTERFACE_DATA,
 };
 
+static volatile bool _enabled = false;
+
 /**
  * Write to serial interface
  * @param [in] interface which interface to talk to.
@@ -168,6 +170,9 @@ static inline void _write_cmd_with_param(uint8_t command, uint8_t value)
 
 void oled_init(void)
 {
+    if (_enabled) {
+        return;
+    }
     // DC-DC OFF
     gpio_set_pin_level(PIN_OLED_ON, 0);
     delay_us(5);
@@ -211,6 +216,7 @@ void oled_init(void)
 
     // DC-DC ON
     gpio_set_pin_level(PIN_OLED_ON, 1);
+    _enabled = true;
 }
 
 void oled_send_buffer(void)
@@ -285,4 +291,15 @@ void oled_set_pixel(uint16_t x, uint16_t y, uint8_t c)
     }
 #endif
     _frame_buffer_updated = true;
+}
+
+void oled_off(void)
+{
+    if (!_enabled) {
+        return;
+    }
+    _write_cmd(OLED_CMD_SET_DISPLAY_OFF);
+    // OFF VCC
+    gpio_set_pin_level(PIN_OLED_ON, 0);
+    _enabled = false;
 }

--- a/src/ui/oled/oled.h
+++ b/src/ui/oled/oled.h
@@ -86,6 +86,11 @@ void oled_clear_buffer(void);
 void oled_mirror(bool mirror);
 
 /**
+ * Turn off oled
+ */
+void oled_off(void);
+
+/**
  * Set a screen pixel. This fills the frame buffer
  * prior to it being sent to the screen by oled_send_buffer().
  */

--- a/src/usb/noise.c
+++ b/src/usb/noise.c
@@ -179,7 +179,10 @@ static bool _process_handshake(
         // We are paired now, so we pop that screen.
         // Pairing is the start of a session, so we clean the screen stack in case
         // we started a new session in the middle of something.
+        // In bitboxbase the "background" screen should never be popped.
+#if PLATFORM_BITBOX02 == 1
         ui_screen_stack_pop_all();
+#endif
 
         out_packet->len = 1;
         out_packet->data_addr[0] = _require_pairing_verification;


### PR DESCRIPTION
- [x] move stuff around so it mirrors `src/`.
- [x] macroize str_to_cstr function

Open questions:
- Should we use `RUSTC_BOOTSTRAP=1` and use nightly features on stable compiler?
  - We would get the `alloc` crate which has the collections in it like `String` and `Vec`.
  - We would get access to const generics.
  - I do prefer using a stable compiler + `RUSTC_BOOTSTRAP=1` over using a pinned nightly compiler.