### PR TITLE
Improve scroll list

### DIFF
--- a/src/ui/component.h
+++ b/src/ui/component.h
@@ -66,6 +66,15 @@ struct component_t {
     struct component_t* parent;
     /* Whether or not to require touch release before emitting touch events. */
     bool emit_without_release;
+    /**
+     * Whether the component is disabled/invisible.
+     *
+     * On creation, every component is enabled.
+     * If a component is disabled, it won't be rendered unless
+     * its render function is called explicitely, and it won't
+     * receive events unless they're passed to it explicitely.
+     */
+    bool disabled;
 };
 
 #endif

--- a/src/ui/components/confirm_mnemonic.c
+++ b/src/ui/components/confirm_mnemonic.c
@@ -60,7 +60,7 @@ component_t* confirm_mnemonic_create(
     ui_util_add_sub_component(
         confirm_mnemonic,
         scroll_through_all_variants_create(
-            wordlist, check_word_cb, length, false, NULL, cancel_cb, confirm_mnemonic));
+            wordlist, check_word_cb, length, "", NULL, cancel_cb, confirm_mnemonic));
 
     return confirm_mnemonic;
 }

--- a/src/ui/components/scroll_through_all_variants.c
+++ b/src/ui/components/scroll_through_all_variants.c
@@ -15,6 +15,7 @@
 #include "scroll_through_all_variants.h"
 #include "../event.h"
 #include "button.h"
+#include "icon_button.h"
 #include "label.h"
 #include "left_arrow.h"
 #include "right_arrow.h"
@@ -294,7 +295,7 @@ component_t* scroll_through_all_variants_create(
     if (cancel_cb != NULL) {
         ui_util_add_sub_component(
             scroll_through_all_variants,
-            button_create("Cancel", top_slider, 0, _cancel, scroll_through_all_variants));
+            icon_button_create(top_slider, ICON_BUTTON_CROSS, _cancel));
     }
 
     data->back_arrow = left_arrow_create(bottom_slider, scroll_through_all_variants);

--- a/src/ui/components/scroll_through_all_variants.c
+++ b/src/ui/components/scroll_through_all_variants.c
@@ -33,7 +33,6 @@ typedef struct {
     component_t** labels;
     uint8_t length;
     uint8_t index;
-    char index_str[4];
     component_t* index_label;
     component_t* back_arrow;
     component_t* forward_arrow;
@@ -72,8 +71,9 @@ static void _display_index(component_t* scroll_through_all_variants)
 {
     scroll_through_all_variants_data_t* data =
         (scroll_through_all_variants_data_t*)scroll_through_all_variants->data;
-    snprintf(data->index_str, sizeof(data->index_str), "%02u", (data->index + 1U));
-    label_update(data->index_label, data->index_str);
+    char index_str[4];
+    snprintf(index_str, sizeof(index_str), "%02u", (data->index + 1U));
+    label_update(data->index_label, index_str);
 }
 
 static void _update_positions(component_t* scroll_through_all_variants, int32_t velocity)
@@ -97,6 +97,7 @@ static void _update_positions(component_t* scroll_through_all_variants, int32_t 
         }
     }
 
+    /* When no title is provided, show the index instead. */
     if (data->show_index) {
         _display_index(scroll_through_all_variants);
     }
@@ -232,7 +233,7 @@ component_t* scroll_through_all_variants_create(
     const char* const* words,
     void (*select_word_cb)(uint8_t),
     const uint8_t length,
-    bool show_index,
+    const char* title,
     void (*continue_on_last_cb)(void),
     void (*cancel_cb)(void),
     component_t* parent)
@@ -264,7 +265,7 @@ component_t* scroll_through_all_variants_create(
     data->select_word_cb = select_word_cb;
     data->length = length;
     data->index = 0;
-    data->show_index = show_index;
+    data->show_index = !title;
     data->continue_on_last_cb = continue_on_last_cb;
     data->continue_on_last_button = NULL;
     data->cancel_cb = cancel_cb;
@@ -275,10 +276,12 @@ component_t* scroll_through_all_variants_create(
         ui_util_add_sub_component(scroll_through_all_variants, label);
         labels[i] = label;
     }
-    if (show_index) {
-        data->index_label = label_create("01", NULL, CENTER_TOP, scroll_through_all_variants);
+    data->index_label = label_create("", NULL, CENTER_TOP, scroll_through_all_variants);
+    ui_util_add_sub_component(scroll_through_all_variants, data->index_label);
+    if (data->show_index) {
         _display_index(scroll_through_all_variants);
-        ui_util_add_sub_component(scroll_through_all_variants, data->index_label);
+    } else {
+        label_update(data->index_label, title);
     }
 
     if (select_word_cb != NULL) {

--- a/src/ui/components/scroll_through_all_variants.c
+++ b/src/ui/components/scroll_through_all_variants.c
@@ -25,12 +25,6 @@
 
 #include <string.h>
 
-// the rate at which the _update_positions function is called
-static const uint8_t UPDATE_RATE = 30;
-// keeps track of the times that the _slide function is called, to trigger the call of
-// _update_positions.
-static uint8_t _update_iteration = 0;
-
 /**
  * Scroll-through data.
  */
@@ -129,28 +123,6 @@ static void _init_positions(component_t* scroll_through_all_variants)
     }
 }
 
-/**
- * Moves to the previous or next word in the words list.
- */
-static void _slide(gestures_slider_data_t* gestures_slider_data, component_t* component)
-{
-    if (_update_iteration % UPDATE_RATE == 0) {
-        if (abs(gestures_slider_data->velocity) > 0) {
-            _update_positions(component, gestures_slider_data->velocity / 2);
-        }
-        _update_iteration = 0;
-    }
-    _update_iteration++;
-}
-
-// animate quicker and snap to the item that is most visible. Update index.
-static void _slide_release(gestures_slider_data_t* gestures_slider_data, component_t* component)
-{
-    (void)gestures_slider_data;
-    scroll_through_all_variants_data_t* data = (scroll_through_all_variants_data_t*)component->data;
-    _update_positions(component, -1 * data->diff_to_middle);
-}
-
 static void _back(component_t* component)
 {
     scroll_through_all_variants_data_t* data = (scroll_through_all_variants_data_t*)component->data;
@@ -191,16 +163,6 @@ static void _on_event(const event_t* event, component_t* component)
 {
     // gestures_slider_data_t* slider_data = (gestures_slider_data_t*)event->data;
     switch (event->id) {
-    case EVENT_TOP_SLIDE:
-    case EVENT_BOTTOM_SLIDE:
-        //_slide(slider_data, component);
-        (void)_slide;
-        break;
-    case EVENT_TOP_SLIDE_RELEASED:
-    case EVENT_BOTTOM_SLIDE_RELEASED:
-        (void)_slide_release;
-        //_slide_release(slider_data, component);
-        break;
     case EVENT_BACKWARD:
         _back(component);
         break;

--- a/src/ui/components/scroll_through_all_variants.c
+++ b/src/ui/components/scroll_through_all_variants.c
@@ -35,6 +35,8 @@ typedef struct {
     uint8_t index;
     char index_str[4];
     component_t* index_label;
+    component_t* back_arrow;
+    component_t* forward_arrow;
     bool show_index;
     int32_t diff_to_middle;
     void (*select_word_cb)(uint8_t);
@@ -123,6 +125,21 @@ static void _init_positions(component_t* scroll_through_all_variants)
     }
 }
 
+static void _update_arrow_visibility(scroll_through_all_variants_data_t* data, uint8_t new_index)
+{
+    if (new_index == 0) {
+        data->back_arrow->disabled = true;
+    } else {
+        data->back_arrow->disabled = false;
+    }
+
+    if (new_index == data->length - 1) {
+        data->forward_arrow->disabled = true;
+    } else {
+        data->forward_arrow->disabled = false;
+    }
+}
+
 static void _back(component_t* component)
 {
     scroll_through_all_variants_data_t* data = (scroll_through_all_variants_data_t*)component->data;
@@ -130,6 +147,7 @@ static void _back(component_t* component)
     int32_t diff_to_middle = (data->labels[new_index]->position.left +
                               data->labels[new_index]->dimension.width / 2 - SCREEN_WIDTH / 2) *
                              -1;
+    _update_arrow_visibility(data, new_index);
     _update_positions(component, diff_to_middle);
 }
 
@@ -140,6 +158,7 @@ static void _forward(component_t* component)
     int32_t diff_to_middle = (data->labels[new_index]->position.left +
                               data->labels[new_index]->dimension.width / 2 - SCREEN_WIDTH / 2) *
                              -1;
+    _update_arrow_visibility(data, new_index);
     _update_positions(component, diff_to_middle);
 }
 
@@ -275,12 +294,13 @@ component_t* scroll_through_all_variants_create(
             button_create("Cancel", top_slider, 0, _cancel, scroll_through_all_variants));
     }
 
-    ui_util_add_sub_component(
-        scroll_through_all_variants, left_arrow_create(bottom_slider, scroll_through_all_variants));
-    ui_util_add_sub_component(
-        scroll_through_all_variants,
-        right_arrow_create(bottom_slider, scroll_through_all_variants));
+    data->back_arrow = left_arrow_create(bottom_slider, scroll_through_all_variants);
+    ui_util_add_sub_component(scroll_through_all_variants, data->back_arrow);
 
+    data->forward_arrow = right_arrow_create(bottom_slider, scroll_through_all_variants);
+    ui_util_add_sub_component(scroll_through_all_variants, data->forward_arrow);
+
+    _update_arrow_visibility(data, 0);
     _init_positions(scroll_through_all_variants);
     return scroll_through_all_variants;
 }

--- a/src/ui/components/scroll_through_all_variants.h
+++ b/src/ui/components/scroll_through_all_variants.h
@@ -25,7 +25,9 @@
  * @param[in] select_word_cb If specified, the callback will be called if the user selects a word.
  * The parameter is the index of the selected word. Should not be used with show_index.
  * @param[in] length The word list length.
- * @param[in] show_index If true, displays the index of the current word (starting at 1).
+ * @param[in] title Title for the window.
+ *                  If NULL, displays the index of the current word instead (starting at 1).
+ *                  For no title, set this to "".
  * @param[in] continue_on_last_cb If set, a checkmark appears when reaching the last word, calling
  * this callback.
  * @param[in] cancel_cb Called when the cancel button is pressed.
@@ -35,7 +37,7 @@ component_t* scroll_through_all_variants_create(
     const char* const* words,
     void (*select_word_cb)(uint8_t),
     uint8_t length,
-    bool show_index,
+    const char* title,
     void (*continue_on_last_cb)(void),
     void (*cancel_cb)(void),
     component_t* parent);

--- a/src/ui/event_handler.c
+++ b/src/ui/event_handler.c
@@ -19,12 +19,13 @@
 
 static void _handle_event(component_t* component, const event_t* event)
 {
-    if (!component) {
+    if (!component || component->disabled) {
         return;
     }
     uint8_t num_components = component->sub_components.amount;
     for (int i = 0; i < num_components; i++) {
-        _handle_event(component->sub_components.sub_components[i], event);
+        component_t* comp = component->sub_components.sub_components[i];
+        _handle_event(comp, event);
     }
     if (component->f->on_event) {
         component->f->on_event(event, component);

--- a/src/ui/ui_util.c
+++ b/src/ui/ui_util.c
@@ -42,8 +42,10 @@ void ui_util_add_sub_component(component_t* parent, component_t* child)
 void ui_util_component_render_subcomponents(component_t* component)
 {
     for (int i = 0; i < component->sub_components.amount; i++) {
-        component->sub_components.sub_components[i]->f->render(
-            component->sub_components.sub_components[i]);
+        component_t* comp = component->sub_components.sub_components[i];
+        if (!comp->disabled) {
+            comp->f->render(comp);
+        }
     }
 }
 

--- a/src/workflow/show_mnemonic.c
+++ b/src/workflow/show_mnemonic.c
@@ -119,7 +119,7 @@ static bool _show_words(const char** words, uint8_t words_count)
     return workflow_cancel_run(
         _cancel_confirm_title,
         scroll_through_all_variants_create(
-            words, NULL, words_count, true, workflow_blocking_unblock, workflow_cancel, NULL));
+            words, NULL, words_count, NULL, workflow_blocking_unblock, workflow_cancel, NULL));
 }
 
 typedef struct {

--- a/test/device-test/src/test_all_variants_menu.c
+++ b/test/device-test/src/test_all_variants_menu.c
@@ -47,7 +47,7 @@ int main(void)
 
     const char* words[] = {"one", "two", "three", "four", "five", "six", "seven"};
     component_t* test_scroll_through_all_variants =
-        scroll_through_all_variants_create(words, NULL, 7, true, NULL, _cancel, NULL);
+        scroll_through_all_variants_create(words, NULL, 7, NULL, NULL, _cancel, NULL);
 
     ui_screen_stack_push(test_scroll_through_all_variants);
     firmware_main_loop();

--- a/test/device-test/src/test_scroll_menu_2.c
+++ b/test/device-test/src/test_scroll_menu_2.c
@@ -50,7 +50,7 @@ int main(void)
 
     const char* words[] = {"first", "second", "third", "forth"};
     component_t* test_scroll_through_2 =
-        scroll_through_all_variants_create(words, NULL, 4, true, NULL, NULL, NULL);
+        scroll_through_all_variants_create(words, NULL, 4, NULL, NULL, NULL, NULL);
 
     ui_screen_stack_push(test_scroll_through_2);
     firmware_main_loop();

--- a/test/device-test/src/test_simple_slide.c
+++ b/test/device-test/src/test_simple_slide.c
@@ -49,6 +49,8 @@ typedef struct {
 
 static void test_slide_on_event(const event_t* event, component_t* component)
 {
+    (void)event;
+    (void)component;
     // test_slide_data_t* data = (test_slide_data_t*)component->data;
     // gestures_slider_data_t* event_data = (gestures_slider_data_t*)event->data;
     // if (event_data->direction == FORWARD) {


### PR DESCRIPTION
UI  improvements for scroll_through_all_variants.

Don't show the forward/back arrows of scroll_through_all_variants
when the first or last option is being shown. Also, replace the "Cancel" text with a cross icon.

Still not sure about 9aa605f, hence the WIP.

Edit: 9aa605f got removed, as it's only needed for future work.