### PR TITLE
eth: make keypath check less restrictive (allow testnet)

### DIFF
--- a/src/apps/eth/eth_common.c
+++ b/src/apps/eth/eth_common.c
@@ -37,7 +37,8 @@ bool eth_common_is_valid_keypath_xpub(ETHCoin coin, const uint32_t* keypath, siz
     if (keypath[0] != 44 + BIP32_INITIAL_HARDENED_CHILD) {
         return false;
     }
-    if (keypath[1] != params->bip44_coin) {
+    if (keypath[1] != 60 + BIP32_INITIAL_HARDENED_CHILD &&
+        keypath[1] != 1 + BIP32_INITIAL_HARDENED_CHILD) {
         return false;
     }
     if (keypath[2] != 0 + BIP32_INITIAL_HARDENED_CHILD) {
@@ -61,7 +62,8 @@ bool eth_common_is_valid_keypath_address(ETHCoin coin, const uint32_t* keypath, 
     if (keypath[0] != 44 + BIP32_INITIAL_HARDENED_CHILD) {
         return false;
     }
-    if (keypath[1] != params->bip44_coin) {
+    if (keypath[1] != 60 + BIP32_INITIAL_HARDENED_CHILD &&
+        keypath[1] != 1 + BIP32_INITIAL_HARDENED_CHILD) {
         return false;
     }
     if (keypath[2] != 0 + BIP32_INITIAL_HARDENED_CHILD) {

--- a/src/apps/eth/eth_common.h
+++ b/src/apps/eth/eth_common.h
@@ -40,7 +40,7 @@ USE_RESULT bool eth_common_is_valid_keypath_address(
 
 /**
  * Does limit checks the keypath, whitelisting bip44 purpose, account and change.
- * Only allows the well-known xpub of m'/44'/60'/0'/0 for now.
+ * Allow m'/44'/60'/0'/0 for mainnet and  m'/44'/1'/0'/0 for testnet (Ropsten + Rinkeby)
  * Since ethereum doesn't use the "change" path part it is always 0 and have become part of the
  * xpub keypath.
  * @return true if the keypath is valid, false if it is invalid.


### PR DESCRIPTION
When @NickeZ made the change to allow keypath length of 4 for getting the xpub, he also whitelisted only the `m'/44'/60'/0'/0` path.
To allow getting the xpub and address for our currently supported testnets (ropsten and rinkeby), we also need the `m'/44'/1'/0'/0` path