### PR TITLE
queue.c: Add synchronization primitives.

### DIFF
--- a/src/queue.c
+++ b/src/queue.c
@@ -16,7 +16,15 @@
 #include <string.h>
 #include <util.h>
 
+#ifndef TESTING
+#include <hal_atomic.h>
+#else
+#define CRITICAL_SECTION_ENTER()
+#define CRITICAL_SECTION_LEAVE()
+#endif
+
 #include "hardfault.h"
+
 // TODO: get rid of this dependency when USB_DATA_MAX_LEN/USB_REPORT_SIZE is
 // removed.
 #include "usb/usb_frame.h"
@@ -34,13 +42,26 @@ struct queue {
     uint8_t items[QUEUE_SIZE];
 };
 
-void queue_clear(struct queue* ctx)
+/**
+ * Thread-unsafe version of queue_clear.
+ */
+static void _queue_clear_sync(struct queue* ctx)
 {
     util_zero(ctx->items, sizeof(ctx->items));
     ctx->start = ctx->end = 0;
 }
 
-void queue_init(struct queue* ctx, size_t item_size)
+void queue_clear(struct queue* ctx)
+{
+    CRITICAL_SECTION_ENTER();
+    _queue_clear_sync(ctx);
+    CRITICAL_SECTION_LEAVE();
+}
+
+/**
+ * Thread-unsafe version of queue_init.
+ */
+static void _queue_init_sync(struct queue* ctx, size_t item_size)
 {
     ctx->item_size = item_size;
     /*
@@ -53,7 +74,17 @@ void queue_init(struct queue* ctx, size_t item_size)
     queue_clear(ctx);
 }
 
-const uint8_t* queue_pull(struct queue* ctx)
+void queue_init(struct queue* ctx, size_t item_size)
+{
+    CRITICAL_SECTION_ENTER();
+    _queue_init_sync(ctx, item_size);
+    CRITICAL_SECTION_LEAVE();
+}
+
+/**
+ * Thread-unsafe version of queue_pull.
+ */
+static const uint8_t* _queue_pull_sync(struct queue* ctx)
 {
     uint32_t p = ctx->start;
     if (p == ctx->end) {
@@ -64,7 +95,19 @@ const uint8_t* queue_pull(struct queue* ctx)
     return ctx->items + p;
 }
 
-queue_error_t queue_push(struct queue* ctx, const uint8_t* data)
+const uint8_t* queue_pull(struct queue* ctx)
+{
+    const uint8_t* result;
+    CRITICAL_SECTION_ENTER();
+    result = _queue_pull_sync(ctx);
+    CRITICAL_SECTION_LEAVE();
+    return result;
+}
+
+/**
+ * Thread-unsafe version of queue_push.
+ */
+static queue_error_t _queue_push_sync(struct queue* ctx, const uint8_t* data)
 {
     uint32_t next = (ctx->end + ctx->item_size) % QUEUE_SIZE;
     if (ctx->start == next) {
@@ -75,7 +118,19 @@ queue_error_t queue_push(struct queue* ctx, const uint8_t* data)
     return QUEUE_ERR_NONE;
 }
 
-const uint8_t* queue_peek(struct queue* ctx)
+queue_error_t queue_push(struct queue* ctx, const uint8_t* data)
+{
+    queue_error_t result;
+    CRITICAL_SECTION_ENTER();
+    result = _queue_push_sync(ctx, data);
+    CRITICAL_SECTION_LEAVE();
+    return result;
+}
+
+/**
+ * Thread-unsafe version of queue_peek.
+ */
+static const uint8_t* _queue_peek_sync(struct queue* ctx)
 {
     uint32_t p = ctx->start;
     if (p == ctx->end) {
@@ -83,6 +138,15 @@ const uint8_t* queue_peek(struct queue* ctx)
         return NULL;
     }
     return ctx->items + p;
+}
+
+const uint8_t* queue_peek(struct queue* ctx)
+{
+    const uint8_t* result;
+    CRITICAL_SECTION_ENTER();
+    result = _queue_peek_sync(ctx);
+    CRITICAL_SECTION_LEAVE();
+    return result;
 }
 
 struct queue* queue_hww_queue(void)


### PR DESCRIPTION
The queue_pull and queue_clear functions can suffer for a race condition that makes the HWW queue evaluate incorrectly the number of packets available for output. Namely, queue_clear being invoked from interrupt space after queue_pull has read the start point of the queue but before
it's read the end point makes the comparison for an empty queue (`start == end`) lose data.

Add synchronization primitives (from hal_atomic.h) to disable interrupts when queue manipulation is invoked, so that both interrupt code and user code is executed atomically.