### PR TITLE
apps/btc: pass on DUPLICATE error in account registration

### DIFF
--- a/src/apps/btc/btc.c
+++ b/src/apps/btc/btc.c
@@ -213,10 +213,14 @@ app_btc_result_t app_btc_register_script_config(
         return APP_BTC_ERR_UNKNOWN;
     }
     // This will rename the multisig config if it already exists.
-    if (memory_multisig_set_by_hash(hash, name) != MEMORY_OK) {
+    memory_result_t result = memory_multisig_set_by_hash(hash, name);
+    switch (result) {
+    case MEMORY_OK:
+        workflow_status_create("Multisig account\nregistered", true);
+        return APP_BTC_OK;
+    case MEMORY_ERR_DUPLICATE_NAME:
+        return APP_BTC_ERR_DUPLICATE;
+    default:
         return APP_BTC_ERR_UNKNOWN;
     }
-
-    workflow_status_create("Multisig account\nregistered", true);
-    return APP_BTC_OK;
 }

--- a/src/apps/btc/btc.h
+++ b/src/apps/btc/btc.h
@@ -27,6 +27,7 @@ typedef enum {
     APP_BTC_OK,
     APP_BTC_ERR_USER_ABORT,
     APP_BTC_ERR_INVALID_INPUT,
+    APP_BTC_ERR_DUPLICATE,
     APP_BTC_ERR_UNKNOWN,
 } app_btc_result_t;
 

--- a/src/commander/commander.h
+++ b/src/commander/commander.h
@@ -30,7 +30,8 @@
     X(COMMANDER_ERR_GENERIC, 103, "generic error")                               \
     X(COMMANDER_ERR_USER_ABORT, 104, "aborted by the user")                      \
     X(COMMANDER_ERR_INVALID_STATE, 105, "can't call this endpoint: wrong state") \
-    X(COMMANDER_ERR_DISABLED, 106, "function disabled")
+    X(COMMANDER_ERR_DISABLED, 106, "function disabled")                          \
+    X(COMMANDER_ERR_DUPLICATE, 107, "duplicate entry")
 
 #define X(a, b, c) a,
 typedef enum { COMMANDER_ERROR_TABLE } commander_error_t;

--- a/src/commander/commander_btc.c
+++ b/src/commander/commander_btc.c
@@ -33,6 +33,8 @@ static commander_error_t _result(app_btc_result_t result)
         return COMMANDER_ERR_USER_ABORT;
     case APP_BTC_ERR_INVALID_INPUT:
         return COMMANDER_ERR_INVALID_INPUT;
+    case APP_BTC_ERR_DUPLICATE:
+        return COMMANDER_ERR_DUPLICATE;
     default:
         return COMMANDER_ERR_GENERIC;
     }


### PR DESCRIPTION
So the client can prompt the user to enter a different name.