### PR TITLE
CMakeLists: bump versions to 5.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,9 +85,9 @@ endif()
 #
 # Versions MUST contain three parts and start with lowercase 'v'.
 # Example 'v1.0.0'. They MUST not contain a pre-release label such as '-beta'.
-set(FIRMWARE_VERSION "v4.4.0")
-set(FIRMWARE_BTC_ONLY_VERSION "v4.4.0")
-set(FIRMWARE_BITBOXBASE_VERSION "v4.4.0")
+set(FIRMWARE_VERSION "v5.0.0")
+set(FIRMWARE_BTC_ONLY_VERSION "v5.0.0")
+set(FIRMWARE_BITBOXBASE_VERSION "v5.0.0")
 set(BOOTLOADER_VERSION "v1.0.2")
 
 find_package(PythonInterp 3.6 REQUIRED)


### PR DESCRIPTION
The reset command now reboots before returning a response, which is a
breaking change.