### PR TITLE
Pairing

### DIFF
--- a/py/bitbox02/bitbox02/communication/bitbox_api_protocol.py
+++ b/py/bitbox02/bitbox02/communication/bitbox_api_protocol.py
@@ -329,16 +329,15 @@ class BitBoxProtocol(ABC):
         pairing_verification_required_by_device = response == b"\x01"
         if pairing_verification_required_by_host or pairing_verification_required_by_device:
             cid = self._transport.generate_cid()
-            self._transport.write(OP_I_CAN_HAS_PAIRIN_VERIFICASHUN, HWW_CMD, cid)
             client_response_success = noise_config.show_pairing(
                 "{} {}\n{} {}".format(
                     pairing_code[:5], pairing_code[5:10], pairing_code[10:15], pairing_code[15:20]
                 )
             )
+            pairing_response = self._raw_query(OP_I_CAN_HAS_PAIRIN_VERIFICASHUN)
             if not client_response_success:
                 self.close()
                 raise Exception("pairing rejected by the user on client")
-            pairing_response = self._transport.read(HWW_CMD, cid)
 
             if pairing_response == RESPONSE_SUCCESS:
                 pass

--- a/py/bitbox02/bitbox02/communication/bitbox_api_protocol.py
+++ b/py/bitbox02/bitbox02/communication/bitbox_api_protocol.py
@@ -21,7 +21,7 @@ import base64
 import binascii
 import hashlib
 import time
-from typing import Optional, List, Dict, Tuple, Union
+from typing import Callable, Optional, List, Dict, Tuple, Union
 from typing_extensions import TypedDict
 
 import ecdsa
@@ -210,8 +210,13 @@ class BitBoxNoiseConfig:
     """ Stores Functions required setup a noise connection """
 
     # pylint: disable=no-self-use,unused-argument
-    def show_pairing(self, code: str) -> bool:
-        return True
+    def show_pairing(self, code: str, device_response: Callable[[], bool]) -> bool:
+        """
+        Returns True if the user confirms the pairing (both device and host).
+        Returns False if the user rejects the pairing (either device or host).
+        This function must call device_response() to invoke the pairing screen on the device.
+        """
+        return device_response()
 
     def attestation_check(self, result: bool) -> None:
         return
@@ -328,25 +333,25 @@ class BitBoxProtocol(ABC):
 
         pairing_verification_required_by_device = response == b"\x01"
         if pairing_verification_required_by_host or pairing_verification_required_by_device:
-            cid = self._transport.generate_cid()
+
+            def get_device_response() -> bool:
+                device_response = self._raw_query(OP_I_CAN_HAS_PAIRIN_VERIFICASHUN)
+                if device_response == RESPONSE_SUCCESS:
+                    return True
+                if device_response == RESPONSE_FAILURE:
+                    return False
+                raise Exception(f"Unexpected pairing response: f{device_response}")
+
             client_response_success = noise_config.show_pairing(
                 "{} {}\n{} {}".format(
                     pairing_code[:5], pairing_code[5:10], pairing_code[10:15], pairing_code[15:20]
-                )
+                ),
+                get_device_response,
             )
-            pairing_response = self._raw_query(OP_I_CAN_HAS_PAIRIN_VERIFICASHUN)
             if not client_response_success:
                 self.close()
-                raise Exception("pairing rejected by the user on client")
-
-            if pairing_response == RESPONSE_SUCCESS:
-                pass
-            elif pairing_response == RESPONSE_FAILURE:
-                self.close()
                 raise Exception("pairing rejected by the user")
-            else:
-                self.close()
-                raise Exception("unexpected response")
+
             noise_config.add_device_static_pubkey(remote_static_key)
         return noise
 

--- a/py/load_firmware.py
+++ b/py/load_firmware.py
@@ -19,7 +19,7 @@ import enum
 import sys
 
 import pprint
-from typing import Any, Tuple
+from typing import Callable, Any, Tuple
 from time import sleep
 
 import hid
@@ -50,18 +50,18 @@ def _get_bitbox_and_reboot(use_cache: bool) -> devices.DeviceInfo:
         def __init__(self) -> None:
             super().__init__("shift/load_firmware")
 
-        def show_pairing(self, code: str) -> bool:
+        def show_pairing(self, code: str, device_response: Callable[[], bool]) -> bool:
             print("Please compare and confirm the pairing code on your BitBox02:")
             print(code)
-            return True
+            return device_response()
 
     class NoiseConfigNoCache(bitbox_api_protocol.BitBoxNoiseConfig):
         """NoiseConfig extends BitBoxNoiseConfig"""
 
-        def show_pairing(self, code: str) -> bool:
+        def show_pairing(self, code: str, device_response: Callable[[], bool]) -> bool:
             print("Please compare and confirm the pairing code on your BitBox02:")
             print(code)
-            return True
+            return device_response()
 
     if use_cache:
         config: bitbox_api_protocol.BitBoxNoiseConfig = NoiseConfig()
@@ -182,18 +182,18 @@ def _find_and_open_usart_bitbox(
         def __init__(self) -> None:
             super().__init__("shift/load_firmware")
 
-        def show_pairing(self, code: str) -> bool:
+        def show_pairing(self, code: str, device_response: Callable[[], bool]) -> bool:
             print("Please compare and confirm the pairing code on your BitBox02:")
             print(code)
-            return True
+            return device_response()
 
     class NoiseConfigNoCache(bitbox_api_protocol.BitBoxNoiseConfig):
         """NoiseConfig extends BitBoxNoiseConfig"""
 
-        def show_pairing(self, code: str) -> bool:
+        def show_pairing(self, code: str, device_response: Callable[[], bool]) -> bool:
             print("Please compare and confirm the pairing code on your BitBox02:")
             print(code)
-            return True
+            return device_response()
 
     if use_cache:
         config: bitbox_api_protocol.BitBoxNoiseConfig = NoiseConfig()

--- a/py/send_message.py
+++ b/py/send_message.py
@@ -730,16 +730,21 @@ def connect_to_usb_bitbox(debug: bool, use_cache: bool) -> int:
             return boot_app.run()
     else:
 
+        def show_pairing(code: str, device_response: Callable[[], bool]) -> bool:
+            print("Please compare and confirm the pairing code on your BitBox02:")
+            print(code)
+            if not device_response():
+                return False
+            return input("Accept pairing? [y]/n: ").strip() != "n"
+
         class NoiseConfig(util.NoiseConfigUserCache):
             """NoiseConfig extends NoiseConfigUserCache"""
 
             def __init__(self) -> None:
                 super().__init__("shift/send_message")
 
-            def show_pairing(self, code: str) -> bool:
-                print("Please compare and confirm the pairing code on your BitBox02:")
-                print(code)
-                return True
+            def show_pairing(self, code: str, device_response: Callable[[], bool]) -> bool:
+                return show_pairing(code, device_response)
 
             def attestation_check(self, result: bool) -> None:
                 if result:
@@ -750,10 +755,8 @@ def connect_to_usb_bitbox(debug: bool, use_cache: bool) -> int:
         class NoiseConfigNoCache(bitbox_api_protocol.BitBoxNoiseConfig):
             """NoiseConfig extends BitBoxNoiseConfig"""
 
-            def show_pairing(self, code: str) -> bool:
-                print("Please compare and confirm the pairing code on your BitBox02:")
-                print(code)
-                return True
+            def show_pairing(self, code: str, device_response: Callable[[], bool]) -> bool:
+                return show_pairing(code, device_response)
 
             def attestation_check(self, result: bool) -> None:
                 if result:
@@ -790,16 +793,19 @@ def connect_to_usart_bitboxbase(debug: bool, serial_port: usart.SerialPort, use_
     print("Trying to connect to BitBoxBase firmware...")
     bootloader_device: devices.DeviceInfo = get_bitboxbase_default_device(serial_port.port)
 
+    def show_pairing(code: str, device_response: Callable[[], bool]) -> bool:
+        print("(Pairing should be automatic) Pairing code:")
+        print(code)
+        return device_response()
+
     class NoiseConfig(util.NoiseConfigUserCache):
         """NoiseConfig extends NoiseConfigUserCache"""
 
         def __init__(self) -> None:
             super().__init__("shift/send_message")
 
-        def show_pairing(self, code: str) -> bool:
-            print("(Pairing should be automatic) Pairing code:")
-            print(code)
-            return True
+        def show_pairing(self, code: str, device_response: Callable[[], bool]) -> bool:
+            return show_pairing(code, device_response)
 
         def attestation_check(self, result: bool) -> None:
             if result:
@@ -810,10 +816,8 @@ def connect_to_usart_bitboxbase(debug: bool, serial_port: usart.SerialPort, use_
     class NoiseConfigNoCache(bitbox_api_protocol.BitBoxNoiseConfig):
         """NoiseConfig extends BitBoxNoiseConfig"""
 
-        def show_pairing(self, code: str) -> bool:
-            print("Please compare and confirm the pairing code on your BitBox02:")
-            print(code)
-            return True
+        def show_pairing(self, code: str, device_response: Callable[[], bool]) -> bool:
+            return show_pairing(code, device_response)
 
         def attestation_check(self, result: bool) -> None:
             if result:


### PR DESCRIPTION
This fixes the 'unexpected response' error we've been seeing on the v7.0.0 firmware.

In addition, the show_pairing flow now behaves the same as as in the bitboxapp/MEW:

1) Wallet shows pairing code, confirmation button is disabled/hidden
2) User confirms on device, which enables/shows the OK button on the wallet
3) User confirms on the host.

send_message.py now also implements this as a demo. Accepting is the default for least annoyance ;)