### PR TITLE
py: fix max version check

### DIFF
--- a/py/bitbox02/bitbox02/communication/bitbox_api_protocol.py
+++ b/py/bitbox02/bitbox02/communication/bitbox_api_protocol.py
@@ -373,14 +373,15 @@ class BitBoxCommonAPI:
             transport.close()
             raise ValueError(f"Could not parse version from {serial_number}")
 
-        # raises exceptions if the library is out of date, does not check BitBoxBase
-        self._check_max_version()
-
         # Delete the prelease part, as it messes with the comparison (e.g. 3.0.0-pre < 3.0.0 is
         # True, but the 3.0.0-pre has already the same API breaking changes like 3.0.0...).
         self.version = semver.VersionInfo(
             self.version.major, self.version.minor, self.version.patch, build=self.version.build
         )
+
+        # raises exceptions if the library is out of date, does not check BitBoxBase
+        self._check_max_version()
+
         self._bitbox_protocol: BitBoxProtocol
         if self.version >= semver.VersionInfo(4, 0, 0):
             self._bitbox_protocol = BitBoxProtocolV4(transport)


### PR DESCRIPTION
Minor potential issue in pre-release versions; use self.version after
it is fully initialized.