### PR TITLE
ui/components/confirm_gesture: Fix clamp getting stuck

### DIFF
--- a/src/ui/components/confirm_gesture.c
+++ b/src/ui/components/confirm_gesture.c
@@ -97,8 +97,17 @@ static void _render(component_t* component)
  */
 static void _on_event(const event_t* event, component_t* component)
 {
+    // Avoid type casting to unknown events
+    if (event->id != EVENT_TOP_SLIDE_RELEASED && event->id != EVENT_BOTTOM_SLIDE_RELEASED &&
+        event->id != EVENT_TOP_CONTINUOUS_TAP && event->id != EVENT_BOTTOM_CONTINUOUS_TAP &&
+        event->id != EVENT_TOP_SHORT_TAP && event->id != EVENT_BOTTOM_SHORT_TAP &&
+        event->id != EVENT_TOP_LONG_TAP && event->id != EVENT_BOTTOM_LONG_TAP &&
+        event->id != EVENT_TOP_SLIDE && event->id != EVENT_BOTTOM_SLIDE) {
+        return;
+    }
     confirm_data_t* data = (confirm_data_t*)component->data;
     gestures_slider_data_t* slider_data = (gestures_slider_data_t*)event->data;
+
     switch (event->id) {
     case EVENT_TOP_SLIDE_RELEASED:
         data->active_top = false;
@@ -110,10 +119,7 @@ static void _on_event(const event_t* event, component_t* component)
         }
         break;
     case EVENT_TOP_SHORT_TAP:
-        if (slider_data->position > SLIDER_POSITION_TWO_THIRD &&
-            slider_data->position <= MAX_SLIDER_POS) {
-            data->active_top = false;
-        }
+        data->active_top = false;
         break;
     case EVENT_BOTTOM_SLIDE_RELEASED:
         data->active_bottom = false;
@@ -125,10 +131,7 @@ static void _on_event(const event_t* event, component_t* component)
         }
         break;
     case EVENT_BOTTOM_SHORT_TAP:
-        if (slider_data->position > SLIDER_POSITION_TWO_THIRD &&
-            slider_data->position <= MAX_SLIDER_POS) {
-            data->active_bottom = false;
-        }
+        data->active_bottom = false;
         break;
     default:
         break;


### PR DESCRIPTION
During password entry the clamp gesture would get stuck if you started
it near the limit of where it can be started (approximately two thirds
to the right) and then released it on the wrong side (a little bit less
than two thirds).