### PR TITLE
Noise encapsulation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,9 +85,9 @@ endif()
 #
 # Versions MUST contain three parts and start with lowercase 'v'.
 # Example 'v1.0.0'. They MUST not contain a pre-release label such as '-beta'.
-set(FIRMWARE_VERSION "v6.0.0")
-set(FIRMWARE_BTC_ONLY_VERSION "v6.0.0")
-set(FIRMWARE_BITBOXBASE_VERSION "v6.0.0")
+set(FIRMWARE_VERSION "v7.0.0")
+set(FIRMWARE_BTC_ONLY_VERSION "v7.0.0")
+set(FIRMWARE_BITBOXBASE_VERSION "v7.0.0")
 set(BOOTLOADER_VERSION "v1.0.2")
 
 find_package(PythonInterp 3.6 REQUIRED)

--- a/py/bitbox02/bitbox02/communication/bitbox_api_protocol.py
+++ b/py/bitbox02/bitbox02/communication/bitbox_api_protocol.py
@@ -113,6 +113,7 @@ OP_ATTESTATION = b"a"
 OP_UNLOCK = b"u"
 OP_INFO = b"i"
 OP_I_CAN_HAS_HANDSHAEK = b"h"
+OP_HER_COMEZ_TEH_HANDSHAEK = b"H"
 OP_I_CAN_HAS_PAIRIN_VERIFICASHUN = b"v"
 OP_NOISE_MSG = b"n"
 
@@ -233,6 +234,15 @@ class BitBoxProtocol(ABC):
         """ Encapsulates an OP_NOISE_MSG message. """
         ...
 
+    @abstractmethod
+    def _handshake_query(self, req: bytes) -> Tuple[bytes, bytes]:
+        """
+        Executes a OP_HER_COMEZ_TEH_HANDSHAEK query with the given
+        request data.
+        Returns a pair (response status, response data).
+        """
+        ...
+
     def encrypted_query(self, msg: bytes) -> bytes:
         """
         Sends msg bytes and reads response bytes over an encrypted channel.
@@ -261,13 +271,20 @@ class BitBoxProtocol(ABC):
         noise.set_keypair_from_private_bytes(Keypair.STATIC, private_key)
         noise.set_prologue(b"Noise_XX_25519_ChaChaPoly_SHA256")
         noise.start_handshake()
-        noise.read_message(self._raw_query(noise.write_message()))
+        start_handshake_status, start_handshake_reply = self._handshake_query(noise.write_message())
+        if start_handshake_status != RESPONSE_SUCCESS:
+            self.close()
+            raise Exception("Handshake process request failed.")
+        noise.read_message(start_handshake_reply)
         remote_static_key = noise.noise_protocol.handshake_state.rs.public_bytes
         assert not noise.handshake_finished
         send_msg = noise.write_message()
         assert noise.handshake_finished
         pairing_code = base64.b32encode(noise.get_handshake_hash()).decode("ascii")
-        response = self._raw_query(send_msg)
+        handshake_finish_status, response = self._handshake_query(send_msg)
+        if handshake_finish_status != RESPONSE_SUCCESS:
+            self.close()
+            raise Exception("Handshake conclusion failed.")
 
         # Check if we recognize the device's public key
         pairing_verification_required_by_host = True
@@ -320,6 +337,14 @@ class BitBoxProtocolV1(BitBoxProtocol):
     def _encode_noise_request(self, encrypted_msg: bytes) -> bytes:
         return encrypted_msg
 
+    def _handshake_query(self, req: bytes) -> Tuple[bytes, bytes]:
+        """
+        V1-6 of the BB noise protocol doesn't encapsulate handshake requests, and don't
+        send back a status code in the response.
+        """
+        noise_result = self._raw_query(req)
+        return RESPONSE_SUCCESS, noise_result
+
 
 class BitBoxProtocolV2(BitBoxProtocolV1):
     """ BitBox Protocol from firmware V2.0.0 onwards. """
@@ -347,6 +372,13 @@ class BitBoxProtocolV4(BitBoxProtocolV3):
 
     def _encode_noise_request(self, encrypted_msg: bytes) -> bytes:
         return OP_NOISE_MSG + encrypted_msg
+
+
+class BitBoxProtocolV7(BitBoxProtocolV4):
+    """ Noise Protocol from firmware V7.0.0 onwards. """
+
+    def _handshake_query(self, req: bytes) -> Tuple[bytes, bytes]:
+        return self.query(OP_HER_COMEZ_TEH_HANDSHAEK, req)
 
 
 class BitBoxCommonAPI:
@@ -382,7 +414,9 @@ class BitBoxCommonAPI:
             self.version.major, self.version.minor, self.version.patch, build=self.version.build
         )
         self._bitbox_protocol: BitBoxProtocol
-        if self.version >= semver.VersionInfo(4, 0, 0):
+        if self.version >= semver.VersionInfo(7, 0, 0):
+            self._bitbox_protocol = BitBoxProtocolV7(transport)
+        elif self.version >= semver.VersionInfo(4, 0, 0):
             self._bitbox_protocol = BitBoxProtocolV4(transport)
         elif self.version >= semver.VersionInfo(3, 0, 0):
             self._bitbox_protocol = BitBoxProtocolV3(transport)

--- a/src/usb/noise.c
+++ b/src/usb/noise.c
@@ -248,8 +248,9 @@ bool bb_noise_process_msg(
         out_packet->data_addr[0] = OP_STATUS_FAILURE;
         return false;
     }
+    const uint8_t cmd = in_packet->data_addr[0];
     // If this is a handshake init message, start the handshake.
-    if (in_packet->data_addr[0] == OP_I_CAN_HAS_HANDSHAKE) {
+    if (cmd == OP_I_CAN_HAS_HANDSHAKE) {
         if (!_setup_and_init_handshake()) {
             return false;
         }
@@ -271,7 +272,7 @@ bool bb_noise_process_msg(
     }
     { // After the handshake we can perform the out of band pairing verification, if required by the
       // device or requested by the host app.
-        if (in_packet->data_addr[0] == OP_I_CAN_HAS_PAIRIN_VERIFICASHUN) {
+        if (cmd == OP_I_CAN_HAS_PAIRIN_VERIFICASHUN) {
 #if PLATFORM_BITBOX02 == 1
             bool result = workflow_pairing_create(_handshake_hash);
 #elif PLATFORM_BITBOXBASE == 1
@@ -305,7 +306,7 @@ bool bb_noise_process_msg(
             return true;
         }
     }
-    if (in_packet->data_addr[0] == OP_NOISE_MSG) {
+    if (cmd == OP_NOISE_MSG) {
         // Otherwise decrypt, process, encrypt.
         NoiseBuffer noise_buffer;
 #pragma GCC diagnostic push


### PR DESCRIPTION
Add encapsulation to Noise handshake requests and OP_NOISE_MSG responses. This fixes a long standing bug that makes handshakes fail occasionally, and allows errors to be reported in a coherent way on the HWW stack.

