### PR TITLE
firmware: BTC sign, supported locktime and sequence bytes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,6 +65,7 @@ set(DBB-FIRMWARE-SOURCES
   ${CMAKE_SOURCE_DIR}/src/apps/btc/btc_params.c
   ${CMAKE_SOURCE_DIR}/src/apps/btc/btc_sign.c
   ${CMAKE_SOURCE_DIR}/src/apps/btc/btc_bip143.c
+  ${CMAKE_SOURCE_DIR}/src/apps/btc/confirm_locktime_rbf.c
   ${CMAKE_SOURCE_DIR}/src/queue.c
   ${CMAKE_SOURCE_DIR}/src/usb/usb_processing.c
 )

--- a/src/apps/btc/btc_params.c
+++ b/src/apps/btc/btc_params.c
@@ -21,6 +21,7 @@ static const app_btc_coin_params_t _params_btc = {
     .base58_version_p2sh = 0x05, // starts with 3
     .bech32_hrp = "bc",
     .unit = "BTC",
+    .rbf_support = true,
 };
 
 static const app_btc_coin_params_t _params_tbtc = {
@@ -29,6 +30,7 @@ static const app_btc_coin_params_t _params_tbtc = {
     .base58_version_p2sh = 0xc4, // starts with 2
     .bech32_hrp = "tb",
     .unit = "TBTC",
+    .rbf_support = true,
 };
 
 static const app_btc_coin_params_t _params_ltc = {
@@ -37,6 +39,7 @@ static const app_btc_coin_params_t _params_ltc = {
     .base58_version_p2sh = 0x32, // starts with M
     .bech32_hrp = "ltc",
     .unit = "LTC",
+    .rbf_support = false,
 };
 
 static const app_btc_coin_params_t _params_tltc = {
@@ -45,6 +48,7 @@ static const app_btc_coin_params_t _params_tltc = {
     .base58_version_p2sh = 0xc4, // starts with 2
     .bech32_hrp = "tltc",
     .unit = "TLTC",
+    .rbf_support = false,
 };
 
 const app_btc_coin_params_t* app_btc_params_get(BTCCoin coin)

--- a/src/apps/btc/btc_params.h
+++ b/src/apps/btc/btc_params.h
@@ -24,6 +24,7 @@ typedef struct {
     const char* bech32_hrp;
     // unit to use in formatted amounts, e.g. "BTC".
     const char* unit;
+    bool rbf_support;
 } app_btc_coin_params_t;
 
 /**

--- a/src/apps/btc/confirm_locktime_rbf.c
+++ b/src/apps/btc/confirm_locktime_rbf.c
@@ -1,0 +1,50 @@
+// Copyright 2019 Shift Cryptosecurity AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "confirm_locktime_rbf.h"
+
+#include <workflow/blocking.h>
+#include <workflow/status.h>
+
+#include <ui/components/confirm_transaction.h>
+#include <ui/screen_stack.h>
+#include <util.h>
+#include <workflow/confirm.h>
+
+bool apps_btc_confirm_locktime_rbf(uint32_t locktime, enum apps_btc_rbf_flag rbf)
+{
+    char formatted_locktime_rbf[100] = {0};
+    const char* locktime_text = "Locktime on block:";
+    const char* rbf_text;
+    if (rbf == CONFIRM_LOCKTIME_RBF_ON) {
+        rbf_text = "Transaction is RBF";
+    } else if (rbf == CONFIRM_LOCKTIME_RBF_OFF) {
+        rbf_text = "Transaction is not RBF";
+    } else {
+        rbf_text = "";
+    }
+    snprintf(
+        formatted_locktime_rbf,
+        sizeof formatted_locktime_rbf,
+        "%s\n%lu\n%s",
+        locktime_text,
+        (unsigned long)locktime,
+        rbf_text);
+
+    bool result = workflow_confirm("", formatted_locktime_rbf, NULL, false, false);
+    if (!result) {
+        workflow_status_create("Transaction\ncanceled", false);
+    }
+    return result;
+}

--- a/src/apps/btc/confirm_locktime_rbf.h
+++ b/src/apps/btc/confirm_locktime_rbf.h
@@ -1,0 +1,38 @@
+// Copyright 2019 Shift Cryptosecurity AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _APPS_BTC_CONFIRM_LOCKTIME_RBF_H_
+#define _APPS_BTC_CONFIRM_LOCKTIME_RBF_H_
+
+#include <util.h>
+
+enum apps_btc_rbf_flag {
+    CONFIRM_LOCKTIME_RBF_OFF,
+    CONFIRM_LOCKTIME_RBF_ON,
+    CONFIRM_LOCKTIME_RBF_DISABLED
+};
+
+/**
+ * Shows a confirmation dialog to the user showing the locktime of the transaction
+ * to be signed, if the locktime is > 0 and whether it is RBF. This call blocks until the user
+ * confirms.
+ * The function expects either locktime > 0 or CONFIRM_LOCKTIME_RBF_ON, providing neither will
+ * result in unwanted behavior.
+ * @param[in] locktime to be confirmed.
+ * @param[in] rbf flag to display different text based on its setting.
+ * @return true if the user confirms, false if the user rejects.
+ */
+bool apps_btc_confirm_locktime_rbf(uint32_t locktime, enum apps_btc_rbf_flag rbf);
+
+#endif

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -164,6 +164,8 @@ set(TEST_LIST
    "-Wl,--wrap=keystore_get_xpub,--wrap=btc_common_is_valid_keypath,--wrap=btc_common_encode_xpub,--wrap=btc_common_outputhash_from_pubkeyhash"
    app_btc_common
    ""
+   app_btc_confirm_locktime_rbf
+   "-Wl,--wrap=workflow_confirm,--wrap=workflow_status_create"
    sd
    ""
    ui_components
@@ -173,7 +175,7 @@ set(TEST_LIST
    ui_component_gestures
    ""
    btc_sign
-   "-Wl,--wrap=workflow_verify_recipient,--wrap=workflow_verify_total,--wrap=btc_common_format_amount,--wrap=btc_common_is_valid_keypath"
+   "-Wl,--wrap=workflow_verify_recipient,--wrap=workflow_verify_total,--wrap=apps_btc_confirm_locktime_rbf,--wrap=btc_common_format_amount,--wrap=btc_common_is_valid_keypath"
    memory
    "-Wl,--wrap=memory_read_chunk_mock,--wrap=memory_write_chunk_mock,--wrap=bb_noise_generate_static_private_key,--wrap=memory_read_shared_bootdata_mock,--wrap=memory_write_to_address_mock"
    salt

--- a/test/unit-test/test_app_btc.c
+++ b/test/unit-test/test_app_btc.c
@@ -214,7 +214,6 @@ static testcase_t _tests[] = {
         .script_type = BTCScriptType_SCRIPT_P2WPKH,
         .out = "tltc1q0stgw6ehkx66r7g22056u0p95f9z4qydg2lue8",
     },
-
 };
 
 static void _test_app_btc_address(void** state)

--- a/test/unit-test/test_app_btc_confirm_locktime_rbf.c
+++ b/test/unit-test/test_app_btc_confirm_locktime_rbf.c
@@ -1,0 +1,102 @@
+// Copyright 2019 Shift Cryptosecurity AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <cmocka.h>
+
+#include <apps/btc/confirm_locktime_rbf.h>
+#include <ui/ugui/ugui.h>
+
+bool __wrap_workflow_confirm(
+    const char* title,
+    const char* body,
+    UG_FONT* font,
+    bool longtouch,
+    bool accept_only)
+{
+    assert_false(longtouch);
+    assert_false(accept_only);
+    check_expected(title);
+    check_expected(body);
+    return mock();
+}
+
+void __wrap_workflow_status_create(const char* msg, bool status_success)
+{
+    assert_false(status_success);
+    check_expected(msg);
+}
+
+static void _test_reject_locktime(void** state)
+{
+    expect_string(__wrap_workflow_confirm, title, "");
+    expect_string(__wrap_workflow_confirm, body, "Locktime on block:\n1\n");
+    will_return(__wrap_workflow_confirm, false);
+
+    expect_string(__wrap_workflow_status_create, msg, "Transaction\ncanceled");
+    assert_false(apps_btc_confirm_locktime_rbf(1, CONFIRM_LOCKTIME_RBF_DISABLED));
+}
+
+static void _test_0_locktime_and_rbf(void** state)
+{
+    expect_string(__wrap_workflow_confirm, title, "");
+    expect_string(__wrap_workflow_confirm, body, "Locktime on block:\n0\nTransaction is RBF");
+    will_return(__wrap_workflow_confirm, true);
+
+    assert_true(apps_btc_confirm_locktime_rbf(0, CONFIRM_LOCKTIME_RBF_ON));
+}
+
+static void _test_high_locktime_and_rbf(void** state)
+{
+    expect_string(__wrap_workflow_confirm, title, "");
+    expect_string(
+        __wrap_workflow_confirm, body, "Locktime on block:\n100000000\nTransaction is RBF");
+    will_return(__wrap_workflow_confirm, true);
+
+    assert_true(apps_btc_confirm_locktime_rbf(100000000, CONFIRM_LOCKTIME_RBF_ON));
+}
+
+static void _test_locktime_no_rbf(void** state)
+{
+    expect_string(__wrap_workflow_confirm, title, "");
+    expect_string(__wrap_workflow_confirm, body, "Locktime on block:\n10\nTransaction is not RBF");
+    will_return(__wrap_workflow_confirm, true);
+
+    assert_true(apps_btc_confirm_locktime_rbf(10, CONFIRM_LOCKTIME_RBF_OFF));
+}
+
+static void _test_no_locktime_no_rbf(void** state)
+{
+    // it is the function caller's job to make sure there is something to verify
+    // no values will just create an empty screen
+    expect_string(__wrap_workflow_confirm, title, "");
+    expect_string(__wrap_workflow_confirm, body, "Locktime on block:\n0\n");
+    will_return(__wrap_workflow_confirm, true);
+    assert_true(apps_btc_confirm_locktime_rbf(0, CONFIRM_LOCKTIME_RBF_DISABLED));
+}
+
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(_test_reject_locktime),
+        cmocka_unit_test(_test_no_locktime_no_rbf),
+        cmocka_unit_test(_test_0_locktime_and_rbf),
+        cmocka_unit_test(_test_high_locktime_and_rbf),
+        cmocka_unit_test(_test_locktime_no_rbf),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/test/unit-test/test_btc_sign.c
+++ b/test/unit-test/test_btc_sign.c
@@ -178,6 +178,8 @@ typedef struct {
     bool wrong_output_value;
     // when a user aborts on an output verification
     bool user_aborts_output;
+    // rbf disabled on Litecoin
+    bool litecoin_rbf_disabled;
     // check workflow when a locktime applies
     bool locktime_applies;
     // when a user aborts on a locktime verification
@@ -381,6 +383,15 @@ static void _sign(const _modification_t* mod)
     if (mod->overflow_output_ours) {
         outputs[4].value = ULLONG_MAX;
     }
+    if (mod->litecoin_rbf_disabled) {
+        init_req.coin = BTCCoin_LTC;
+        init_req.locktime = 1;
+        inputs[0].sequence = 0xffffffff - 2;
+        inputs[0].keypath[1] += 2;
+        inputs[1].keypath[1] += 2;
+        outputs[4].keypath[1] += 2;
+        outputs[5].keypath[1] += 2;
+    }
 
     BTCSignNextResponse next = {0};
     assert_int_equal(APP_BTC_SIGN_OK, app_btc_sign_init(&init_req, &next));
@@ -442,10 +453,19 @@ static void _sign(const _modification_t* mod)
         return;
     }
     expect_value(__wrap_btc_common_format_amount, satoshi, outputs[0].value);
-    expect_string(__wrap_btc_common_format_amount, unit, "BTC");
+    if (!mod->litecoin_rbf_disabled) {
+        expect_string(__wrap_btc_common_format_amount, unit, "BTC");
+    } else {
+        expect_string(__wrap_btc_common_format_amount, unit, "LTC");
+    }
     will_return(__wrap_btc_common_format_amount, "amount0");
-    expect_string(
-        __wrap_workflow_verify_recipient, recipient, "12ZEw5Hcv1hTb6YUQJ69y1V7uhcoDz92PH");
+    if (!mod->litecoin_rbf_disabled) {
+        expect_string(
+            __wrap_workflow_verify_recipient, recipient, "12ZEw5Hcv1hTb6YUQJ69y1V7uhcoDz92PH");
+    } else {
+        expect_string(
+            __wrap_workflow_verify_recipient, recipient, "LLnCCHbSzfwWquEdaS5TF2Yt7uz5Qb1SZ1");
+    }
     expect_string(__wrap_workflow_verify_recipient, amount, "amount0");
     will_return(__wrap_workflow_verify_recipient, true);
     assert_int_equal(APP_BTC_SIGN_OK, app_btc_sign_output(&outputs[0], &next));
@@ -459,10 +479,19 @@ static void _sign(const _modification_t* mod)
         return;
     }
     expect_value(__wrap_btc_common_format_amount, satoshi, outputs[1].value);
-    expect_string(__wrap_btc_common_format_amount, unit, "BTC");
+    if (!mod->litecoin_rbf_disabled) {
+        expect_string(__wrap_btc_common_format_amount, unit, "BTC");
+    } else {
+        expect_string(__wrap_btc_common_format_amount, unit, "LTC");
+    }
     will_return(__wrap_btc_common_format_amount, "amount1");
-    expect_string(
-        __wrap_workflow_verify_recipient, recipient, "34oVnh4gNviJGMnNvgquMeLAxvXJuaRVMZ");
+    if (!mod->litecoin_rbf_disabled) {
+        expect_string(
+            __wrap_workflow_verify_recipient, recipient, "34oVnh4gNviJGMnNvgquMeLAxvXJuaRVMZ");
+    } else {
+        expect_string(
+            __wrap_workflow_verify_recipient, recipient, "MB1e6aUeL3Zj4s4H2ZqFBHaaHd7kvvzTco");
+    }
     expect_string(__wrap_workflow_verify_recipient, amount, "amount1");
     will_return(__wrap_workflow_verify_recipient, !mod->user_aborts_output);
     if (mod->user_aborts_output) {
@@ -478,10 +507,23 @@ static void _sign(const _modification_t* mod)
 
     // Third output
     expect_value(__wrap_btc_common_format_amount, satoshi, outputs[2].value);
-    expect_string(__wrap_btc_common_format_amount, unit, "BTC");
+    if (!mod->litecoin_rbf_disabled) {
+        expect_string(__wrap_btc_common_format_amount, unit, "BTC");
+    } else {
+        expect_string(__wrap_btc_common_format_amount, unit, "LTC");
+    }
     will_return(__wrap_btc_common_format_amount, "amount2");
-    expect_string(
-        __wrap_workflow_verify_recipient, recipient, "bc1qxvenxvenxvenxvenxvenxvenxvenxven2ymjt8");
+    if (!mod->litecoin_rbf_disabled) {
+        expect_string(
+            __wrap_workflow_verify_recipient,
+            recipient,
+            "bc1qxvenxvenxvenxvenxvenxvenxvenxven2ymjt8");
+    } else {
+        expect_string(
+            __wrap_workflow_verify_recipient,
+            recipient,
+            "ltc1qxvenxvenxvenxvenxvenxvenxvenxvenwcpknh");
+    }
     expect_string(__wrap_workflow_verify_recipient, amount, "amount2");
     will_return(__wrap_workflow_verify_recipient, true);
     assert_int_equal(APP_BTC_SIGN_OK, app_btc_sign_output(&outputs[2], &next));
@@ -491,12 +533,23 @@ static void _sign(const _modification_t* mod)
 
     // Fourth output
     expect_value(__wrap_btc_common_format_amount, satoshi, outputs[3].value);
-    expect_string(__wrap_btc_common_format_amount, unit, "BTC");
+    if (!mod->litecoin_rbf_disabled) {
+        expect_string(__wrap_btc_common_format_amount, unit, "BTC");
+    } else {
+        expect_string(__wrap_btc_common_format_amount, unit, "LTC");
+    }
     will_return(__wrap_btc_common_format_amount, "amount3");
-    expect_string(
-        __wrap_workflow_verify_recipient,
-        recipient,
-        "bc1qg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zqd8sxw4");
+    if (!mod->litecoin_rbf_disabled) {
+        expect_string(
+            __wrap_workflow_verify_recipient,
+            recipient,
+            "bc1qg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zqd8sxw4");
+    } else {
+        expect_string(
+            __wrap_workflow_verify_recipient,
+            recipient,
+            "ltc1qg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zqwr7k5s");
+    }
     expect_string(__wrap_workflow_verify_recipient, amount, "amount3");
     will_return(__wrap_workflow_verify_recipient, true);
     assert_int_equal(APP_BTC_SIGN_OK, app_btc_sign_output(&outputs[3], &next));
@@ -538,6 +591,12 @@ static void _sign(const _modification_t* mod)
         return;
     }
 
+    if (mod->litecoin_rbf_disabled) {
+        expect_value(__wrap_apps_btc_confirm_locktime_rbf, locktime, 1);
+        expect_value(__wrap_apps_btc_confirm_locktime_rbf, rbf, CONFIRM_LOCKTIME_RBF_DISABLED);
+        will_return(__wrap_apps_btc_confirm_locktime_rbf, mod->litecoin_rbf_disabled);
+    }
+
     if (mod->locktime_applies) {
         expect_value(__wrap_apps_btc_confirm_locktime_rbf, locktime, 1);
         expect_value(__wrap_apps_btc_confirm_locktime_rbf, rbf, CONFIRM_LOCKTIME_RBF_OFF);
@@ -556,10 +615,18 @@ static void _sign(const _modification_t* mod)
     }
 
     expect_value(__wrap_btc_common_format_amount, satoshi, total);
-    expect_string(__wrap_btc_common_format_amount, unit, "BTC");
+    if (!mod->litecoin_rbf_disabled) {
+        expect_string(__wrap_btc_common_format_amount, unit, "BTC");
+    } else {
+        expect_string(__wrap_btc_common_format_amount, unit, "LTC");
+    }
     will_return(__wrap_btc_common_format_amount, "amount total");
     expect_value(__wrap_btc_common_format_amount, satoshi, fee);
-    expect_string(__wrap_btc_common_format_amount, unit, "BTC");
+    if (!mod->litecoin_rbf_disabled) {
+        expect_string(__wrap_btc_common_format_amount, unit, "BTC");
+    } else {
+        expect_string(__wrap_btc_common_format_amount, unit, "LTC");
+    }
     will_return(__wrap_btc_common_format_amount, "amount fee");
     expect_string(__wrap_workflow_verify_total, total, "amount total");
     expect_string(__wrap_workflow_verify_total, fee, "amount fee");
@@ -714,6 +781,12 @@ static void _test_user_aborts_output(void** state)
     invalid.user_aborts_output = true;
     _sign(&invalid);
 }
+static void _test_litecoin_rbf_disabled(void** state)
+{
+    _modification_t invalid = _valid;
+    invalid.litecoin_rbf_disabled = true;
+    _sign(&invalid);
+}
 static void _test_locktime_applies(void** state)
 {
     _modification_t invalid = _valid;
@@ -777,6 +850,7 @@ int main(void)
         cmocka_unit_test(_test_wrong_input_value),
         cmocka_unit_test(_test_wrong_output_value),
         cmocka_unit_test(_test_user_aborts_output),
+        cmocka_unit_test(_test_litecoin_rbf_disabled),
         cmocka_unit_test(_test_locktime_applies),
         cmocka_unit_test(_test_user_aborts_locktime_rbf),
         cmocka_unit_test(_test_user_aborts_total),


### PR DESCRIPTION
The following pairs of locktime and sequence bytes are now supported:

locktime = 0 , nsequence = 0xffffffff
-> as before

locktime > 0, nsequence = 0xffffffff - 1
-> nsequence < 0xffffffff indicates a locktime on a transaction.

locktime > 0, nsequence = 0xffffffff - 2
-> nsequence == 0xffffffff - 2 indicates that the transaction is RBF. Since
we have the above rule on the locktime, the RBF rule only makes sense if the locktime is not zero again.

All other combinations of nsequence and locktime bytes are still not allowed. Other combinations should eventually be allowed as well to support BIP68 (nseuqnece byte definitions), BIP65
(OP_CHECKLOCKTIMEVERIFY) and BIP112 (OP_CHECKSEQUENCEVERIFY).

The relaxed constraints were chosen to accommodate for electrum's usage of RBF. The relation between locktime, nsequence and RBF is explained in this bitcoinwiki article: https://en.bitcoinwiki.org/wiki/NSequence .

I initially wrote this code for myself, but since it seems to work reasonably well, I thought I might as well post a pull request. My C is horrible, so fill your pockets with grains of salt before reviewing. At some point I am converting a `uint32` to a `const char *` with `snprintf(formatted_locktime, sizeof formatted_locktime, "\n\n\n%lu", (unsigned long)_locktime);`, which feels especially wrong.

EDIT: There is still one case that is supported with extra verification, which is when the sequence bytes are 0xffffffff and the locktime is > 0. I am not sure if this case should be rejected or not.