### PR TITLE
apps/btc: move xpub_type to btc_common_encode_xpub

### DIFF
--- a/src/apps/btc/btc.c
+++ b/src/apps/btc/btc.c
@@ -21,15 +21,6 @@
 #include <hww.pb.h>
 #include <keystore.h>
 
-static const uint8_t _xpub_version[4] = {0x04, 0x88, 0xb2, 0x1e};
-static const uint8_t _ypub_version[4] = {0x04, 0x9d, 0x7c, 0xb2};
-static const uint8_t _zpub_version[4] = {0x04, 0xb2, 0x47, 0x46};
-static const uint8_t _tpub_version[4] = {0x04, 0x35, 0x87, 0xcf};
-static const uint8_t _vpub_version[4] = {0x04, 0x5f, 0x1c, 0xf6};
-static const uint8_t _upub_version[4] = {0x04, 0x4a, 0x52, 0x62};
-static const uint8_t _capital_vpub_version[4] = {0x02, 0x57, 0x54, 0x83};
-static const uint8_t _capital_zpub_version[4] = {0x02, 0xaa, 0x7e, 0xd3};
-
 bool app_btc_xpub(
     BTCCoin coin,
     BTCPubRequest_XPubType xpub_type,
@@ -50,26 +41,7 @@ bool app_btc_xpub(
     if (!keystore_get_xpub(keypath, keypath_len, &derived_xpub)) {
         return false;
     }
-    switch (xpub_type) {
-    case BTCPubRequest_XPubType_TPUB:
-        return btc_common_encode_xpub(&derived_xpub, _tpub_version, out, out_len);
-    case BTCPubRequest_XPubType_VPUB:
-        return btc_common_encode_xpub(&derived_xpub, _vpub_version, out, out_len);
-    case BTCPubRequest_XPubType_UPUB:
-        return btc_common_encode_xpub(&derived_xpub, _upub_version, out, out_len);
-    case BTCPubRequest_XPubType_XPUB:
-        return btc_common_encode_xpub(&derived_xpub, _xpub_version, out, out_len);
-    case BTCPubRequest_XPubType_YPUB:
-        return btc_common_encode_xpub(&derived_xpub, _ypub_version, out, out_len);
-    case BTCPubRequest_XPubType_ZPUB:
-        return btc_common_encode_xpub(&derived_xpub, _zpub_version, out, out_len);
-    case BTCPubRequest_XPubType_CAPITAL_VPUB:
-        return btc_common_encode_xpub(&derived_xpub, _capital_vpub_version, out, out_len);
-    case BTCPubRequest_XPubType_CAPITAL_ZPUB:
-        return btc_common_encode_xpub(&derived_xpub, _capital_zpub_version, out, out_len);
-    default:
-        return false;
-    }
+    return btc_common_encode_xpub(&derived_xpub, xpub_type, out, out_len);
 }
 
 bool app_btc_address_simple(

--- a/src/apps/btc/btc_common.c
+++ b/src/apps/btc/btc_common.c
@@ -33,6 +33,15 @@
 
 #define MULTISIG_P2WSH_MAX_SIGNERS 15
 
+static const uint8_t _xpub_version[4] = {0x04, 0x88, 0xb2, 0x1e};
+static const uint8_t _ypub_version[4] = {0x04, 0x9d, 0x7c, 0xb2};
+static const uint8_t _zpub_version[4] = {0x04, 0xb2, 0x47, 0x46};
+static const uint8_t _tpub_version[4] = {0x04, 0x35, 0x87, 0xcf};
+static const uint8_t _vpub_version[4] = {0x04, 0x5f, 0x1c, 0xf6};
+static const uint8_t _upub_version[4] = {0x04, 0x4a, 0x52, 0x62};
+static const uint8_t _capital_vpub_version[4] = {0x02, 0x57, 0x54, 0x83};
+static const uint8_t _capital_zpub_version[4] = {0x02, 0xaa, 0x7e, 0xd3};
+
 const char* btc_common_coin_name(BTCCoin coin)
 {
     static const char* _coin_btc = "Bitcoin";
@@ -168,7 +177,7 @@ bool btc_common_is_valid_keypath_address_simple(
 
 bool btc_common_encode_xpub(
     const struct ext_key* derived_xpub,
-    const uint8_t* version, // must be 4 bytes
+    BTCPubRequest_XPubType xpub_type,
     char* out,
     size_t out_len)
 {
@@ -178,6 +187,36 @@ bool btc_common_encode_xpub(
         WALLY_OK) {
         return false;
     }
+    const uint8_t* version;
+    switch (xpub_type) {
+    case BTCPubRequest_XPubType_TPUB:
+        version = _tpub_version;
+        break;
+    case BTCPubRequest_XPubType_VPUB:
+        version = _vpub_version;
+        break;
+    case BTCPubRequest_XPubType_UPUB:
+        version = _upub_version;
+        break;
+    case BTCPubRequest_XPubType_XPUB:
+        version = _xpub_version;
+        break;
+    case BTCPubRequest_XPubType_YPUB:
+        version = _ypub_version;
+        break;
+    case BTCPubRequest_XPubType_ZPUB:
+        version = _zpub_version;
+        break;
+    case BTCPubRequest_XPubType_CAPITAL_VPUB:
+        version = _capital_vpub_version;
+        break;
+    case BTCPubRequest_XPubType_CAPITAL_ZPUB:
+        version = _capital_zpub_version;
+        break;
+    default:
+        return false;
+    }
+
     // Overwrite bip32 version (libwally doesn't give the option to provide a
     // different one)
     memcpy(bytes, version, 4);

--- a/src/apps/btc/btc_common.h
+++ b/src/apps/btc/btc_common.h
@@ -62,14 +62,14 @@ USE_RESULT bool btc_common_is_valid_keypath_address_simple(
 /**
  * Encode an xpub as a base58 string.
  * @param[in] dervived_xpub the xpub to encode.
- * @param[in] version 4 bytes version determining the prefix (e.g. 0x0488b21e for "xpub...")
+ * @param[in] xpub_type determines the xpub format, e.g. xpub, ypub, zpub, ...
  * @param[out] out resulting string, must be at least of size 113 (including the null terminator).
  * @param[in] out_len size of `out`.
  * @return false on failure, true on success.
  */
 USE_RESULT bool btc_common_encode_xpub(
     const struct ext_key* derived_xpub,
-    const uint8_t* version, // must be 4 bytes
+    BTCPubRequest_XPubType xpub_type,
     char* out,
     size_t out_len);
 

--- a/src/apps/eth/eth.c
+++ b/src/apps/eth/eth.c
@@ -69,8 +69,7 @@ bool app_eth_address(
         if (!keystore_get_xpub(keypath, keypath_len, &derived_xpub)) {
             return false;
         }
-        const uint8_t version[4] = {0x04, 0x88, 0xb2, 0x1e}; // xpub
-        return btc_common_encode_xpub(&derived_xpub, version, out, out_len);
+        return btc_common_encode_xpub(&derived_xpub, BTCPubRequest_XPubType_XPUB, out, out_len);
     }
     default:
         return false;

--- a/test/unit-test/test_app_btc_common.c
+++ b/test/unit-test/test_app_btc_common.c
@@ -419,13 +419,50 @@ static void _test_btc_common_encode_xpub(void** state)
         WALLY_OK);
     assert_int_equal(bip32_key_strip_private_key(&xpub), WALLY_OK);
     char out[113] = {0};
-    assert_false(btc_common_encode_xpub(&xpub, (const uint8_t*)"\x04\x88\xb2\x1e", out, 110));
-    assert_true(
-        btc_common_encode_xpub(&xpub, (const uint8_t*)"\x04\x88\xb2\x1e", out, sizeof(out)));
+    assert_false(btc_common_encode_xpub(&xpub, BTCPubRequest_XPubType_XPUB, out, 110));
+
+    assert_true(btc_common_encode_xpub(&xpub, BTCPubRequest_XPubType_TPUB, out, sizeof(out)));
+    assert_string_equal(
+        out,
+        "tpubD6NzVbkrYhZ4X8SrpdvxUfkKsPg5iSLHQqmQ2e7MGczVsJskvL4uD62ckffe8zi4BVtbZXRCsVDythz1eNN3fN"
+        "S2A14YakBkWLBbyJiVFQ9");
+    assert_true(btc_common_encode_xpub(&xpub, BTCPubRequest_XPubType_XPUB, out, sizeof(out)));
     assert_string_equal(
         out,
         "xpub661MyMwAqRbcFLG1NSwsGkQxYGaRj3qDsDB6g64CviEc82D3r7Dp4eMnWdarcVkpPbMgwwuLLPPwCXVQFWWomv"
         "yj6QKEuDXWvNbCDF98tgM");
+    assert_true(btc_common_encode_xpub(&xpub, BTCPubRequest_XPubType_YPUB, out, sizeof(out)));
+    assert_string_equal(
+        out,
+        "ypub6QqdH2c5z7966dT8CojVUqWTiEisffpinKhKTUx6JicVB82H6mPNgi1vXqYScQQjoEUVhRVto3kV5p6xyCvpaA"
+        "fKxk1fV8M1C6eqbq4wvip");
+    assert_true(btc_common_encode_xpub(&xpub, BTCPubRequest_XPubType_ZPUB, out, sizeof(out)));
+    assert_string_equal(
+        out,
+        "zpub6jftahH18ngZwveF3AX7gvbxtCsKcHpDhSDYEsqygizNEDqWMRYwJmg4Z3W2cK4fCsbJSu6TFi72y6iXguLqNQ"
+        "Lvq5i653AVTpiUzQXvTSr");
+    assert_true(btc_common_encode_xpub(&xpub, BTCPubRequest_XPubType_VPUB, out, sizeof(out)));
+    assert_string_equal(
+        out,
+        "vpub5SLqN2bLY4WeYjsmhjNcraDxCLHXqorE2z8f7JGSAhUr1pabLntgpX3WUDfgcgSyaK85SziDR4gqRxGGp7gnBT"
+        "cXMivPjPtYNvTuS6sWM3J");
+    assert_true(btc_common_encode_xpub(&xpub, BTCPubRequest_XPubType_UPUB, out, sizeof(out)));
+    assert_string_equal(
+        out,
+        "upub57Wa4MvRPNyAhSgesNazeV8T2N95uBrj7scSKuNYnh6xximN68j8CTPNT1i6cmo4Ag1GhX7exQLHYfei6RGmPD"
+        "vvVPDy9V547CQG3b2p2sZ");
+    assert_true(
+        btc_common_encode_xpub(&xpub, BTCPubRequest_XPubType_CAPITAL_VPUB, out, sizeof(out)));
+    assert_string_equal(
+        out,
+        "Vpub5dEvVGKn7251yK39ePqbgeZkv8Ko4AXpMFnL2ZXyYUKFe19W7CGxuduSGvdAB7fsonC4KaiLJH5LZ7t37LqjKw"
+        "jCCC2o8oMYGejn221hXB7");
+    assert_true(
+        btc_common_encode_xpub(&xpub, BTCPubRequest_XPubType_CAPITAL_ZPUB, out, sizeof(out)));
+    assert_string_equal(
+        out,
+        "Zpub6vZyhw1ShkEwNVocypz6WzwmbzuapeVp1hsDA97X4VpmrQQR7pwDPtXzMkTWAkHZSLfHKV6a8vVY6GLHz8VnWt"
+        "TbfYpVUSdVMYzMaJxms8u");
 }
 
 typedef struct {

--- a/test/unit-test/test_apps_common_bip32.c
+++ b/test/unit-test/test_apps_common_bip32.c
@@ -30,9 +30,9 @@ static void _test_apps_common_bip32_xpub_from_protobuf(void** state)
     struct ext_key xpub = {0};
     assert_true(apps_common_bip32_xpub_from_protobuf(&xpub_in, &xpub));
 
-    const uint8_t version[4] = {0x04, 0x88, 0xb2, 0x1e};
     char xpub_str[113] = {0};
-    assert_true(btc_common_encode_xpub(&xpub, version, xpub_str, sizeof(xpub_str)));
+    assert_true(
+        btc_common_encode_xpub(&xpub, BTCPubRequest_XPubType_XPUB, xpub_str, sizeof(xpub_str)));
     assert_string_equal(xpub_str, test_xpub);
 }
 

--- a/test/unit-test/test_keystore_functional.c
+++ b/test/unit-test/test_keystore_functional.c
@@ -38,7 +38,6 @@
 
 static const char* _some_password = "foo";
 static const char* _some_other_password = "bar";
-static const uint8_t _xpub_version[4] = {0x04, 0x88, 0xb2, 0x1e};
 
 static uint8_t _seed[KEYSTORE_MAX_SEED_LENGTH] =
     "\xcb\x33\xc2\x0c\xea\x62\xa5\xc2\x77\x52\x7e\x20\x02\xda\x82\xe6\xe2\xb3\x74\x50\xa7\x55\x14"
@@ -134,8 +133,8 @@ static void _check_pubs(
 
     assert_true(keystore_get_xpub(keypath, 3, &xpub));
     char xpub_serialized[120];
-    assert_true(
-        btc_common_encode_xpub(&xpub, _xpub_version, xpub_serialized, sizeof(xpub_serialized)));
+    assert_true(btc_common_encode_xpub(
+        &xpub, BTCPubRequest_XPubType_XPUB, xpub_serialized, sizeof(xpub_serialized)));
     assert_string_equal(xpub_serialized, expected_xpub);
 
     uint8_t hash160[20];


### PR DESCRIPTION
More and more places are hardcoding the needed xpub version bytes
ad-hoc. Preparation for multisig Zpub use.