### PR TITLE
components/icon_button: add ICON_BUTTON_NEXT

### DIFF
--- a/src/rust/bitbox02/src/lib.rs
+++ b/src/rust/bitbox02/src/lib.rs
@@ -130,6 +130,7 @@ pub fn workflow_confirm(
         scrollable: false,
         longtouch: longtouch,
         accept_only: accept_only,
+        accept_is_nextarrow: false,
     };
 
     unsafe {

--- a/src/ui/components/confirm.c
+++ b/src/ui/components/confirm.c
@@ -95,7 +95,11 @@ component_t* confirm_create(
             ui_util_add_sub_component(confirm, confirm_gesture_create(confirm));
         } else {
             ui_util_add_sub_component(
-                confirm, icon_button_create(slider_position, ICON_BUTTON_CHECK, confirm_callback));
+                confirm,
+                icon_button_create(
+                    slider_position,
+                    params->accept_is_nextarrow ? ICON_BUTTON_NEXT : ICON_BUTTON_CHECK,
+                    confirm_callback));
         }
     }
 

--- a/src/ui/components/confirm.h
+++ b/src/ui/components/confirm.h
@@ -32,6 +32,9 @@ typedef struct {
     bool longtouch;
     // If true, the user can only confirm, not reject.
     bool accept_only;
+    // if true, the accept icon is a right arrow instead of a checkmark (indicating going to the
+    // "next" screen).
+    bool accept_is_nextarrow;
 } confirm_params_t;
 
 /**

--- a/src/ui/components/icon_button.c
+++ b/src/ui/components/icon_button.c
@@ -44,12 +44,22 @@ typedef struct {
 static void _render(component_t* component)
 {
     data_t* data = (data_t*)component->data;
-    uint16_t y;
-
-    if (data->location == top_slider) {
-        y = data->active_count / SCALE;
+    uint16_t y = 0;
+    uint16_t x = data->type == ICON_BUTTON_CROSS ? (SCREEN_WIDTH / 6) : (SCREEN_WIDTH / 6 * 5);
+    const uint16_t arrow_height = 4;
+    if (data->type == ICON_BUTTON_NEXT) {
+        if (data->location == bottom_slider) {
+            y = SCREEN_HEIGHT - arrow_height * 2;
+        }
+        // horizontal animation
+        x += data->active_count / SCALE;
     } else {
-        y = SCREEN_HEIGHT - data->active_count / SCALE - IMAGE_DEFAULT_ARROW_HEIGHT - 1;
+        // vertical animation
+        if (data->location == top_slider) {
+            y = data->active_count / SCALE;
+        } else {
+            y = SCREEN_HEIGHT - data->active_count / SCALE - IMAGE_DEFAULT_ARROW_HEIGHT - 1;
+        }
     }
 
     // Explicit upcast to signed int, avoids underflow (happens automatically,
@@ -59,10 +69,13 @@ static void _render(component_t* component)
 
     switch (data->type) {
     case ICON_BUTTON_CHECK:
-        image_checkmark(SCREEN_WIDTH / 6 * 5, y, IMAGE_DEFAULT_CHECKMARK_HEIGHT);
+        image_checkmark(x, y, IMAGE_DEFAULT_CHECKMARK_HEIGHT);
         break;
     case ICON_BUTTON_CROSS:
-        image_cross(SCREEN_WIDTH / 6, y, IMAGE_DEFAULT_CROSS_HEIGHT);
+        image_cross(x, y, IMAGE_DEFAULT_CROSS_HEIGHT);
+        break;
+    case ICON_BUTTON_NEXT:
+        image_arrow(x, y, arrow_height, ARROW_RIGHT);
         break;
     default:
         break;
@@ -99,6 +112,7 @@ static void _on_event(const event_t* event, component_t* component)
     gestures_slider_data_t* slider_data = (gestures_slider_data_t*)event->data;
     switch (data->type) {
     case ICON_BUTTON_CHECK:
+    case ICON_BUTTON_NEXT:
         if (slider_data->position < SLIDER_POSITION_TWO_THIRD) {
             data->active = false;
             return;

--- a/src/ui/components/icon_button.h
+++ b/src/ui/components/icon_button.h
@@ -21,6 +21,7 @@
 typedef enum {
     ICON_BUTTON_CHECK,
     ICON_BUTTON_CROSS,
+    ICON_BUTTON_NEXT,
 } icon_button_type_t;
 
 /**


### PR DESCRIPTION
Quite a few workflow can benefit of a "next" button instead of a
checkmark, when there are multiple consecutive confirmation screens.

This will be used in multisig confirmation.

A horizontal animation is added instead of a vertical one.