### PR TITLE
Add testnet segwit upub and vpub

### DIFF
--- a/messages/btc.proto
+++ b/messages/btc.proto
@@ -36,6 +36,8 @@ message BTCPubRequest {
     YPUB = 2;
     ZPUB = 3;
     ADDRESS = 4;
+    VPUB = 5;
+    UPUB = 6;
   }
   BTCScriptType script_type = 2; // only applies for ADDRESS
   BTCCoin coin = 3;

--- a/py/bitbox02/communication/generated/btc_pb2.py
+++ b/py/bitbox02/communication/generated/btc_pb2.py
@@ -20,7 +20,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='btc.proto',
   package='',
   syntax='proto3',
-  serialized_pb=_b('\n\tbtc.proto\"\xe1\x01\n\rBTCPubRequest\x12\x0f\n\x07keypath\x18\x01 \x03(\r\x12#\n\x0bscript_type\x18\x02 \x01(\x0e\x32\x0e.BTCScriptType\x12\x16\n\x04\x63oin\x18\x03 \x01(\x0e\x32\x08.BTCCoin\x12.\n\x0boutput_type\x18\x04 \x01(\x0e\x32\x19.BTCPubRequest.OutputType\x12\x0f\n\x07\x64isplay\x18\x05 \x01(\x08\"A\n\nOutputType\x12\x08\n\x04TPUB\x10\x00\x12\x08\n\x04XPUB\x10\x01\x12\x08\n\x04YPUB\x10\x02\x12\x08\n\x04ZPUB\x10\x03\x12\x0b\n\x07\x41\x44\x44RESS\x10\x04\"\xb4\x01\n\x12\x42TCSignInitRequest\x12\x16\n\x04\x63oin\x18\x01 \x01(\x0e\x32\x08.BTCCoin\x12#\n\x0bscript_type\x18\x02 \x01(\x0e\x32\x0e.BTCScriptType\x12\x15\n\rbip44_account\x18\x03 \x01(\r\x12\x0f\n\x07version\x18\x04 \x01(\r\x12\x12\n\nnum_inputs\x18\x05 \x01(\r\x12\x13\n\x0bnum_outputs\x18\x06 \x01(\r\x12\x10\n\x08locktime\x18\x07 \x01(\r\"\xa0\x01\n\x13\x42TCSignNextResponse\x12\'\n\x04type\x18\x01 \x01(\x0e\x32\x19.BTCSignNextResponse.Type\x12\r\n\x05index\x18\x02 \x01(\r\x12\x15\n\rhas_signature\x18\x03 \x01(\x08\x12\x11\n\tsignature\x18\x04 \x01(\x0c\"\'\n\x04Type\x12\t\n\x05INPUT\x10\x00\x12\n\n\x06OUTPUT\x10\x01\x12\x08\n\x04\x44ONE\x10\x02\"y\n\x13\x42TCSignInputRequest\x12\x13\n\x0bprevOutHash\x18\x01 \x01(\x0c\x12\x14\n\x0cprevOutIndex\x18\x02 \x01(\r\x12\x14\n\x0cprevOutValue\x18\x03 \x01(\x04\x12\x10\n\x08sequence\x18\x04 \x01(\r\x12\x0f\n\x07keypath\x18\x06 \x03(\r\"p\n\x14\x42TCSignOutputRequest\x12\x0c\n\x04ours\x18\x01 \x01(\x08\x12\x1c\n\x04type\x18\x02 \x01(\x0e\x32\x0e.BTCOutputType\x12\r\n\x05value\x18\x03 \x01(\x04\x12\x0c\n\x04hash\x18\x04 \x01(\x0c\x12\x0f\n\x07keypath\x18\x05 \x03(\r*/\n\x07\x42TCCoin\x12\x07\n\x03\x42TC\x10\x00\x12\x08\n\x04TBTC\x10\x01\x12\x07\n\x03LTC\x10\x02\x12\x08\n\x04TLTC\x10\x03*`\n\rBTCScriptType\x12\x12\n\x0eSCRIPT_UNKNOWN\x10\x00\x12\x10\n\x0cSCRIPT_P2PKH\x10\x01\x12\x16\n\x12SCRIPT_P2WPKH_P2SH\x10\x02\x12\x11\n\rSCRIPT_P2WPKH\x10\x03*H\n\rBTCOutputType\x12\x0b\n\x07UNKNOWN\x10\x00\x12\t\n\x05P2PKH\x10\x01\x12\x08\n\x04P2SH\x10\x02\x12\n\n\x06P2WPKH\x10\x03\x12\t\n\x05P2WSH\x10\x04\x62\x06proto3')
+  serialized_pb=_b('\n\tbtc.proto\"\xf5\x01\n\rBTCPubRequest\x12\x0f\n\x07keypath\x18\x01 \x03(\r\x12#\n\x0bscript_type\x18\x02 \x01(\x0e\x32\x0e.BTCScriptType\x12\x16\n\x04\x63oin\x18\x03 \x01(\x0e\x32\x08.BTCCoin\x12.\n\x0boutput_type\x18\x04 \x01(\x0e\x32\x19.BTCPubRequest.OutputType\x12\x0f\n\x07\x64isplay\x18\x05 \x01(\x08\"U\n\nOutputType\x12\x08\n\x04TPUB\x10\x00\x12\x08\n\x04XPUB\x10\x01\x12\x08\n\x04YPUB\x10\x02\x12\x08\n\x04ZPUB\x10\x03\x12\x0b\n\x07\x41\x44\x44RESS\x10\x04\x12\x08\n\x04VPUB\x10\x05\x12\x08\n\x04UPUB\x10\x06\"\xb4\x01\n\x12\x42TCSignInitRequest\x12\x16\n\x04\x63oin\x18\x01 \x01(\x0e\x32\x08.BTCCoin\x12#\n\x0bscript_type\x18\x02 \x01(\x0e\x32\x0e.BTCScriptType\x12\x15\n\rbip44_account\x18\x03 \x01(\r\x12\x0f\n\x07version\x18\x04 \x01(\r\x12\x12\n\nnum_inputs\x18\x05 \x01(\r\x12\x13\n\x0bnum_outputs\x18\x06 \x01(\r\x12\x10\n\x08locktime\x18\x07 \x01(\r\"\xa0\x01\n\x13\x42TCSignNextResponse\x12\'\n\x04type\x18\x01 \x01(\x0e\x32\x19.BTCSignNextResponse.Type\x12\r\n\x05index\x18\x02 \x01(\r\x12\x15\n\rhas_signature\x18\x03 \x01(\x08\x12\x11\n\tsignature\x18\x04 \x01(\x0c\"\'\n\x04Type\x12\t\n\x05INPUT\x10\x00\x12\n\n\x06OUTPUT\x10\x01\x12\x08\n\x04\x44ONE\x10\x02\"y\n\x13\x42TCSignInputRequest\x12\x13\n\x0bprevOutHash\x18\x01 \x01(\x0c\x12\x14\n\x0cprevOutIndex\x18\x02 \x01(\r\x12\x14\n\x0cprevOutValue\x18\x03 \x01(\x04\x12\x10\n\x08sequence\x18\x04 \x01(\r\x12\x0f\n\x07keypath\x18\x06 \x03(\r\"p\n\x14\x42TCSignOutputRequest\x12\x0c\n\x04ours\x18\x01 \x01(\x08\x12\x1c\n\x04type\x18\x02 \x01(\x0e\x32\x0e.BTCOutputType\x12\r\n\x05value\x18\x03 \x01(\x04\x12\x0c\n\x04hash\x18\x04 \x01(\x0c\x12\x0f\n\x07keypath\x18\x05 \x03(\r*/\n\x07\x42TCCoin\x12\x07\n\x03\x42TC\x10\x00\x12\x08\n\x04TBTC\x10\x01\x12\x07\n\x03LTC\x10\x02\x12\x08\n\x04TLTC\x10\x03*`\n\rBTCScriptType\x12\x12\n\x0eSCRIPT_UNKNOWN\x10\x00\x12\x10\n\x0cSCRIPT_P2PKH\x10\x01\x12\x16\n\x12SCRIPT_P2WPKH_P2SH\x10\x02\x12\x11\n\rSCRIPT_P2WPKH\x10\x03*H\n\rBTCOutputType\x12\x0b\n\x07UNKNOWN\x10\x00\x12\t\n\x05P2PKH\x10\x01\x12\x08\n\x04P2SH\x10\x02\x12\n\n\x06P2WPKH\x10\x03\x12\t\n\x05P2WSH\x10\x04\x62\x06proto3')
 )
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
@@ -49,8 +49,8 @@ _BTCCOIN = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=824,
-  serialized_end=871,
+  serialized_start=844,
+  serialized_end=891,
 )
 _sym_db.RegisterEnumDescriptor(_BTCCOIN)
 
@@ -80,8 +80,8 @@ _BTCSCRIPTTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=873,
-  serialized_end=969,
+  serialized_start=893,
+  serialized_end=989,
 )
 _sym_db.RegisterEnumDescriptor(_BTCSCRIPTTYPE)
 
@@ -115,8 +115,8 @@ _BTCOUTPUTTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=971,
-  serialized_end=1043,
+  serialized_start=991,
+  serialized_end=1063,
 )
 _sym_db.RegisterEnumDescriptor(_BTCOUTPUTTYPE)
 
@@ -162,11 +162,19 @@ _BTCPUBREQUEST_OUTPUTTYPE = _descriptor.EnumDescriptor(
       name='ADDRESS', index=4, number=4,
       options=None,
       type=None),
+    _descriptor.EnumValueDescriptor(
+      name='VPUB', index=5, number=5,
+      options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='UPUB', index=6, number=6,
+      options=None,
+      type=None),
   ],
   containing_type=None,
   options=None,
   serialized_start=174,
-  serialized_end=239,
+  serialized_end=259,
 )
 _sym_db.RegisterEnumDescriptor(_BTCPUBREQUEST_OUTPUTTYPE)
 
@@ -191,8 +199,8 @@ _BTCSIGNNEXTRESPONSE_TYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=546,
-  serialized_end=585,
+  serialized_start=566,
+  serialized_end=605,
 )
 _sym_db.RegisterEnumDescriptor(_BTCSIGNNEXTRESPONSE_TYPE)
 
@@ -253,7 +261,7 @@ _BTCPUBREQUEST = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=14,
-  serialized_end=239,
+  serialized_end=259,
 )
 
 
@@ -325,8 +333,8 @@ _BTCSIGNINITREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=242,
-  serialized_end=422,
+  serialized_start=262,
+  serialized_end=442,
 )
 
 
@@ -378,8 +386,8 @@ _BTCSIGNNEXTRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=425,
-  serialized_end=585,
+  serialized_start=445,
+  serialized_end=605,
 )
 
 
@@ -437,8 +445,8 @@ _BTCSIGNINPUTREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=587,
-  serialized_end=708,
+  serialized_start=607,
+  serialized_end=728,
 )
 
 
@@ -496,8 +504,8 @@ _BTCSIGNOUTPUTREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=710,
-  serialized_end=822,
+  serialized_start=730,
+  serialized_end=842,
 )
 
 _BTCPUBREQUEST.fields_by_name['script_type'].enum_type = _BTCSCRIPTTYPE

--- a/py/bitbox02/communication/generated/btc_pb2.pyi
+++ b/py/bitbox02/communication/generated/btc_pb2.pyi
@@ -108,11 +108,15 @@ class BTCPubRequest(google___protobuf___message___Message):
         YPUB = typing___cast(BTCPubRequest.OutputType, 2)
         ZPUB = typing___cast(BTCPubRequest.OutputType, 3)
         ADDRESS = typing___cast(BTCPubRequest.OutputType, 4)
+        VPUB = typing___cast(BTCPubRequest.OutputType, 5)
+        UPUB = typing___cast(BTCPubRequest.OutputType, 6)
     TPUB = typing___cast(BTCPubRequest.OutputType, 0)
     XPUB = typing___cast(BTCPubRequest.OutputType, 1)
     YPUB = typing___cast(BTCPubRequest.OutputType, 2)
     ZPUB = typing___cast(BTCPubRequest.OutputType, 3)
     ADDRESS = typing___cast(BTCPubRequest.OutputType, 4)
+    VPUB = typing___cast(BTCPubRequest.OutputType, 5)
+    UPUB = typing___cast(BTCPubRequest.OutputType, 6)
 
     keypath = ... # type: google___protobuf___internal___containers___RepeatedScalarFieldContainer[int]
     script_type = ... # type: BTCScriptType

--- a/src/apps/btc/btc.c
+++ b/src/apps/btc/btc.c
@@ -25,6 +25,8 @@ static const uint8_t _xpub_version[4] = {0x04, 0x88, 0xb2, 0x1e};
 static const uint8_t _ypub_version[4] = {0x04, 0x9d, 0x7c, 0xb2};
 static const uint8_t _zpub_version[4] = {0x04, 0xb2, 0x47, 0x46};
 static const uint8_t _tpub_version[4] = {0x04, 0x35, 0x87, 0xcf};
+static const uint8_t _vpub_version[4] = {0x04, 0x5f, 0x1c, 0xf6};
+static const uint8_t _upub_version[4] = {0x04, 0x4a, 0x52, 0x62};
 
 bool app_btc_address(
     BTCCoin coin,
@@ -50,6 +52,10 @@ bool app_btc_address(
     switch (output_type) {
     case BTCPubRequest_OutputType_TPUB:
         return btc_common_encode_xpub(&derived_xpub, _tpub_version, out, out_len);
+    case BTCPubRequest_OutputType_VPUB:
+        return btc_common_encode_xpub(&derived_xpub, _vpub_version, out, out_len);
+    case BTCPubRequest_OutputType_UPUB:
+        return btc_common_encode_xpub(&derived_xpub, _upub_version, out, out_len);
     case BTCPubRequest_OutputType_XPUB:
         return btc_common_encode_xpub(&derived_xpub, _xpub_version, out, out_len);
     case BTCPubRequest_OutputType_YPUB:

--- a/src/apps/btc/btc_common.c
+++ b/src/apps/btc/btc_common.c
@@ -63,6 +63,8 @@ bool btc_common_is_valid_keypath(
 {
     switch (output_type) {
     case BTCPubRequest_OutputType_TPUB:
+    case BTCPubRequest_OutputType_VPUB:
+    case BTCPubRequest_OutputType_UPUB:
     case BTCPubRequest_OutputType_XPUB:
     case BTCPubRequest_OutputType_YPUB:
     case BTCPubRequest_OutputType_ZPUB:

--- a/src/commander/commander_btc.c
+++ b/src/commander/commander_btc.c
@@ -64,6 +64,8 @@ commander_error_t commander_btc_pub(const BTCPubRequest* request, PubResponse* r
         char title[100] = {0};
         switch (request->output_type) {
         case BTCPubRequest_OutputType_TPUB:
+        case BTCPubRequest_OutputType_VPUB:
+        case BTCPubRequest_OutputType_UPUB:
         case BTCPubRequest_OutputType_XPUB:
         case BTCPubRequest_OutputType_YPUB:
         case BTCPubRequest_OutputType_ZPUB:

--- a/test/unit-test/test_app_btc.c
+++ b/test/unit-test/test_app_btc.c
@@ -109,6 +109,19 @@ static testcase_t _tests[] = {
     },
     {
         .coin = BTCCoin_BTC,
+        .type = BTCPubRequest_OutputType_VPUB,
+        .out = "vpub5SLqN2bLY4WeZeEAtJZU1iVTewpdyE7vsZHiZaJuSa47cTQYsoEZDoZEpskmHCynVyMMukSnz3X3PVg"
+               "J5G1bo6YYoiNdwVeRzaNXeC1Tqgo",
+    },
+    {
+        .coin = BTCCoin_BTC,
+        .type = BTCPubRequest_OutputType_UPUB,
+        .out = "upub57Wa4MvRPNyAiM343wmqodPxUygC2c8RxSmVnBR24ZgEZMbKd94zbju6ofoBHJKs6LEZAGrEXPAVWD4"
+               "jMZbazrrwwNgDMapwirJtFbjQ8Nj",
+    },
+
+    {
+        .coin = BTCCoin_BTC,
         .type = BTCPubRequest_OutputType_XPUB,
         .out = "xpub661MyMwAqRbcGEcQZ28iRtgTzt7XrU6vhnLA8N6gCaosif31P7ZgTvsWsHfwH2HdKFayQhduuNE9A4u"
                "RWeqdPZukYPmV7KHQY2VpRNV7PiJ",
@@ -255,6 +268,8 @@ static void _test_app_btc_address(void** state)
             if (keypath_valid && get_xpub_success) {
                 switch (test_case->type) {
                 case BTCPubRequest_OutputType_TPUB:
+                case BTCPubRequest_OutputType_VPUB:
+                case BTCPubRequest_OutputType_UPUB:
                 case BTCPubRequest_OutputType_XPUB:
                 case BTCPubRequest_OutputType_YPUB:
                 case BTCPubRequest_OutputType_ZPUB:

--- a/test/unit-test/test_app_btc_common.c
+++ b/test/unit-test/test_app_btc_common.c
@@ -91,6 +91,8 @@ static void _test_btc_common_is_valid_keypath_xpubs(void** state)
     };
     const BTCOutputType output_types[] = {
         BTCPubRequest_OutputType_TPUB,
+        BTCPubRequest_OutputType_VPUB,
+        BTCPubRequest_OutputType_UPUB,
         BTCPubRequest_OutputType_XPUB,
         BTCPubRequest_OutputType_YPUB,
         BTCPubRequest_OutputType_ZPUB,


### PR DESCRIPTION
BIP49: Testnet uses 0x044a5262 "upub" and 0x044a4e28 "uprv."
BIP84: Testnet uses 0x045f1cf6 "vpub" and 0x045f18bc "vprv."
Update the generated python protobuf code.
Add extra fields to the BTCPubRequest for each of them.