### PR TITLE
Py: Move noise verification callback after send, before response

### DIFF
--- a/py/bitbox02/bitboxbase/bitboxbase.py
+++ b/py/bitbox02/bitboxbase/bitboxbase.py
@@ -39,7 +39,7 @@ class BitBoxBase(communication.BitBoxCommonAPI):
         self,
         device: communication.TransportLayer,
         device_info: DeviceInfo,
-        show_pairing_callback: Callable[[str], None],
+        show_pairing_callback: Callable[[str], bool],
         attestation_check_callback: Optional[Callable[[bool], None]] = None,
     ):
         communication.BitBoxCommonAPI.__init__(

--- a/py/load_firmware.py
+++ b/py/load_firmware.py
@@ -44,9 +44,10 @@ def _get_bitbox_and_reboot() -> devices.DeviceInfo:
     device = devices.get_any_bitbox02()
 
     # bitbox02 detected -> send command to reboot into bootloader to upgrade.
-    def _show_pairing(code: str) -> None:
+    def _show_pairing(code: str) -> bool:
         print("Please compare and confirm the pairing code on your BitBox02:")
         print(code)
+        return True
 
     hid_device = hid.device()
     hid_device.open_path(device["path"])
@@ -155,9 +156,10 @@ def _find_and_open_usart_bitbox(serial_port: usart.SerialPort) -> devices.Device
     print("BitBox bootloader not available.")
     print("Trying to connect to BitBox firmware instead...")
 
-    def _show_pairing(code: str) -> None:
+    def _show_pairing(code: str) -> bool:
         print("(Pairing should be automatic) Pairing code:")
         print(code)
+        return True
 
     try:
         transport = usart.U2FUsart(serial_port)

--- a/py/send_message.py
+++ b/py/send_message.py
@@ -541,9 +541,10 @@ def connect_to_usb_bitbox(debug: bool) -> int:
             return boot_app.run()
     else:
 
-        def show_pairing(code: str) -> None:
+        def show_pairing(code: str) -> bool:
             print("Please compare and confirm the pairing code on your BitBox02:")
             print(code)
+            return True
 
         def attestation_check(result: bool) -> None:
             if result:
@@ -574,9 +575,10 @@ def connect_to_usart_bitboxbase(debug: bool, serial_port: usart.SerialPort) -> i
     print("Trying to connect to BitBoxBase firmware...")
     bootloader_device: devices.DeviceInfo = get_bitboxbase_default_device(serial_port.port)
 
-    def show_pairing(code: str) -> None:
+    def show_pairing(code: str) -> bool:
         print("(Pairing should be automatic) Pairing code:")
         print(code)
+        return True
 
     def attestation_check(result: bool) -> None:
         if result:


### PR DESCRIPTION
The noise verification callback might not return if the callback function does a blocking call to a client (for example to render the pairing code on a window). If that is the case, the client would display the pairing code before it is displayed on the device. To evade this, place the callback after making the pairing verification request to the device, and read the response once the callback returns.

Why is the 2ufhid interface used here in the first place? Is this just the unencrypted interface, or is it a separate hid handler?