### PR TITLE
py/bitbox02: fix unlock call on uninitialized device

### DIFF
--- a/py/bitbox02/bitbox02/communication/bitbox_api_protocol.py
+++ b/py/bitbox02/bitbox02/communication/bitbox_api_protocol.py
@@ -421,7 +421,7 @@ class BitBoxProtocolV3(BitBoxProtocolV2):
         unlock_result, unlock_data = self.query(OP_UNLOCK, b"")
         if len(unlock_data) != 0:
             raise ValueError(f"OP_UNLOCK (V3) replied with wrong length.")
-        if unlock_result != RESPONSE_SUCCESS:
+        if unlock_result == RESPONSE_FAILURE:
             self.close()
             raise Exception("Unlock process aborted")
 


### PR DESCRIPTION
Regression from b698a92fee36708c6e73e54ad1ca35e972c969a7

The unlock call can also return UNINITIALIZED besides FAILURE and
SUCCESS.

```
-                # since 3.0.0, unlock can fail if cancelled
-                if unlock_result == RESPONSE_FAILURE:
-                    self.close()
-                    raise Exception("Unlock process aborted")
...
+        if unlock_result != RESPONSE_SUCCESS:
+            self.close()
+            raise Exception("Unlock process aborted")
+
```
