### PR TITLE
Keystore: Use keystore to get xpub with simple xpub version bytes

### DIFF
--- a/src/apps/btc/btc.c
+++ b/src/apps/btc/btc.c
@@ -26,9 +26,6 @@
 #include <workflow/status.h>
 #include <workflow/verify_pub.h>
 
-#define ELECTRUM_WALLET_ENCRYPTION_KEYPATH_LEVEL_ONE (4541509 + BIP32_INITIAL_HARDENED_CHILD)
-#define ELECTRUM_WALLET_ENCRYPTION_KEYPATH_LEVEL_TWO (1112098098 + BIP32_INITIAL_HARDENED_CHILD)
-
 bool app_btc_xpub(
     BTCCoin coin,
     BTCPubRequest_XPubType xpub_type,
@@ -50,27 +47,6 @@ bool app_btc_xpub(
         return false;
     }
     return btc_common_encode_xpub(&derived_xpub, xpub_type, out, out_len);
-}
-
-bool app_btc_electrum_encryption_key(
-    const uint32_t* keypath,
-    size_t keypath_len,
-    char* out,
-    size_t out_len)
-{
-    if (keypath_len != 2) {
-        return false;
-    }
-    if (keypath[0] != ELECTRUM_WALLET_ENCRYPTION_KEYPATH_LEVEL_ONE ||
-        keypath[1] != ELECTRUM_WALLET_ENCRYPTION_KEYPATH_LEVEL_TWO) {
-        return false;
-    }
-
-    struct ext_key derived_xpub __attribute__((__cleanup__(keystore_zero_xkey))) = {0};
-    if (!keystore_get_xpub(keypath, keypath_len, &derived_xpub)) {
-        return false;
-    }
-    return btc_common_encode_xpub(&derived_xpub, BTCPubRequest_XPubType_XPUB, out, out_len);
 }
 
 bool app_btc_address_simple(

--- a/src/apps/btc/btc.h
+++ b/src/apps/btc/btc.h
@@ -50,19 +50,6 @@ USE_RESULT bool app_btc_xpub(
     size_t out_len);
 
 /**
- * Returns the electrum wallet encryption xpub.
- * @param[in] keypath its value currently needs to be m/4541509'/1112098098'
- * @param[in] keypath_len number of keypath elements.
- * @param[out] out will hold the xpub.
- * @param[in] out_len size of out.
- */
-bool app_btc_electrum_encryption_key(
-    const uint32_t* keypath,
-    size_t keypath_len,
-    char* out,
-    size_t out_len);
-
-/**
  * Creates an address from a public key at a given keypath.
  * @param[in] coin Coin to generate address for.
  * @param[in] script_config script configuration, which determines the address.

--- a/src/apps/eth/eth.c
+++ b/src/apps/eth/eth.c
@@ -14,7 +14,6 @@
 
 #include "eth.h"
 #include "eth_common.h"
-#include <apps/btc/btc_common.h>
 
 #include <keystore.h>
 
@@ -69,7 +68,7 @@ bool app_eth_address(
         if (!keystore_get_xpub(keypath, keypath_len, &derived_xpub)) {
             return false;
         }
-        return btc_common_encode_xpub(&derived_xpub, BTCPubRequest_XPubType_XPUB, out, out_len);
+        return keystore_encode_xpub(&derived_xpub, out, out_len);
     }
     default:
         return false;

--- a/src/commander/commander.c
+++ b/src/commander/commander.c
@@ -57,8 +57,6 @@
 #include <pb_decode.h>
 #include <pb_encode.h>
 
-#include <apps/btc/btc.h>
-
 #define X(a, b, c) b,
 static const int32_t _error_code[] = {COMMANDER_ERROR_TABLE};
 #undef X
@@ -217,7 +215,7 @@ static commander_error_t _api_electrum_encryption_key(
     const ElectrumEncryptionKeyRequest* request,
     ElectrumEncryptionKeyResponse* response)
 {
-    if (!app_btc_electrum_encryption_key(
+    if (!keystore_electrum_encryption_key(
             request->keypath, request->keypath_count, response->key, sizeof(response->key))) {
         return COMMANDER_ERR_INVALID_INPUT;
     }

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -147,6 +147,30 @@ USE_RESULT bool keystore_get_xpub(
     struct ext_key* hdkey_neutered_out);
 
 /**
+ * Encode an xpub as a base58 string. For xpubs that need special version bytes, use
+ * btc_common_encode_xpub
+ * @param[in] derived_xpub the xpub to encode.
+ * @param[out] out resulting string, must be at least of size `XPUB_ENCODED_LEN` (including the null
+ * terminator).
+ * @param[in] out_len size of `out`.
+ * @return false on failure, true on success.
+ */
+bool keystore_encode_xpub(const struct ext_key* derived_xpub, char* out, size_t out_len);
+
+/**
+ * Returns the electrum wallet encryption xpub.
+ * @param[in] keypath its value currently needs to be m/4541509'/1112098098'
+ * @param[in] keypath_len number of keypath elements.
+ * @param[out] out will hold the xpub.
+ * @param[in] out_len size of out.
+ */
+bool keystore_electrum_encryption_key(
+    const uint32_t* keypath,
+    size_t keypath_len,
+    char* out,
+    size_t out_len);
+
+/**
  * Safely destroy a xpub or xprv.
  */
 void keystore_zero_xkey(struct ext_key* xkey);

--- a/test/unit-test/test_app_btc.c
+++ b/test/unit-test/test_app_btc.c
@@ -261,46 +261,6 @@ static void _test_app_btc_xpub(void** state)
     }
 }
 
-static void _test_app_btc_electrum_encryption_key(void** satte)
-{
-#define ELECTRUM_WALLET_ENCRYPTION_KEYPATH_LEVEL_ONE (4541509 + BIP32_INITIAL_HARDENED_CHILD)
-#define ELECTRUM_WALLET_ENCRYPTION_KEYPATH_LEVEL_TWO (1112098098 + BIP32_INITIAL_HARDENED_CHILD)
-
-    uint32_t keypath[2] = {ELECTRUM_WALLET_ENCRYPTION_KEYPATH_LEVEL_ONE,
-                           ELECTRUM_WALLET_ENCRYPTION_KEYPATH_LEVEL_TWO};
-
-    char out[XPUB_ENCODED_LEN] = {0};
-    expect_memory(__wrap_keystore_get_xpub, keypath, keypath, 2);
-    expect_value(__wrap_keystore_get_xpub, keypath_len, sizeof(keypath) / sizeof(uint32_t));
-    will_return(__wrap_keystore_get_xpub, true);
-
-    expect_value(__wrap_btc_common_encode_xpub, out_len, sizeof(out));
-    will_return(__wrap_btc_common_encode_xpub, true);
-
-    bool result = app_btc_electrum_encryption_key(
-        keypath, sizeof(keypath) / sizeof(uint32_t), out, sizeof(out));
-    assert_true(result);
-    assert_string_equal(
-        out,
-        "xpub661MyMwAqRbcGEcQZ28iRtgTzt7XrU6vhnLA8N6gCaosif31P7ZgTvsWsHfwH2HdKFayQhduuNE9A4uRWeqdPZ"
-        "ukYPmV7KHQY2VpRNV7PiJ");
-
-    uint32_t keypath_invalid[2] = {ELECTRUM_WALLET_ENCRYPTION_KEYPATH_LEVEL_ONE, 0};
-    result = app_btc_electrum_encryption_key(
-        keypath_invalid, sizeof(keypath_invalid) / sizeof(uint32_t), out, sizeof(out));
-    assert_false(result);
-
-    uint32_t keypath_invalid2[2] = {0, ELECTRUM_WALLET_ENCRYPTION_KEYPATH_LEVEL_TWO};
-    result = app_btc_electrum_encryption_key(
-        keypath_invalid, sizeof(keypath_invalid2) / sizeof(uint32_t), out, sizeof(out));
-    assert_false(result);
-
-    uint32_t keypath_invalid3[1];
-    result = app_btc_electrum_encryption_key(
-        keypath_invalid2, sizeof(keypath_invalid3) / sizeof(uint32_t), out, sizeof(out));
-    assert_false(result);
-}
-
 static void _test_app_btc_address_simple(void** state)
 {
     { // invalid coin
@@ -358,7 +318,6 @@ int main(void)
 {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(_test_app_btc_xpub),
-        cmocka_unit_test(_test_app_btc_electrum_encryption_key),
         cmocka_unit_test(_test_app_btc_address_simple),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
The ethereum app had to call code in the bitcoin app to get a serialized xpub with the normal "xpub" version bytes. This breaks the app isolation in the code. The ethereum xpub call just requires the simple xpub, without version tweaks, so this can be handled in a separate function in keystore.c . Also change this for the electrum encryption key function, which now also serializes the xpub directly in keystore.c .