### PR TITLE
unit-test: make a fresh coverage report every time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -416,7 +416,7 @@ else()
       add_custom_command(
         OUTPUT gcovr/coverage.html __dummy
         COMMAND ${CMAKE_COMMAND} -E make_directory gcovr
-        COMMAND ${GCOVR} --gcov-executable gcov-8 --html-details -o gcovr/coverage.html -r ${CMAKE_SOURCE_DIR} -f ${CMAKE_SOURCE_DIR}/src
+        COMMAND ${GCOVR} --gcov-executable gcov-8 --delete --html-details -o gcovr/coverage.html -r ${CMAKE_SOURCE_DIR} -f ${CMAKE_SOURCE_DIR}/src
       )
       add_custom_target(
         coverage


### PR DESCRIPTION
It is easier to use if everytime you run all tests or a specific test,
that the coverage report only shows the result of the last run, and
not the result of all previous runs combined.