### PR TITLE
apps/btc/bip143: remove needless "static" keyword

### DIFF
--- a/src/apps/btc/btc_bip143.c
+++ b/src/apps/btc/btc_bip143.c
@@ -32,7 +32,7 @@ void btc_bip143_sighash(
     uint8_t* out // 32 bytes result
 )
 {
-    static sha256_context_t ctx = {0};
+    sha256_context_t ctx = {0};
     sha256_reset(&ctx);
     // https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki#specification
     // 1.


### PR DESCRIPTION
Must have been a copy/paste error, ctx can be a stack var instead.