### PR TITLE
apps/btc/sign: keypath_account added to BTCSigninit

### DIFF
--- a/messages/btc.options
+++ b/messages/btc.options
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 BTCPubRequest.keypath max_count:10
+BTCSignInitRequest.keypath_account max_count:10
 BTCSignInputRequest.prevOutHash fixed_length:true max_size:32
 BTCSignInputRequest.keypath max_count:10
 BTCSignOutputRequest.hash max_size:32

--- a/messages/btc.proto
+++ b/messages/btc.proto
@@ -59,7 +59,7 @@ message BTCPubRequest {
 message BTCSignInitRequest {
   BTCCoin coin = 1;
   BTCScriptConfig script_config = 2; // script config for inputs and changes
-  uint32 bip44_account = 3;
+  repeated uint32 keypath_account = 3; // prefix to all input and change keypaths.
   uint32 version = 4; // must be 1 or 2
   uint32 num_inputs = 5;
   uint32 num_outputs = 6;

--- a/py/bitbox02/bitbox02/bitbox02.py
+++ b/py/bitbox02/bitbox02/bitbox02.py
@@ -256,7 +256,7 @@ class BitBox02(BitBoxCommonAPI):
         self,
         coin: btc.BTCCoin,
         script_config: btc.BTCScriptConfig,
-        bip44_account: int,
+        keypath_account: List[int],
         inputs: List[BTCInputType],
         outputs: List[BTCOutputType],
         version: int = 1,
@@ -294,7 +294,7 @@ class BitBox02(BitBoxCommonAPI):
             btc.BTCSignInitRequest(
                 coin=coin,
                 script_config=script_config,
-                bip44_account=bip44_account,
+                keypath_account=keypath_account,
                 version=version,
                 num_inputs=len(inputs),
                 num_outputs=len(outputs),

--- a/py/bitbox02/communication/generated/btc_pb2.py
+++ b/py/bitbox02/communication/generated/btc_pb2.py
@@ -20,7 +20,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='btc.proto',
   package='',
   syntax='proto3',
-  serialized_pb=_b('\n\tbtc.proto\"z\n\x0f\x42TCScriptConfig\x12\x32\n\x0bsimple_type\x18\x01 \x01(\x0e\x32\x1b.BTCScriptConfig.SimpleTypeH\x00\")\n\nSimpleType\x12\x0f\n\x0bP2WPKH_P2SH\x10\x00\x12\n\n\x06P2WPKH\x10\x01\x42\x08\n\x06\x63onfig\"\xf4\x01\n\rBTCPubRequest\x12\x16\n\x04\x63oin\x18\x01 \x01(\x0e\x32\x08.BTCCoin\x12\x0f\n\x07keypath\x18\x02 \x03(\r\x12,\n\txpub_type\x18\x03 \x01(\x0e\x32\x17.BTCPubRequest.XPubTypeH\x00\x12)\n\rscript_config\x18\x04 \x01(\x0b\x32\x10.BTCScriptConfigH\x00\x12\x0f\n\x07\x64isplay\x18\x05 \x01(\x08\"F\n\x08XPubType\x12\x08\n\x04TPUB\x10\x00\x12\x08\n\x04XPUB\x10\x01\x12\x08\n\x04YPUB\x10\x02\x12\x08\n\x04ZPUB\x10\x03\x12\x08\n\x04VPUB\x10\x04\x12\x08\n\x04UPUB\x10\x05\x42\x08\n\x06output\"\xb8\x01\n\x12\x42TCSignInitRequest\x12\x16\n\x04\x63oin\x18\x01 \x01(\x0e\x32\x08.BTCCoin\x12\'\n\rscript_config\x18\x02 \x01(\x0b\x32\x10.BTCScriptConfig\x12\x15\n\rbip44_account\x18\x03 \x01(\r\x12\x0f\n\x07version\x18\x04 \x01(\r\x12\x12\n\nnum_inputs\x18\x05 \x01(\r\x12\x13\n\x0bnum_outputs\x18\x06 \x01(\r\x12\x10\n\x08locktime\x18\x07 \x01(\r\"\xa0\x01\n\x13\x42TCSignNextResponse\x12\'\n\x04type\x18\x01 \x01(\x0e\x32\x19.BTCSignNextResponse.Type\x12\r\n\x05index\x18\x02 \x01(\r\x12\x15\n\rhas_signature\x18\x03 \x01(\x08\x12\x11\n\tsignature\x18\x04 \x01(\x0c\"\'\n\x04Type\x12\t\n\x05INPUT\x10\x00\x12\n\n\x06OUTPUT\x10\x01\x12\x08\n\x04\x44ONE\x10\x02\"y\n\x13\x42TCSignInputRequest\x12\x13\n\x0bprevOutHash\x18\x01 \x01(\x0c\x12\x14\n\x0cprevOutIndex\x18\x02 \x01(\r\x12\x14\n\x0cprevOutValue\x18\x03 \x01(\x04\x12\x10\n\x08sequence\x18\x04 \x01(\r\x12\x0f\n\x07keypath\x18\x06 \x03(\r\"p\n\x14\x42TCSignOutputRequest\x12\x0c\n\x04ours\x18\x01 \x01(\x08\x12\x1c\n\x04type\x18\x02 \x01(\x0e\x32\x0e.BTCOutputType\x12\r\n\x05value\x18\x03 \x01(\x04\x12\x0c\n\x04hash\x18\x04 \x01(\x0c\x12\x0f\n\x07keypath\x18\x05 \x03(\r*/\n\x07\x42TCCoin\x12\x07\n\x03\x42TC\x10\x00\x12\x08\n\x04TBTC\x10\x01\x12\x07\n\x03LTC\x10\x02\x12\x08\n\x04TLTC\x10\x03*H\n\rBTCOutputType\x12\x0b\n\x07UNKNOWN\x10\x00\x12\t\n\x05P2PKH\x10\x01\x12\x08\n\x04P2SH\x10\x02\x12\n\n\x06P2WPKH\x10\x03\x12\t\n\x05P2WSH\x10\x04\x62\x06proto3')
+  serialized_pb=_b('\n\tbtc.proto\"z\n\x0f\x42TCScriptConfig\x12\x32\n\x0bsimple_type\x18\x01 \x01(\x0e\x32\x1b.BTCScriptConfig.SimpleTypeH\x00\")\n\nSimpleType\x12\x0f\n\x0bP2WPKH_P2SH\x10\x00\x12\n\n\x06P2WPKH\x10\x01\x42\x08\n\x06\x63onfig\"\xf4\x01\n\rBTCPubRequest\x12\x16\n\x04\x63oin\x18\x01 \x01(\x0e\x32\x08.BTCCoin\x12\x0f\n\x07keypath\x18\x02 \x03(\r\x12,\n\txpub_type\x18\x03 \x01(\x0e\x32\x17.BTCPubRequest.XPubTypeH\x00\x12)\n\rscript_config\x18\x04 \x01(\x0b\x32\x10.BTCScriptConfigH\x00\x12\x0f\n\x07\x64isplay\x18\x05 \x01(\x08\"F\n\x08XPubType\x12\x08\n\x04TPUB\x10\x00\x12\x08\n\x04XPUB\x10\x01\x12\x08\n\x04YPUB\x10\x02\x12\x08\n\x04ZPUB\x10\x03\x12\x08\n\x04VPUB\x10\x04\x12\x08\n\x04UPUB\x10\x05\x42\x08\n\x06output\"\xba\x01\n\x12\x42TCSignInitRequest\x12\x16\n\x04\x63oin\x18\x01 \x01(\x0e\x32\x08.BTCCoin\x12\'\n\rscript_config\x18\x02 \x01(\x0b\x32\x10.BTCScriptConfig\x12\x17\n\x0fkeypath_account\x18\x03 \x03(\r\x12\x0f\n\x07version\x18\x04 \x01(\r\x12\x12\n\nnum_inputs\x18\x05 \x01(\r\x12\x13\n\x0bnum_outputs\x18\x06 \x01(\r\x12\x10\n\x08locktime\x18\x07 \x01(\r\"\xa0\x01\n\x13\x42TCSignNextResponse\x12\'\n\x04type\x18\x01 \x01(\x0e\x32\x19.BTCSignNextResponse.Type\x12\r\n\x05index\x18\x02 \x01(\r\x12\x15\n\rhas_signature\x18\x03 \x01(\x08\x12\x11\n\tsignature\x18\x04 \x01(\x0c\"\'\n\x04Type\x12\t\n\x05INPUT\x10\x00\x12\n\n\x06OUTPUT\x10\x01\x12\x08\n\x04\x44ONE\x10\x02\"y\n\x13\x42TCSignInputRequest\x12\x13\n\x0bprevOutHash\x18\x01 \x01(\x0c\x12\x14\n\x0cprevOutIndex\x18\x02 \x01(\r\x12\x14\n\x0cprevOutValue\x18\x03 \x01(\x04\x12\x10\n\x08sequence\x18\x04 \x01(\r\x12\x0f\n\x07keypath\x18\x06 \x03(\r\"p\n\x14\x42TCSignOutputRequest\x12\x0c\n\x04ours\x18\x01 \x01(\x08\x12\x1c\n\x04type\x18\x02 \x01(\x0e\x32\x0e.BTCOutputType\x12\r\n\x05value\x18\x03 \x01(\x04\x12\x0c\n\x04hash\x18\x04 \x01(\x0c\x12\x0f\n\x07keypath\x18\x05 \x03(\r*/\n\x07\x42TCCoin\x12\x07\n\x03\x42TC\x10\x00\x12\x08\n\x04TBTC\x10\x01\x12\x07\n\x03LTC\x10\x02\x12\x08\n\x04TLTC\x10\x03*H\n\rBTCOutputType\x12\x0b\n\x07UNKNOWN\x10\x00\x12\t\n\x05P2PKH\x10\x01\x12\x08\n\x04P2SH\x10\x02\x12\n\n\x06P2WPKH\x10\x03\x12\t\n\x05P2WSH\x10\x04\x62\x06proto3')
 )
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
@@ -49,8 +49,8 @@ _BTCCOIN = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=971,
-  serialized_end=1018,
+  serialized_start=973,
+  serialized_end=1020,
 )
 _sym_db.RegisterEnumDescriptor(_BTCCOIN)
 
@@ -84,8 +84,8 @@ _BTCOUTPUTTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=1020,
-  serialized_end=1092,
+  serialized_start=1022,
+  serialized_end=1094,
 )
 _sym_db.RegisterEnumDescriptor(_BTCOUTPUTTYPE)
 
@@ -182,8 +182,8 @@ _BTCSIGNNEXTRESPONSE_TYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=693,
-  serialized_end=732,
+  serialized_start=695,
+  serialized_end=734,
 )
 _sym_db.RegisterEnumDescriptor(_BTCSIGNNEXTRESPONSE_TYPE)
 
@@ -308,9 +308,9 @@ _BTCSIGNINITREQUEST = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='bip44_account', full_name='BTCSignInitRequest.bip44_account', index=2,
-      number=3, type=13, cpp_type=3, label=1,
-      has_default_value=False, default_value=0,
+      name='keypath_account', full_name='BTCSignInitRequest.keypath_account', index=2,
+      number=3, type=13, cpp_type=3, label=3,
+      has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
@@ -355,7 +355,7 @@ _BTCSIGNINITREQUEST = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=385,
-  serialized_end=569,
+  serialized_end=571,
 )
 
 
@@ -407,8 +407,8 @@ _BTCSIGNNEXTRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=572,
-  serialized_end=732,
+  serialized_start=574,
+  serialized_end=734,
 )
 
 
@@ -466,8 +466,8 @@ _BTCSIGNINPUTREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=734,
-  serialized_end=855,
+  serialized_start=736,
+  serialized_end=857,
 )
 
 
@@ -525,8 +525,8 @@ _BTCSIGNOUTPUTREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=857,
-  serialized_end=969,
+  serialized_start=859,
+  serialized_end=971,
 )
 
 _BTCSCRIPTCONFIG.fields_by_name['simple_type'].enum_type = _BTCSCRIPTCONFIG_SIMPLETYPE

--- a/py/bitbox02/communication/generated/btc_pb2.pyi
+++ b/py/bitbox02/communication/generated/btc_pb2.pyi
@@ -161,7 +161,7 @@ class BTCPubRequest(google___protobuf___message___Message):
 
 class BTCSignInitRequest(google___protobuf___message___Message):
     coin = ... # type: BTCCoin
-    bip44_account = ... # type: int
+    keypath_account = ... # type: google___protobuf___internal___containers___RepeatedScalarFieldContainer[int]
     version = ... # type: int
     num_inputs = ... # type: int
     num_outputs = ... # type: int
@@ -174,7 +174,7 @@ class BTCSignInitRequest(google___protobuf___message___Message):
         *,
         coin : typing___Optional[BTCCoin] = None,
         script_config : typing___Optional[BTCScriptConfig] = None,
-        bip44_account : typing___Optional[int] = None,
+        keypath_account : typing___Optional[typing___Iterable[int]] = None,
         version : typing___Optional[int] = None,
         num_inputs : typing___Optional[int] = None,
         num_outputs : typing___Optional[int] = None,
@@ -186,10 +186,10 @@ class BTCSignInitRequest(google___protobuf___message___Message):
     def CopyFrom(self, other_msg: google___protobuf___message___Message) -> None: ...
     if sys.version_info >= (3,):
         def HasField(self, field_name: typing_extensions___Literal[u"script_config"]) -> bool: ...
-        def ClearField(self, field_name: typing_extensions___Literal[u"bip44_account",u"coin",u"locktime",u"num_inputs",u"num_outputs",u"script_config",u"version"]) -> None: ...
+        def ClearField(self, field_name: typing_extensions___Literal[u"coin",u"keypath_account",u"locktime",u"num_inputs",u"num_outputs",u"script_config",u"version"]) -> None: ...
     else:
         def HasField(self, field_name: typing_extensions___Literal[u"script_config",b"script_config"]) -> bool: ...
-        def ClearField(self, field_name: typing_extensions___Literal[u"bip44_account",b"bip44_account",u"coin",b"coin",u"locktime",b"locktime",u"num_inputs",b"num_inputs",u"num_outputs",b"num_outputs",u"script_config",b"script_config",u"version",b"version"]) -> None: ...
+        def ClearField(self, field_name: typing_extensions___Literal[u"coin",b"coin",u"keypath_account",b"keypath_account",u"locktime",b"locktime",u"num_inputs",b"num_inputs",u"num_outputs",b"num_outputs",u"script_config",b"script_config",u"version",b"version"]) -> None: ...
 
 class BTCSignNextResponse(google___protobuf___message___Message):
     class Type(int):

--- a/py/send_message.py
+++ b/py/send_message.py
@@ -230,7 +230,7 @@ class SendMessage:
             bitbox02.btc.BTCScriptConfig(
                 simple_type=bitbox02.btc.BTCScriptConfig.P2WPKH  # pylint: disable=no-member
             ),
-            bip44_account=bip44_account,
+            keypath_account=[84 + HARDENED, 0 + HARDENED, bip44_account],
             inputs=inputs,
             outputs=outputs,
         )

--- a/test/unit-test/test_btc_sign.c
+++ b/test/unit-test/test_btc_sign.c
@@ -96,7 +96,13 @@ static void _test_btc_sign_init(void** state)
                         .simple_type = BTCScriptConfig_SimpleType_P2WPKH,
                     },
             },
-        .bip44_account = BIP32_INITIAL_HARDENED_CHILD,
+        .keypath_account_count = 3,
+        .keypath_account =
+            {
+                84 + BIP32_INITIAL_HARDENED_CHILD,
+                0 + BIP32_INITIAL_HARDENED_CHILD,
+                0 + BIP32_INITIAL_HARDENED_CHILD,
+            },
         .version = 1,
         .num_inputs = 1,
         .num_outputs = 1,
@@ -212,7 +218,13 @@ static void _sign(const _modification_t* mod)
                         .simple_type = BTCScriptConfig_SimpleType_P2WPKH,
                     },
             },
-        .bip44_account = BIP32_INITIAL_HARDENED_CHILD + 10,
+        .keypath_account_count = 3,
+        .keypath_account =
+            {
+                84 + BIP32_INITIAL_HARDENED_CHILD,
+                0 + BIP32_INITIAL_HARDENED_CHILD,
+                10 + BIP32_INITIAL_HARDENED_CHILD,
+            },
         .version = 1,
         .num_inputs = 2,
         .num_outputs = 6,
@@ -233,9 +245,9 @@ static void _sign(const _modification_t* mod)
             .keypath_count = 5,
             .keypath =
                 {
-                    84 + BIP32_INITIAL_HARDENED_CHILD,
-                    0 + BIP32_INITIAL_HARDENED_CHILD,
-                    init_req.bip44_account,
+                    init_req.keypath_account[0],
+                    init_req.keypath_account[1],
+                    init_req.keypath_account[2],
                     0,
                     5,
                 },
@@ -253,9 +265,9 @@ static void _sign(const _modification_t* mod)
             .keypath_count = 5,
             .keypath =
                 {
-                    84 + BIP32_INITIAL_HARDENED_CHILD,
-                    0 + BIP32_INITIAL_HARDENED_CHILD,
-                    init_req.bip44_account,
+                    init_req.keypath_account[0],
+                    init_req.keypath_account[1],
+                    init_req.keypath_account[2],
                     0,
                     7,
                 },
@@ -350,9 +362,9 @@ static void _sign(const _modification_t* mod)
             .keypath_count = 5,
             .keypath =
                 {
-                    84 + BIP32_INITIAL_HARDENED_CHILD,
-                    0 + BIP32_INITIAL_HARDENED_CHILD,
-                    init_req.bip44_account,
+                    init_req.keypath_account[0],
+                    init_req.keypath_account[1],
+                    init_req.keypath_account[2],
                     mod->bip44_change,
                     3,
                 },
@@ -364,9 +376,9 @@ static void _sign(const _modification_t* mod)
             .keypath_count = 5,
             .keypath =
                 {
-                    84 + BIP32_INITIAL_HARDENED_CHILD,
-                    0 + BIP32_INITIAL_HARDENED_CHILD,
-                    init_req.bip44_account,
+                    init_req.keypath_account[0],
+                    init_req.keypath_account[1],
+                    init_req.keypath_account[2],
                     mod->bip44_change,
                     30,
                 },
@@ -393,6 +405,7 @@ static void _sign(const _modification_t* mod)
     if (mod->litecoin_rbf_disabled) {
         init_req.coin = BTCCoin_LTC;
         init_req.locktime = 1;
+        init_req.keypath_account[1] = 2 + BIP32_INITIAL_HARDENED_CHILD;
         inputs[0].sequence = 0xffffffff - 2;
         inputs[0].keypath[1] = 2 + BIP32_INITIAL_HARDENED_CHILD;
         inputs[1].keypath[1] = 2 + BIP32_INITIAL_HARDENED_CHILD;


### PR DESCRIPTION
It is the derivation to the account, e.g. m/84'/0'/1'.

It is a prefix to all input and change keypaths.

This subsumes bip44_account (as it is part of it), and will make it
easier to verify the account to be used during signing upfront. Doing
it that way is easier to read/maintain, as we don't need to cache the
result so each input/change don't have to redo the validation.