### PR TITLE
bitboxbase: Don't abort on wrong screen orientation

### DIFF
--- a/src/bootloader/bootloader.c
+++ b/src/bootloader/bootloader.c
@@ -775,12 +775,16 @@ static void _api_reboot(void)
 
 static size_t _api_screen_rotate(uint8_t* output)
 {
+#if PLATFORM_BITBOX02 == 1
     if (_loading_ready) {
         return _report_status(OP_STATUS_ERR_LOAD_FLAG, output);
     }
     screen_rotate();
     _render_default_screen();
     return _report_status(OP_STATUS_OK, output);
+#elif PLATFORM_BITBOXBASE == 1
+    return _report_status(OP_STATUS_ERR_INVALID_CMD, output);
+#endif
 }
 
 static size_t _api_command(const uint8_t* input, uint8_t* output, const size_t max_out_len)
@@ -966,9 +970,11 @@ void bootloader_jump(void)
 
     _check_init(&bootdata);
 
+#if PLATFORM_BITBOX02 == 1
     if (shared_data.fields.upside_down) {
         screen_rotate();
     }
+#endif
 
     if (shared_data.fields.auto_enter != sectrue_u8) {
 #ifdef BOOTLOADER_DEVDEVICE

--- a/src/screen.c
+++ b/src/screen.c
@@ -26,7 +26,9 @@
 #include <util.h>
 
 static UG_GUI guioled; // Global GUI structure for OLED screen
+#if PLATFORM_BITBOX02 == 1 || defined(TESTING)
 static bool screen_upside_down = false;
+#endif
 
 UG_COLOR screen_front_color = C_WHITE;
 UG_COLOR screen_back_color = C_BLACK;
@@ -83,17 +85,24 @@ void screen_splash(void)
     UG_ClearBuffer();
 }
 
+// TODO(nc): Remove these 2 functions from bitboxbase
 void screen_rotate(void)
 {
+#if PLATFORM_BITBOX02 == 1 || defined(TESTING)
     screen_upside_down = !screen_upside_down;
     top_slider = 1 - top_slider;
     bottom_slider = 1 - bottom_slider;
     oled_mirror(screen_upside_down);
+#endif
 }
 
 bool screen_is_upside_down(void)
 {
+#if PLATFORM_BITBOX02 == 1 || defined(TESTING)
     return screen_upside_down;
+#else
+    return false;
+#endif
 }
 
 void screen_init(void)

--- a/src/screen.h
+++ b/src/screen.h
@@ -19,6 +19,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <platform_config.h>
 #include <ui/ugui/ugui.h>
 
 // TODO: allow updating

--- a/src/ui/oled/oled.c
+++ b/src/ui/oled/oled.c
@@ -67,6 +67,7 @@
 
 #include <driver_init.h>
 #include <hardfault.h>
+#include <screen.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
@@ -253,7 +254,8 @@ void oled_mirror(bool mirror)
     }
 #elif PLATFORM_BITBOXBASE == 1
     (void)mirror;
-    Abort("BitBoxBase cannot mirror screen");
+    // DON'T ABORT HERE, this is called in the bootloader
+    screen_print_debug("BitBoxBase cannot mirror screen", 5000);
 #endif
 }
 

--- a/src/workflow/reboot.c
+++ b/src/workflow/reboot.c
@@ -26,7 +26,13 @@ static void _reboot(void)
         .value = sectrue_u8,
     };
     upside_down_t upside_down = {
+#if PLATFORM_BITBOX02 == 1 || defined(TESTING)
         .value = screen_is_upside_down(),
+#elif PLATFORM_BITBOXBASE == 1
+        .value = false,
+#else
+#error "No platform"
+#endif
     };
     if (!memory_bootloader_set_flags(auto_enter, upside_down)) {
         // If this failed, we might not be able to reboot into the bootloader.

--- a/src/workflow/workflow.c
+++ b/src/workflow/workflow.c
@@ -61,6 +61,7 @@ void workflow_start(void)
     ui_screen_stack_push(info_centered_create("See the BitBoxApp", NULL));
 }
 
+#if PLATFORM_BITBOX02 == 1
 /**
  * Called when the "select orientation" screen is over.
  * Switch to the main view.
@@ -73,11 +74,13 @@ static void _select_orientation_done(bool upside_down)
     component_t* show_logo = show_logo_create(workflow_start, 200);
     ui_screen_stack_switch(show_logo);
 }
+#endif
 
 void workflow_start_orientation_screen(void)
 {
 #if PLATFORM_BITBOXBASE == 1
-    _select_orientation_done(false);
+    component_t* show_logo = show_logo_create(workflow_start, 200);
+    ui_screen_stack_switch(show_logo);
 #elif PLATFORM_BITBOX02 == 1
     component_t* select_orientation = orientation_arrows_create(_select_orientation_done);
     ui_screen_stack_switch(select_orientation);


### PR DESCRIPTION
Also don't rotate screen in bootloader and always set it to not flipped
when rebooting