### PR TITLE
firmware/btc: Support for transaction byte version 2

### DIFF
--- a/py/bitbox02/bitbox02/bitbox02.py
+++ b/py/bitbox02/bitbox02/bitbox02.py
@@ -268,7 +268,7 @@ class BitBox02(BitBoxCommonAPI):
         # pylint: disable=too-many-locals,no-member
 
         # Reserved for future use.
-        assert version == 1 and locktime == 0
+        assert version in (1, 2)
 
         sigs: List[Tuple[int, bytes]] = []
 

--- a/src/apps/btc/btc_sign.c
+++ b/src/apps/btc/btc_sign.c
@@ -114,9 +114,9 @@ app_btc_sign_error_t app_btc_sign_init(
     if (_state != STATE_INIT) {
         return _error(APP_BTC_SIGN_ERR_STATE);
     }
-    // currently only support version 1 tx.
+    // currently only support version 1 or version 2 tx.
     // version 2: https://github.com/bitcoin/bips/blob/master/bip-0068.mediawiki
-    if (request->version != 1) {
+    if (request->version != 1 && request->version != 2) {
         return _error(APP_BTC_SIGN_ERR_INVALID_INPUT);
     }
     if (request->num_inputs < 1 || request->num_outputs < 1) {

--- a/test/unit-test/test_btc_sign.c
+++ b/test/unit-test/test_btc_sign.c
@@ -100,7 +100,7 @@ static void _test_btc_sign_init(void** state)
         tst_app_btc_reset();
         BTCSignInitRequest invalid = init_req_valid;
         for (invalid.version = 0; invalid.version < 10; invalid.version++) {
-            if (invalid.version == 1) {
+            if (invalid.version == 1 || invalid.version == 2) {
                 continue;
             }
             assert_int_equal(APP_BTC_SIGN_ERR_INVALID_INPUT, app_btc_sign_init(&invalid, &next));


### PR DESCRIPTION
Transaction byte version 2 was introduced with the CHECKSEQUENCEVERIFY soft fork and has been in usage with many clients (including Bitcoin Core as a default) since a long time.

For the sake of transaction uniformity we should change this in the desktop app as well. Electrum for example also uses the version 2 transaction byte since nearly a year now: https://github.com/spesmilo/electrum/pull/5039 and bitcoin since 2014 https://github.com/bitcoin/bitcoin/pull/7562