### PR TITLE
rust: simplify CStrMut.AsMut

### DIFF
--- a/src/apps/eth/eth_sign_msg.c
+++ b/src/apps/eth/eth_sign_msg.c
@@ -21,6 +21,7 @@
 #include "eth.h"
 #include <hardfault.h>
 #include <keystore.h>
+#include <rust/rust.h>
 #include <util.h>
 #include <util/util_string.h>
 #include <workflow/confirm.h>
@@ -75,7 +76,8 @@ app_eth_sign_error_t app_eth_sign_msg(
     memcpy(&msg[payload_offset], request->msg.bytes, request->msg.size);
 
     // determine if the message is in ASCII
-    bool all_ascii = util_string_all_ascii_bytes(request->msg.bytes, request->msg.size);
+    bool all_ascii =
+        rust_util_all_ascii_bytes(rust_util_bytes(request->msg.bytes, request->msg.size));
 
     char body[sizeof(request->msg.bytes) * 2 + 1] = {0};
     confirm_params_t params = {

--- a/src/rust/bitbox02-rust-c/src/util.rs
+++ b/src/rust/bitbox02-rust-c/src/util.rs
@@ -24,12 +24,11 @@ pub extern "C" fn rust_util_all_ascii(cstr: CStr) -> bool {
 
 /// Convert bytes to hex representation
 ///
-/// * `buf_ptr` - Must be a valid pointer to an array of bytes
-/// * `buf_len` - Length of buffer, `buf_ptr[buf_len-1]` must be a valid dereference
-/// * `out_ptr` - Must be a valid pointer to an array of bytes that is buf_len*2+1 long
+/// * `buf` - bytes to convert to hex.
+/// * `out` - hex will be written here. out.len must be 2*buf.len+1.
 #[no_mangle]
 pub extern "C" fn rust_util_uint8_to_hex(buf: Bytes, mut out: CStrMut) {
-    // UNSAFE: We promise that we never write non-utf8 valid bytes to the `str`.
+    // UNSAFE: We promise that we null terminate the string.
     let out = unsafe { out.as_bytes_mut() };
     let out_len = out.len();
     hex::encode_to_slice(&buf, &mut out[0..out_len - 1]).unwrap();

--- a/src/rust/bitbox02-rust-c/src/util.rs
+++ b/src/rust/bitbox02-rust-c/src/util.rs
@@ -30,7 +30,7 @@ pub extern "C" fn rust_util_all_ascii(cstr: CStr) -> bool {
 #[no_mangle]
 pub extern "C" fn rust_util_uint8_to_hex(buf: Bytes, mut out: CStrMut) {
     // UNSAFE: We promise that we never write non-utf8 valid bytes to the `str`.
-    let out = out.as_mut();
+    let out = unsafe { out.as_bytes_mut() };
     let out_len = out.len();
     hex::encode_to_slice(&buf, &mut out[0..out_len - 1]).unwrap();
     out[out_len - 1] = b'\0';
@@ -125,17 +125,17 @@ impl AsRef<str> for CStrMut {
     }
 }
 
-impl AsMut<[u8]> for CStrMut {
+impl CStrMut {
     /// Create a slice to a buffer. Only allowed for non-null pointers with length or null pointers
     /// with 0 length due to limitation in `core::slice`.
     /// The caller must ensure that the string is null terminated.
-    fn as_mut(&mut self) -> &mut [u8] {
+    pub unsafe fn as_bytes_mut(&mut self) -> &mut [u8] {
         let mut buf = self.buf;
         if self.len == 0 && self.buf.is_null() {
             buf = core::ptr::NonNull::dangling().as_ptr();
         }
         assert!(!buf.is_null());
-        unsafe { core::slice::from_raw_parts_mut(buf, self.len) }
+        core::slice::from_raw_parts_mut(buf, self.len)
     }
 }
 

--- a/src/util/util_string.c
+++ b/src/util/util_string.c
@@ -19,16 +19,6 @@
 
 #include <string.h>
 
-bool util_string_all_ascii_bytes(const uint8_t* bytes, size_t bytes_len)
-{
-    return rust_util_all_ascii_bytes(rust_util_bytes(bytes, bytes_len));
-}
-
-bool util_string_all_ascii(const char* str)
-{
-    return rust_util_all_ascii(rust_util_cstr(str));
-}
-
 bool util_string_validate_name(const char* name, size_t max_len)
 {
     if (name == NULL) {
@@ -38,7 +28,7 @@ bool util_string_validate_name(const char* name, size_t max_len)
     if (len == 0 || len > max_len) {
         return false;
     }
-    if (!util_string_all_ascii(name)) {
+    if (!rust_util_all_ascii(rust_util_cstr(name))) {
         return false;
     }
     if (name[0] == ' ') {

--- a/src/util/util_string.h
+++ b/src/util/util_string.h
@@ -18,20 +18,6 @@
 #include <compiler_util.h>
 #include <stdbool.h>
 #include <stddef.h>
-#include <stdint.h>
-
-/*
- * Returns true if all bytes are in this set (including the space ' '):
- *  !"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~
- * Note that newline, tab, etc. are not part of this set.
- */
-USE_RESULT bool util_string_all_ascii_bytes(const uint8_t* bytes, size_t bytes_len);
-
-/*
- * Returns true if all chars in the string are ascii, as specified in the documentation of
- * `util_string_all_ascii_bytes`.
- */
-USE_RESULT bool util_string_all_ascii(const char* str);
 
 /**
  * Validate a user given name. The name must be smaller or equal to `max_len` and larger than 0 in

--- a/test/unit-test/test_util_string.c
+++ b/test/unit-test/test_util_string.c
@@ -25,17 +25,6 @@ static const char* _all_ascii =
     "! \"#$%&\'()*+,-./"
     "0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~";
 
-static void _test_util_string_all_ascii(void** state)
-{
-    // All ascii chars.
-    assert_true(util_string_all_ascii(_all_ascii));
-    // Edge cases: highest and lowest non ascii chars.
-    assert_false(util_string_all_ascii("\x7f"));
-    assert_false(util_string_all_ascii("\x19"));
-    assert_false(util_string_all_ascii("\n"));
-    assert_false(util_string_all_ascii("\t"));
-}
-
 static void _test_util_string_validate_name(void** state)
 {
     // Max len.
@@ -63,7 +52,6 @@ static void _test_util_string_validate_name(void** state)
 int main(void)
 {
     const struct CMUnitTest tests[] = {
-        cmocka_unit_test(_test_util_string_all_ascii),
         cmocka_unit_test(_test_util_string_validate_name),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
Should not be &str but &[u8].