### PR TITLE
components/confirm: move confirm buttons to top, always.

### DIFF
--- a/src/ui/components/confirm.c
+++ b/src/ui/components/confirm.c
@@ -75,7 +75,7 @@ component_t* confirm_create(
     confirm->dimension.width = SCREEN_WIDTH;
     confirm->dimension.height = SCREEN_HEIGHT;
 
-    uint8_t slider_position = params->scrollable || params->longtouch ? top_slider : bottom_slider;
+    slider_location_t slider_position = top_slider;
     // Create labels
     if (params->scrollable) {
         ui_util_add_sub_component(

--- a/src/ui/components/icon_button.c
+++ b/src/ui/components/icon_button.c
@@ -45,7 +45,7 @@ static void _render(component_t* component)
 {
     data_t* data = (data_t*)component->data;
     uint16_t y = 0;
-    uint16_t x = data->type == ICON_BUTTON_CROSS ? (SCREEN_WIDTH / 6) : (SCREEN_WIDTH / 6 * 5);
+    uint16_t x = data->type == ICON_BUTTON_CROSS ? (SCREEN_WIDTH / 7) : (SCREEN_WIDTH / 7 * 6);
     const uint16_t arrow_height = 4;
     if (data->type == ICON_BUTTON_NEXT) {
         if (data->location == bottom_slider) {


### PR DESCRIPTION
The UX was inconsistent.

The buttons are also moved a little closer to the edges to make a bit
more space for titles.