### PR TITLE
docker_exec.sh: Fail the docker subprocess returns nonzero.

### DIFF
--- a/scripts/docker_exec.sh
+++ b/scripts/docker_exec.sh
@@ -32,8 +32,18 @@ function docker_exec {
     docker exec --user=dockeruser --workdir="$DIR/.." -i $IMAGE bash -c "echo \"\$\$\" > $PIDFILE; eval $*" &
     PID=$!
     wait $PID
+    RESULT=$?
+    if [ ! $RESULT -ne 0 ]
+    then
+        exit $RESULT
+    fi
     trap - TERM INT
     wait $PID
+    RESULT=$?
+    if [ $RESULT -ne 0 ]
+    then
+        exit $RESULT
+    fi
 }
 
 docker_exec $CONTAINER_NAME "$@"


### PR DESCRIPTION
Running docker_exec.sh <command> will always exit 0, even if the invoked command has failed. This prevents using it as e.g. a git hook to verify commits.