### PR TITLE
keystore: erase seed from memory before creating a new one

### DIFF
--- a/src/keystore.c
+++ b/src/keystore.c
@@ -223,6 +223,7 @@ bool keystore_encrypt_and_store_seed(
     if (memory_is_initialized()) {
         return false;
     }
+    keystore_lock();
     if (!_validate_seed_length(seed_length)) {
         return false;
     }


### PR DESCRIPTION
The process of creating a new wallet is:

create seed (status: seeded) -> unlock -> create backup (status:
initialized).

After unlock, before create backup, the device could be unplugged, in
which case the process starts again.

There is an issue though if the process is started again without
reconnecting: the previous seed is still in memory, but a new seed is
created, so unlock runs into the "Seed has suddenly changed" abort.

The abort is a sanity check, but in this case, nothing bad would have
happened otherwise.