### PR TITLE
blocking.c: Remove unused workflow_force_unlock() calls.

### DIFF
--- a/src/workflow/blocking.c
+++ b/src/workflow/blocking.c
@@ -6,17 +6,11 @@
 #include <ui/workflow_stack.h>
 #include <workflow/workflow.h>
 
-typedef enum {
-    BLOCKED,
-    UNBLOCKED_NORMAL,
-    UNBLOCKED_FORCED,
-} _done_t;
-
-static _done_t _done = UNBLOCKED_NORMAL;
+static bool _done = true;
 
 static bool _is_done(void)
 {
-    return _done != BLOCKED;
+    return _done;
 }
 
 /**
@@ -40,22 +34,16 @@ static void _run_blocking_ui(bool (*is_done)(void))
     }
 }
 
-bool workflow_blocking_block(void)
+void workflow_blocking_block(void)
 {
-    if (!_is_done()) {
+    if (!_done) {
         Abort("workflow_blocking_block");
     }
-    _done = BLOCKED;
+    _done = false;
     _run_blocking_ui(_is_done);
-    return _done == UNBLOCKED_NORMAL;
 }
 
 void workflow_blocking_unblock(void)
 {
-    _done = UNBLOCKED_NORMAL;
-}
-
-void workflow_blocking_unblock_force(void)
-{
-    _done = UNBLOCKED_FORCED;
+    _done = true;
 }

--- a/src/workflow/blocking.h
+++ b/src/workflow/blocking.h
@@ -21,23 +21,15 @@
 #include <stdint.h>
 
 /**
- * Start a blocking workflow. Call workflow_blocking_end() to unblock this call.
+ * Start a blocking workflow. Call workflow_blocking_unblock() to unblock this call.
  * This function aborts if there is already a blocking workflow running.
- * @return false if the workflow was forcibly unlocked
  */
-USE_RESULT bool workflow_blocking_block(void);
+void workflow_blocking_block(void);
 
 /**
  * Unblocks the workflow. Use this to terminate the worklow after the workflow finishes normally by
  * user interaction.
  */
 void workflow_blocking_unblock(void);
-
-/**
- * Unblocks the workflow forcibly. This is used to cancel the workflow without user interaction,
- * e.g. when a new host connects while a workflow is still lingering, or the the host app sends a
- * cancel message when shutting down.
- */
-void workflow_blocking_unblock_force(void);
 
 #endif

--- a/src/workflow/cancel.c
+++ b/src/workflow/cancel.c
@@ -21,11 +21,7 @@ bool workflow_cancel_run(const char* title, component_t* component)
     ui_screen_stack_push(component);
     while (true) {
         _cancel_pressed = false;
-        bool unblock_result = workflow_blocking_block();
-        if (!unblock_result) {
-            ui_screen_stack_pop();
-            return false;
-        }
+        workflow_blocking_block();
         if (_cancel_pressed) {
             const confirm_params_t params = {
                 .title = title,

--- a/src/workflow/confirm.c
+++ b/src/workflow/confirm.c
@@ -180,18 +180,14 @@ bool workflow_confirm_blocking(const confirm_params_t* params)
     bool _result;
     workflow_t* confirm_wf = workflow_confirm(params, _confirm_blocking_cb, &_result);
     workflow_stack_start_workflow(confirm_wf);
-    bool blocking_result = workflow_blocking_block();
-    if (!blocking_result) {
-        return false;
-    }
+    workflow_blocking_block();
     return _result;
 }
 
 bool workflow_confirm_scrollable_longtouch_blocking(
     const char* title,
     const char* body,
-    const UG_FONT* font,
-    bool* cancel_forced_out)
+    const UG_FONT* font)
 {
     bool _result = false;
     const confirm_params_t params = {
@@ -204,10 +200,6 @@ bool workflow_confirm_scrollable_longtouch_blocking(
 
     workflow_t* confirm_wf = workflow_confirm(&params, _confirm_blocking_cb, &_result);
     workflow_stack_start_workflow(confirm_wf);
-    bool blocking_result = workflow_blocking_block();
-    *cancel_forced_out = !blocking_result;
-    if (*cancel_forced_out) {
-        return false;
-    }
+    workflow_blocking_block();
     return _result;
 }

--- a/src/workflow/confirm.h
+++ b/src/workflow/confirm.h
@@ -77,6 +77,5 @@ bool workflow_confirm_blocking(const confirm_params_t* params);
 bool workflow_confirm_scrollable_longtouch_blocking(
     const char* title,
     const char* body,
-    const UG_FONT* font,
-    bool* cancel_forced_out);
+    const UG_FONT* font);
 #endif

--- a/src/workflow/password_enter.c
+++ b/src/workflow/password_enter.c
@@ -37,11 +37,8 @@ bool password_enter(const char* title, bool special_chars, char* password_out)
 {
     ui_screen_stack_push(
         trinary_input_string_create_password(title, special_chars, _pw_entered, NULL));
-    bool result = workflow_blocking_block();
+    workflow_blocking_block();
     ui_screen_stack_pop();
-    if (!result) {
-        return false;
-    }
     snprintf(password_out, SET_PASSWORD_MAX_PASSWORD_LENGTH, "%s", _password);
     util_zero(_password, sizeof(_password));
     return true;

--- a/src/workflow/restore_from_mnemonic.c
+++ b/src/workflow/restore_from_mnemonic.c
@@ -50,11 +50,11 @@ static void _number_of_words_picked(component_t* trinary_choice, trinary_choice_
  * Workflow to pick how many words.
  * @param[out] number_of_words_out 12, 18 or 24.
  */
-static bool _pick_number_of_words(uint8_t* number_of_words_out)
+static void _pick_number_of_words(uint8_t* number_of_words_out)
 {
     ui_screen_stack_push(
         trinary_choice_create("How many words?", "12", "18", "24", _number_of_words_picked, NULL));
-    bool result = workflow_blocking_block();
+    workflow_blocking_block();
     ui_screen_stack_pop();
     switch (_number_of_words_choice) {
     case TRINARY_CHOICE_LEFT:
@@ -69,7 +69,6 @@ static bool _pick_number_of_words(uint8_t* number_of_words_out)
     default:
         Abort("restore_from_mnemonic: unreachable");
     }
-    return result;
 }
 
 static void _cleanup_wordlist(char*** wordlist)
@@ -107,9 +106,7 @@ static bool _get_mnemonic(char* mnemonic_out)
     }
 
     uint8_t num_words;
-    if (!_pick_number_of_words(&num_words)) {
-        return false;
-    }
+    _pick_number_of_words(&num_words);
     char num_words_success_msg[20];
     snprintf(num_words_success_msg, sizeof(num_words_success_msg), "Enter %d words", num_words);
     workflow_status_create(num_words_success_msg, true);

--- a/src/workflow/sdcard.c
+++ b/src/workflow/sdcard.c
@@ -46,9 +46,6 @@ void sdcard_handle(const InsertRemoveSDCardRequest* insert_remove_sdcard)
     }
 
     ui_screen_stack_push(screen);
-    bool blocking_result = workflow_blocking_block();
+    workflow_blocking_block();
     ui_screen_stack_pop();
-    if (!blocking_result) {
-        // No meaningful error handling here.
-    }
 }

--- a/src/workflow/status.c
+++ b/src/workflow/status.c
@@ -23,9 +23,6 @@ void workflow_status_create(const char* msg, bool status_success)
 {
     ui_screen_stack_push(
         status_create(msg, status_success, STATUS_DEFAULT_DELAY, workflow_blocking_unblock));
-    bool result = workflow_blocking_block();
+    workflow_blocking_block();
     ui_screen_stack_pop();
-    if (!result) {
-        // Ignore, not critical if status screen is removed in a cancel operation.
-    }
 }

--- a/src/workflow/unlock.c
+++ b/src/workflow/unlock.c
@@ -54,13 +54,9 @@ static bool _get_mnemonic_passphrase(char* passphrase_out)
         if (!workflow_confirm_blocking(&params)) {
             return false;
         }
-        bool cancel_forced = false;
         if (workflow_confirm_scrollable_longtouch_blocking(
-                "Confirm", passphrase_out, &font_password_11X12, &cancel_forced)) {
+                "Confirm", passphrase_out, &font_password_11X12)) {
             break;
-        }
-        if (cancel_forced) {
-            return false;
         }
         workflow_status_create("Please try again", false);
     }

--- a/src/workflow/verify_recipient.c
+++ b/src/workflow/verify_recipient.c
@@ -37,11 +37,8 @@ bool workflow_verify_recipient(const char* recipient, const char* amount)
 {
     _result = false;
     ui_screen_stack_push(confirm_transaction_address_create(amount, recipient, _confirm, _reject));
-    bool result = workflow_blocking_block();
+    workflow_blocking_block();
     ui_screen_stack_pop();
-    if (!result) {
-        return false;
-    }
     if (!_result) {
         workflow_status_create("Transaction\ncanceled", false);
     }

--- a/src/workflow/verify_total.c
+++ b/src/workflow/verify_total.c
@@ -37,11 +37,8 @@ bool workflow_verify_total(const char* total, const char* fee)
 {
     _result = false;
     ui_screen_stack_push(confirm_transaction_fee_create(total, fee, _confirm, _reject));
-    bool result = workflow_blocking_block();
+    workflow_blocking_block();
     ui_screen_stack_pop();
-    if (!result) {
-        return false;
-    }
     workflow_status_create(_result ? "Transaction\nconfirmed" : "Transaction\ncanceled", _result);
     return _result;
 }

--- a/test/unit-test/framework/mock_blocking.c
+++ b/test/unit-test/framework/mock_blocking.c
@@ -21,14 +21,13 @@
 
 static void (*_unblock_func)(void) = NULL;
 static bool _blocked = false;
-bool __wrap_workflow_blocking_block(void)
+void __wrap_workflow_blocking_block(void)
 {
     assert_false(_blocked);
     _blocked = true;
     if (_unblock_func != NULL) {
         _unblock_func();
     }
-    return mock();
 }
 
 void __wrap_workflow_blocking_unblock(void)

--- a/test/unit-test/test_workflow_blocking.c
+++ b/test/unit-test/test_workflow_blocking.c
@@ -21,16 +21,9 @@
 #include <workflow/blocking.h>
 #include <workflow/workflow.h>
 
-static bool _force_unblock = false;
-static bool _unblock = false;
-
 void __wrap_screen_process(void)
 {
-    if (_force_unblock) {
-        workflow_blocking_unblock_force();
-    } else if (_unblock) {
-        workflow_blocking_unblock();
-    }
+    workflow_blocking_unblock();
 }
 
 /**
@@ -51,21 +44,10 @@ static void _do_nothing_spin(workflow_t* self)
 
 static void _test_workflow_blocking(void** state)
 {
-    _force_unblock = false;
-    _unblock = true;
-
     workflow_t* dummy_workflow = workflow_allocate(_do_nothing, NULL, _do_nothing_spin, 0);
     expect_value(_do_nothing, self, (uintptr_t)dummy_workflow);
     workflow_stack_start_workflow(dummy_workflow);
-    assert_true(workflow_blocking_block());
-    workflow_stack_stop_workflow();
-
-    _force_unblock = true;
-    _unblock = false;
-    dummy_workflow = workflow_allocate(_do_nothing, NULL, _do_nothing_spin, 0);
-    expect_value(_do_nothing, self, (uintptr_t)dummy_workflow);
-    workflow_stack_start_workflow(dummy_workflow);
-    assert_false(workflow_blocking_block());
+    workflow_blocking_block();
     workflow_stack_stop_workflow();
 }
 

--- a/test/unit-test/test_workflow_cancel.c
+++ b/test/unit-test/test_workflow_cancel.c
@@ -55,7 +55,6 @@ static void _test_workflow_cancel(void** state)
     expect_value_count(__wrap_ui_screen_stack_push, component, &component, -1);
     { // go through without cancel with normal unblocking
         _unblock_func_first = workflow_blocking_unblock;
-        will_return(__wrap_workflow_blocking_block, true);
         // will_return(__wrap_workflow_confirm_blocking, true);
         assert_true(workflow_cancel_run("My Operation", &component));
         mock_screen_stack_assert_clean();
@@ -63,22 +62,14 @@ static void _test_workflow_cancel(void** state)
     { // pressing cancel, but declining the prompt to cancel
         _unblock_func_first = workflow_cancel;
         _unblock_func_second = workflow_blocking_unblock;
-        will_return(__wrap_workflow_blocking_block, true);
         will_return(__wrap_workflow_confirm_blocking, false);
-        will_return(__wrap_workflow_blocking_block, true);
 
         assert_true(workflow_cancel_run("My Operation", &component));
         mock_screen_stack_assert_clean();
     }
     { // pressing cancel, accepting cancel
         _unblock_func_first = workflow_cancel;
-        will_return(__wrap_workflow_blocking_block, true);
         will_return(__wrap_workflow_confirm_blocking, true);
-        assert_false(workflow_cancel_run("My Operation", &component));
-        mock_screen_stack_assert_clean();
-    }
-    { // block fails
-        will_return(__wrap_workflow_blocking_block, false);
         assert_false(workflow_cancel_run("My Operation", &component));
         mock_screen_stack_assert_clean();
     }

--- a/test/unit-test/test_workflow_status.c
+++ b/test/unit-test/test_workflow_status.c
@@ -43,9 +43,7 @@ static void _test_workflow_status(void** state)
 {
     for (int flags = 0; flags < 4; flags++) {
         const bool status = flags & 1;
-        const bool blocking_result = flags & 2;
 
-        will_return(__wrap_workflow_blocking_block, blocking_result);
         expect_value(__wrap_status_create, status_success, status);
         expect_value(__wrap_ui_screen_stack_push, component, &_component);
         workflow_status_create(_msg, status);


### PR DESCRIPTION
The possibility of forcefully unlocking a blocking workflow
is not used anywhere and adds additional complexity to the code.

Get rid of it.