### PR TITLE
Py: Fix sendmessage eth and btc pubkey pb2 import

### DIFF
--- a/py/bitbox02/bitbox02/__init__.py
+++ b/py/bitbox02/bitbox02/__init__.py
@@ -50,6 +50,7 @@ from .bitbox02 import (
     HARDENED,
     hww,
     btc,
+    eth,
     UserAbortException,
 )
 from .bootloader import Bootloader

--- a/py/send_message.py
+++ b/py/send_message.py
@@ -170,7 +170,7 @@ class SendMessage:
             "m/84'/0'/0' xpub: ",
             self._device.btc_pub(
                 keypath=[84 + HARDENED, 0 + HARDENED, 0 + HARDENED],
-                output_type=bitbox02.hww.BTCPubRequest.ZPUB,  # pylint: disable=no-member
+                output_type=bitbox02.btc.BTCPubRequest.ZPUB,  # pylint: disable=no-member
             ),
         )
 
@@ -264,7 +264,7 @@ class SendMessage:
         def address(display: bool = False) -> str:
             return self._device.eth_pub(
                 keypath=[44 + HARDENED, 60 + HARDENED, 0 + HARDENED, 0, 0],
-                output_type=bitbox02.hww.ETHPubRequest.ADDRESS,  # pylint: disable=no-member
+                output_type=bitbox02.eth.ETHPubRequest.ADDRESS,  # pylint: disable=no-member
                 display=display,
             )
 


### PR DESCRIPTION
I also saw that in https://github.com/digitalbitbox/bitbox02-firmware/blob/master/messages/hww.proto the btc requests are included, but the eth requests are not. What is the reason for that? I also did not understand, why I could not do `bitbox02.eth.ETHPubRequest.Address`, even though `eth` is aliased as an import of `generated.eth_pb2` in the bitbox02 package.