### PR TITLE
apps/btc/common: enable xpub for m/48'/coin'/account'/2', Zpub, Vpub

### DIFF
--- a/messages/btc.proto
+++ b/messages/btc.proto
@@ -51,9 +51,11 @@ message BTCPubRequest {
     TPUB = 0;
     XPUB = 1;
     YPUB = 2;
-    ZPUB = 3;
-    VPUB = 4;
+    ZPUB = 3; // zpub
+    VPUB = 4; // vpub
     UPUB = 5;
+    CAPITAL_VPUB = 6; // Vpub
+    CAPITAL_ZPUB = 7; // Zpub
   }
 
   BTCCoin coin = 1;

--- a/py/bitbox02/communication/generated/btc_pb2.py
+++ b/py/bitbox02/communication/generated/btc_pb2.py
@@ -21,7 +21,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='btc.proto',
   package='',
   syntax='proto3',
-  serialized_pb=_b('\n\tbtc.proto\x1a\x0c\x63ommon.proto\"\xc7\x01\n\x0f\x42TCScriptConfig\x12\x32\n\x0bsimple_type\x18\x01 \x01(\x0e\x32\x1b.BTCScriptConfig.SimpleTypeH\x00\x1aK\n\x08Multisig\x12\x11\n\tthreshold\x18\x01 \x01(\r\x12\x14\n\x05xpubs\x18\x02 \x03(\x0b\x32\x05.XPub\x12\x16\n\x0eour_xpub_index\x18\x03 \x01(\r\")\n\nSimpleType\x12\x0f\n\x0bP2WPKH_P2SH\x10\x00\x12\n\n\x06P2WPKH\x10\x01\x42\x08\n\x06\x63onfig\"\xf4\x01\n\rBTCPubRequest\x12\x16\n\x04\x63oin\x18\x01 \x01(\x0e\x32\x08.BTCCoin\x12\x0f\n\x07keypath\x18\x02 \x03(\r\x12,\n\txpub_type\x18\x03 \x01(\x0e\x32\x17.BTCPubRequest.XPubTypeH\x00\x12)\n\rscript_config\x18\x04 \x01(\x0b\x32\x10.BTCScriptConfigH\x00\x12\x0f\n\x07\x64isplay\x18\x05 \x01(\x08\"F\n\x08XPubType\x12\x08\n\x04TPUB\x10\x00\x12\x08\n\x04XPUB\x10\x01\x12\x08\n\x04YPUB\x10\x02\x12\x08\n\x04ZPUB\x10\x03\x12\x08\n\x04VPUB\x10\x04\x12\x08\n\x04UPUB\x10\x05\x42\x08\n\x06output\"\xba\x01\n\x12\x42TCSignInitRequest\x12\x16\n\x04\x63oin\x18\x01 \x01(\x0e\x32\x08.BTCCoin\x12\'\n\rscript_config\x18\x02 \x01(\x0b\x32\x10.BTCScriptConfig\x12\x17\n\x0fkeypath_account\x18\x03 \x03(\r\x12\x0f\n\x07version\x18\x04 \x01(\r\x12\x12\n\nnum_inputs\x18\x05 \x01(\r\x12\x13\n\x0bnum_outputs\x18\x06 \x01(\r\x12\x10\n\x08locktime\x18\x07 \x01(\r\"\xa0\x01\n\x13\x42TCSignNextResponse\x12\'\n\x04type\x18\x01 \x01(\x0e\x32\x19.BTCSignNextResponse.Type\x12\r\n\x05index\x18\x02 \x01(\r\x12\x15\n\rhas_signature\x18\x03 \x01(\x08\x12\x11\n\tsignature\x18\x04 \x01(\x0c\"\'\n\x04Type\x12\t\n\x05INPUT\x10\x00\x12\n\n\x06OUTPUT\x10\x01\x12\x08\n\x04\x44ONE\x10\x02\"y\n\x13\x42TCSignInputRequest\x12\x13\n\x0bprevOutHash\x18\x01 \x01(\x0c\x12\x14\n\x0cprevOutIndex\x18\x02 \x01(\r\x12\x14\n\x0cprevOutValue\x18\x03 \x01(\x04\x12\x10\n\x08sequence\x18\x04 \x01(\r\x12\x0f\n\x07keypath\x18\x06 \x03(\r\"p\n\x14\x42TCSignOutputRequest\x12\x0c\n\x04ours\x18\x01 \x01(\x08\x12\x1c\n\x04type\x18\x02 \x01(\x0e\x32\x0e.BTCOutputType\x12\r\n\x05value\x18\x03 \x01(\x04\x12\x0c\n\x04hash\x18\x04 \x01(\x0c\x12\x0f\n\x07keypath\x18\x05 \x03(\r*/\n\x07\x42TCCoin\x12\x07\n\x03\x42TC\x10\x00\x12\x08\n\x04TBTC\x10\x01\x12\x07\n\x03LTC\x10\x02\x12\x08\n\x04TLTC\x10\x03*H\n\rBTCOutputType\x12\x0b\n\x07UNKNOWN\x10\x00\x12\t\n\x05P2PKH\x10\x01\x12\x08\n\x04P2SH\x10\x02\x12\n\n\x06P2WPKH\x10\x03\x12\t\n\x05P2WSH\x10\x04\x62\x06proto3')
+  serialized_pb=_b('\n\tbtc.proto\x1a\x0c\x63ommon.proto\"\xc7\x01\n\x0f\x42TCScriptConfig\x12\x32\n\x0bsimple_type\x18\x01 \x01(\x0e\x32\x1b.BTCScriptConfig.SimpleTypeH\x00\x1aK\n\x08Multisig\x12\x11\n\tthreshold\x18\x01 \x01(\r\x12\x14\n\x05xpubs\x18\x02 \x03(\x0b\x32\x05.XPub\x12\x16\n\x0eour_xpub_index\x18\x03 \x01(\r\")\n\nSimpleType\x12\x0f\n\x0bP2WPKH_P2SH\x10\x00\x12\n\n\x06P2WPKH\x10\x01\x42\x08\n\x06\x63onfig\"\x98\x02\n\rBTCPubRequest\x12\x16\n\x04\x63oin\x18\x01 \x01(\x0e\x32\x08.BTCCoin\x12\x0f\n\x07keypath\x18\x02 \x03(\r\x12,\n\txpub_type\x18\x03 \x01(\x0e\x32\x17.BTCPubRequest.XPubTypeH\x00\x12)\n\rscript_config\x18\x04 \x01(\x0b\x32\x10.BTCScriptConfigH\x00\x12\x0f\n\x07\x64isplay\x18\x05 \x01(\x08\"j\n\x08XPubType\x12\x08\n\x04TPUB\x10\x00\x12\x08\n\x04XPUB\x10\x01\x12\x08\n\x04YPUB\x10\x02\x12\x08\n\x04ZPUB\x10\x03\x12\x08\n\x04VPUB\x10\x04\x12\x08\n\x04UPUB\x10\x05\x12\x10\n\x0c\x43\x41PITAL_VPUB\x10\x06\x12\x10\n\x0c\x43\x41PITAL_ZPUB\x10\x07\x42\x08\n\x06output\"\xba\x01\n\x12\x42TCSignInitRequest\x12\x16\n\x04\x63oin\x18\x01 \x01(\x0e\x32\x08.BTCCoin\x12\'\n\rscript_config\x18\x02 \x01(\x0b\x32\x10.BTCScriptConfig\x12\x17\n\x0fkeypath_account\x18\x03 \x03(\r\x12\x0f\n\x07version\x18\x04 \x01(\r\x12\x12\n\nnum_inputs\x18\x05 \x01(\r\x12\x13\n\x0bnum_outputs\x18\x06 \x01(\r\x12\x10\n\x08locktime\x18\x07 \x01(\r\"\xa0\x01\n\x13\x42TCSignNextResponse\x12\'\n\x04type\x18\x01 \x01(\x0e\x32\x19.BTCSignNextResponse.Type\x12\r\n\x05index\x18\x02 \x01(\r\x12\x15\n\rhas_signature\x18\x03 \x01(\x08\x12\x11\n\tsignature\x18\x04 \x01(\x0c\"\'\n\x04Type\x12\t\n\x05INPUT\x10\x00\x12\n\n\x06OUTPUT\x10\x01\x12\x08\n\x04\x44ONE\x10\x02\"y\n\x13\x42TCSignInputRequest\x12\x13\n\x0bprevOutHash\x18\x01 \x01(\x0c\x12\x14\n\x0cprevOutIndex\x18\x02 \x01(\r\x12\x14\n\x0cprevOutValue\x18\x03 \x01(\x04\x12\x10\n\x08sequence\x18\x04 \x01(\r\x12\x0f\n\x07keypath\x18\x06 \x03(\r\"p\n\x14\x42TCSignOutputRequest\x12\x0c\n\x04ours\x18\x01 \x01(\x08\x12\x1c\n\x04type\x18\x02 \x01(\x0e\x32\x0e.BTCOutputType\x12\r\n\x05value\x18\x03 \x01(\x04\x12\x0c\n\x04hash\x18\x04 \x01(\x0c\x12\x0f\n\x07keypath\x18\x05 \x03(\r*/\n\x07\x42TCCoin\x12\x07\n\x03\x42TC\x10\x00\x12\x08\n\x04TBTC\x10\x01\x12\x07\n\x03LTC\x10\x02\x12\x08\n\x04TLTC\x10\x03*H\n\rBTCOutputType\x12\x0b\n\x07UNKNOWN\x10\x00\x12\t\n\x05P2PKH\x10\x01\x12\x08\n\x04P2SH\x10\x02\x12\n\n\x06P2WPKH\x10\x03\x12\t\n\x05P2WSH\x10\x04\x62\x06proto3')
   ,
   dependencies=[common__pb2.DESCRIPTOR,])
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
@@ -51,8 +51,8 @@ _BTCCOIN = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=1065,
-  serialized_end=1112,
+  serialized_start=1101,
+  serialized_end=1148,
 )
 _sym_db.RegisterEnumDescriptor(_BTCCOIN)
 
@@ -86,8 +86,8 @@ _BTCOUTPUTTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=1114,
-  serialized_end=1186,
+  serialized_start=1150,
+  serialized_end=1222,
 )
 _sym_db.RegisterEnumDescriptor(_BTCOUTPUTTYPE)
 
@@ -155,11 +155,19 @@ _BTCPUBREQUEST_XPUBTYPE = _descriptor.EnumDescriptor(
       name='UPUB', index=5, number=5,
       options=None,
       type=None),
+    _descriptor.EnumValueDescriptor(
+      name='CAPITAL_VPUB', index=6, number=6,
+      options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='CAPITAL_ZPUB', index=7, number=7,
+      options=None,
+      type=None),
   ],
   containing_type=None,
   options=None,
   serialized_start=394,
-  serialized_end=464,
+  serialized_end=500,
 )
 _sym_db.RegisterEnumDescriptor(_BTCPUBREQUEST_XPUBTYPE)
 
@@ -184,8 +192,8 @@ _BTCSIGNNEXTRESPONSE_TYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=787,
-  serialized_end=826,
+  serialized_start=823,
+  serialized_end=862,
 )
 _sym_db.RegisterEnumDescriptor(_BTCSIGNNEXTRESPONSE_TYPE)
 
@@ -328,7 +336,7 @@ _BTCPUBREQUEST = _descriptor.Descriptor(
       index=0, containing_type=None, fields=[]),
   ],
   serialized_start=230,
-  serialized_end=474,
+  serialized_end=510,
 )
 
 
@@ -400,8 +408,8 @@ _BTCSIGNINITREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=477,
-  serialized_end=663,
+  serialized_start=513,
+  serialized_end=699,
 )
 
 
@@ -453,8 +461,8 @@ _BTCSIGNNEXTRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=666,
-  serialized_end=826,
+  serialized_start=702,
+  serialized_end=862,
 )
 
 
@@ -512,8 +520,8 @@ _BTCSIGNINPUTREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=828,
-  serialized_end=949,
+  serialized_start=864,
+  serialized_end=985,
 )
 
 
@@ -571,8 +579,8 @@ _BTCSIGNOUTPUTREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=951,
-  serialized_end=1063,
+  serialized_start=987,
+  serialized_end=1099,
 )
 
 _BTCSCRIPTCONFIG_MULTISIG.fields_by_name['xpubs'].message_type = common__pb2._XPUB

--- a/py/bitbox02/communication/generated/btc_pb2.pyi
+++ b/py/bitbox02/communication/generated/btc_pb2.pyi
@@ -151,12 +151,16 @@ class BTCPubRequest(google___protobuf___message___Message):
         ZPUB = typing___cast(BTCPubRequest.XPubType, 3)
         VPUB = typing___cast(BTCPubRequest.XPubType, 4)
         UPUB = typing___cast(BTCPubRequest.XPubType, 5)
+        CAPITAL_VPUB = typing___cast(BTCPubRequest.XPubType, 6)
+        CAPITAL_ZPUB = typing___cast(BTCPubRequest.XPubType, 7)
     TPUB = typing___cast(BTCPubRequest.XPubType, 0)
     XPUB = typing___cast(BTCPubRequest.XPubType, 1)
     YPUB = typing___cast(BTCPubRequest.XPubType, 2)
     ZPUB = typing___cast(BTCPubRequest.XPubType, 3)
     VPUB = typing___cast(BTCPubRequest.XPubType, 4)
     UPUB = typing___cast(BTCPubRequest.XPubType, 5)
+    CAPITAL_VPUB = typing___cast(BTCPubRequest.XPubType, 6)
+    CAPITAL_ZPUB = typing___cast(BTCPubRequest.XPubType, 7)
 
     coin = ... # type: BTCCoin
     keypath = ... # type: google___protobuf___internal___containers___RepeatedScalarFieldContainer[int]

--- a/src/apps/btc/btc.c
+++ b/src/apps/btc/btc.c
@@ -27,6 +27,8 @@ static const uint8_t _zpub_version[4] = {0x04, 0xb2, 0x47, 0x46};
 static const uint8_t _tpub_version[4] = {0x04, 0x35, 0x87, 0xcf};
 static const uint8_t _vpub_version[4] = {0x04, 0x5f, 0x1c, 0xf6};
 static const uint8_t _upub_version[4] = {0x04, 0x4a, 0x52, 0x62};
+static const uint8_t _capital_vpub_version[4] = {0x02, 0x57, 0x54, 0x83};
+static const uint8_t _capital_zpub_version[4] = {0x02, 0xaa, 0x7e, 0xd3};
 
 bool app_btc_xpub(
     BTCCoin coin,
@@ -61,6 +63,10 @@ bool app_btc_xpub(
         return btc_common_encode_xpub(&derived_xpub, _ypub_version, out, out_len);
     case BTCPubRequest_XPubType_ZPUB:
         return btc_common_encode_xpub(&derived_xpub, _zpub_version, out, out_len);
+    case BTCPubRequest_XPubType_CAPITAL_VPUB:
+        return btc_common_encode_xpub(&derived_xpub, _capital_vpub_version, out, out_len);
+    case BTCPubRequest_XPubType_CAPITAL_ZPUB:
+        return btc_common_encode_xpub(&derived_xpub, _capital_zpub_version, out, out_len);
     default:
         return false;
     }

--- a/src/apps/btc/btc_common.c
+++ b/src/apps/btc/btc_common.c
@@ -99,11 +99,17 @@ bool btc_common_is_valid_keypath_xpub(
 {
     switch (xpub_type) {
     case BTCPubRequest_XPubType_TPUB:
-    case BTCPubRequest_XPubType_VPUB:
-    case BTCPubRequest_XPubType_UPUB:
     case BTCPubRequest_XPubType_XPUB:
     case BTCPubRequest_XPubType_YPUB:
     case BTCPubRequest_XPubType_ZPUB:
+    case BTCPubRequest_XPubType_VPUB:
+    case BTCPubRequest_XPubType_UPUB:
+    case BTCPubRequest_XPubType_CAPITAL_VPUB:
+    case BTCPubRequest_XPubType_CAPITAL_ZPUB:
+        if (_is_valid_keypath_account_multisig_p2wsh(keypath, keypath_len, expected_coin)) {
+            return true;
+        }
+
         if (keypath_len != 3) {
             return false;
         }

--- a/src/commander/commander_btc.c
+++ b/src/commander/commander_btc.c
@@ -64,11 +64,13 @@ static commander_error_t _btc_pub_xpub(const BTCPubRequest* request, PubResponse
         char title[100] = {0};
         switch (request->output.xpub_type) {
         case BTCPubRequest_XPubType_TPUB:
-        case BTCPubRequest_XPubType_VPUB:
-        case BTCPubRequest_XPubType_UPUB:
         case BTCPubRequest_XPubType_XPUB:
         case BTCPubRequest_XPubType_YPUB:
         case BTCPubRequest_XPubType_ZPUB:
+        case BTCPubRequest_XPubType_VPUB:
+        case BTCPubRequest_XPubType_UPUB:
+        case BTCPubRequest_XPubType_CAPITAL_VPUB:
+        case BTCPubRequest_XPubType_CAPITAL_ZPUB:
             snprintf(
                 title,
                 sizeof(title),

--- a/test/unit-test/test_app_btc.c
+++ b/test/unit-test/test_app_btc.c
@@ -152,6 +152,18 @@ static xpub_testcase_t _xpub_tests[] = {
         .out = "zpub6jftahH18ngZxpzeDjhxr4sULpQRji5vY1Nbh9tSxbZdprfTtRtoi4Bnuhb7GqbU8Xpaueq2pgwEve8"
                "Yx3fez3GxH5ALH8vP5Ud7CUbyUKz",
     },
+    {
+        .coin = BTCCoin_BTC,
+        .xpub_type = BTCPubRequest_XPubType_CAPITAL_VPUB,
+        .out = "Vpub5dEvVGKn7251zDPYpy2SqnqGNjruBaoXBpwPUqaSpLtXEdyTeCcqJvRAdaiEqeCgjSRLnLSusFuYWfJ"
+               "4NVAYwafDeBV3Lu7RtJeQEBLEptm",
+    },
+    {
+        .coin = BTCCoin_BTC,
+        .xpub_type = BTCPubRequest_XPubType_CAPITAL_ZPUB,
+        .out = "Zpub6vZyhw1ShkEwPQA2AQAwg9DH4cSgx4mWrH2GcR9zLNQ3T3ENeqH5oB3iiQYaqGpNMztZnEq9huKk3ok"
+               "KFGpc8XPd7YGjgYPNyCtynNreibs",
+    },
 };
 
 static address_testcase_t _address_tests[] = {


### PR DESCRIPTION
Allow retrieval and verification of multisig xpubs. The versions are
taken from Electrum (Zpub for mainnet, Vpub for testnet, for p2wsh
scripts).