### PR TITLE
rust: Change optmimzation for size

### DIFF
--- a/src/rust/bitbox02-rust/Cargo.toml
+++ b/src/rust/bitbox02-rust/Cargo.toml
@@ -8,6 +8,15 @@ description = "BitBox02 functionality implemented in rust"
 [lib]
 crate-type = ["staticlib"]
 
+[profile.release]
+debug = true
+opt-level = 'z'
+codegen-units = 1
+panic = 'abort'
+
+[profile.dev]
+opt-level = 'z'
+
 [dependencies]
 bitbox02 = {path = "../bitbox02"}
 binascii = "0.1"
@@ -17,6 +26,3 @@ binascii = "0.1"
 version  = "0.5.1"
 # Disable the "std" feature
 default-features = false
-
-[profile.release]
-debug = true

--- a/src/rust/bitbox02-rust/src/lib.rs
+++ b/src/rust/bitbox02-rust/src/lib.rs
@@ -37,9 +37,13 @@ type c_char = u8;
 // handler will print the available information on the screen. If we compile with `panic=abort`
 // this code will never get executed.
 #[cfg(not(test))]
+#[cfg_attr(not(debug_assertions), allow(unused_variables))]
 #[panic_handler]
 fn panic(info: &PanicInfo) -> ! {
-    print_debug!(0, "Internal error: {}", info);
+    #[cfg(debug_assertions)]
+    print_debug!(0, "Error: {}", info);
+    #[cfg(not(debug_assertions))]
+    print_debug!(0, "Error");
     loop {}
 }
 


### PR DESCRIPTION
optimize for size instead of whatever is default. Also remove some debug strings by abort as the panic strategy instead of unwind.