### PR TITLE
ugui: don't draw out of screen horizontally

### DIFF
--- a/src/ui/ugui/ugui.c
+++ b/src/ui/ugui/ugui.c
@@ -124,6 +124,10 @@ static void _UG_PutChar( char chr, UG_S16 x, UG_S16 y, UG_COLOR fc, UG_COLOR bc,
     actual_char_width = (font->widths ? font->widths[bt - font->start_char] :
                          font->char_width);
 
+    if (x + actual_char_width < 0 || x > gui->x_dim) {
+        return;
+    }
+
     if (font->font_type == FONT_TYPE_1BPP) {
         index = (bt - font->start_char) * font->char_height * bn;
         for ( j = 0; j < font->char_height; j++ ) {


### PR DESCRIPTION
UG_PutChar does a lot of looping and pixel drawing, which is pretty
slow. A longtouch confirm for example is noticable slower if a long
string is rendered, like an xpub (most of it cut off being out of
screen).

With a small bound check the device feels snappier and the
scrolling/confirm speeds are much more consistent.

Vertical check could be added, but we have no vertical scrolling, so
there is no benefit.