### PR TITLE
btc,eth: validate names / ascii

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,6 +23,7 @@ set(DBB-FIRMWARE-SOURCES
   ${CMAKE_SOURCE_DIR}/src/attestation.c
   ${CMAKE_SOURCE_DIR}/src/hardfault.c
   ${CMAKE_SOURCE_DIR}/src/util.c
+  ${CMAKE_SOURCE_DIR}/src/util/util_string.c
   ${CMAKE_SOURCE_DIR}/src/sd.c
   ${CMAKE_SOURCE_DIR}/src/hww.c
   ${CMAKE_SOURCE_DIR}/src/memory/bitbox02_smarteeprom.c

--- a/src/apps/btc/btc.c
+++ b/src/apps/btc/btc.c
@@ -22,6 +22,7 @@
 #include <hww.pb.h>
 #include <keystore.h>
 #include <memory/memory.h>
+#include <util/util_string.h>
 #include <workflow/status.h>
 #include <workflow/verify_pub.h>
 
@@ -196,7 +197,7 @@ app_btc_result_t app_btc_register_script_config(
     }
     const BTCScriptConfig_Multisig* multisig = &script_config->config.multisig;
 
-    if (strlen(name) >= MEMORY_MULTISIG_NAME_MAX_LEN) {
+    if (!util_string_validate_name(name, MEMORY_MULTISIG_NAME_MAX_LEN - 1)) {
         return APP_BTC_ERR_INVALID_INPUT;
     }
 

--- a/src/apps/eth/eth_sign_msg.c
+++ b/src/apps/eth/eth_sign_msg.c
@@ -22,6 +22,7 @@
 #include <hardfault.h>
 #include <keystore.h>
 #include <util.h>
+#include <util/util_string.h>
 #include <workflow/confirm.h>
 
 app_eth_sign_error_t app_eth_sign_msg(
@@ -73,12 +74,7 @@ app_eth_sign_error_t app_eth_sign_msg(
     memcpy(&msg[payload_offset], request->msg.bytes, request->msg.size);
 
     // determine if the message is in ASCII
-    bool all_ascii = true;
-    for (size_t i = 0; i < request->msg.size; ++i) {
-        if (request->msg.bytes[i] < 20 || request->msg.bytes[i] > 127) {
-            all_ascii = false;
-        }
-    }
+    bool all_ascii = util_string_all_ascii_bytes(request->msg.bytes, request->msg.size);
 
     char body[sizeof(request->msg.bytes) * 2 + 1] = {0};
     confirm_params_t params = {

--- a/src/util/util_string.c
+++ b/src/util/util_string.c
@@ -1,0 +1,61 @@
+// Copyright 2019 Shift Cryptosecurity AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "util_string.h"
+
+#include <hardfault.h>
+
+#include <string.h>
+
+bool util_string_all_ascii_bytes(const uint8_t* bytes, size_t bytes_len)
+{
+    if (bytes == NULL) {
+        Abort("util_string_all_ascii_bytes");
+    }
+    for (size_t i = 0; i < bytes_len; ++i) {
+        if (bytes[i] < 32 || bytes[i] > 126) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool util_string_all_ascii(const char* str)
+{
+    if (str == NULL) {
+        Abort("util_string_all_ascii");
+    }
+    return util_string_all_ascii_bytes((const uint8_t*)str, strlen(str));
+}
+
+bool util_string_validate_name(const char* name, size_t max_len)
+{
+    if (name == NULL) {
+        Abort("util_string_validate_name");
+    }
+    const size_t len = strlen(name);
+    if (len == 0 || len > max_len) {
+        return false;
+    }
+    if (!util_string_all_ascii(name)) {
+        return false;
+    }
+    if (name[0] == ' ') {
+        return false;
+    }
+    if (name[len - 1] == ' ') {
+        return false;
+    }
+    return true;
+}

--- a/src/util/util_string.h
+++ b/src/util/util_string.h
@@ -1,0 +1,44 @@
+// Copyright 2019 Shift Cryptosecurity AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _UTIL_NAME_VALIDATE_H_
+#define _UTIL_NAME_VALIDATE_H_
+
+#include <compiler_util.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/*
+ * Returns true if all bytes are in this set (including the space ' '):
+ *  !"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~
+ * Note that newline, tab, etc. are not part of this set.
+ */
+USE_RESULT bool util_string_all_ascii_bytes(const uint8_t* bytes, size_t bytes_len);
+
+/*
+ * Returns true if all chars in the string are ascii, as specified in the documentation of
+ * `util_string_all_ascii_bytes`.
+ */
+USE_RESULT bool util_string_all_ascii(const char* str);
+
+/**
+ * Validate a user given name. The name must be smaller or equal to `max_len` and larger than 0 in
+ * size (without the null terminator), consist of printable ASCII characters only (and space), not
+ * start or end with whitespace, and contain no whitespace other than space.
+ * @return true if the name is valid, false if it is invalid.
+ */
+USE_RESULT bool util_string_validate_name(const char* name, size_t max_len);
+
+#endif

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -209,6 +209,8 @@ set(TEST_LIST
    "-Wl,--wrap=usb_processing_enqueue"
    util
    ""
+   util_string
+   ""
    commander_set_device_name
    "-Wl,--wrap=workflow_confirm,--wrap=memory_set_device_name"
    commander_set_mnemonic_passphrase_enabled

--- a/test/unit-test/test_util_string.c
+++ b/test/unit-test/test_util_string.c
@@ -1,0 +1,70 @@
+#include "util.h"
+
+// Copyright 2019 Shift Cryptosecurity AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <cmocka.h>
+
+#include <util/util_string.h>
+
+static const char* _all_ascii =
+    "! \"#$%&\'()*+,-./"
+    "0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~";
+
+static void _test_util_string_all_ascii(void** state)
+{
+    // All ascii chars.
+    assert_true(util_string_all_ascii(_all_ascii));
+    // Edge cases: highest and lowest non ascii chars.
+    assert_false(util_string_all_ascii("\x7f"));
+    assert_false(util_string_all_ascii("\x19"));
+    assert_false(util_string_all_ascii("\n"));
+    assert_false(util_string_all_ascii("\t"));
+}
+
+static void _test_util_string_validate_name(void** state)
+{
+    // Max len.
+    assert_true(util_string_validate_name("foo", 5));
+    assert_true(util_string_validate_name("foo", 4));
+    assert_true(util_string_validate_name("foo", 3));
+    assert_false(util_string_validate_name("foo", 2));
+
+    // Ascii.
+    assert_true(util_string_validate_name(_all_ascii, 100));
+    assert_false(util_string_validate_name("\n", 100));
+    assert_false(util_string_validate_name("\t", 100));
+
+    // Starts / ends with space.
+    assert_false(util_string_validate_name(" foo", 100));
+    assert_false(util_string_validate_name("foo ", 100));
+
+    // Can contain space otherwise.
+    assert_true(util_string_validate_name("hello world", 100));
+
+    // Empty string.
+    assert_false(util_string_validate_name("", 100));
+}
+
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(_test_util_string_all_ascii),
+        cmocka_unit_test(_test_util_string_validate_name),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
To be able to print names on the screen for confirmation, they need to
be all ascii and not start/end with spaces.

ascii util function added also for bytes as that can be reused in
eth's sign message function.