### PR TITLE
USB: Async workflow timeouts.

### DIFF
--- a/src/hww.c
+++ b/src/hww.c
@@ -253,9 +253,14 @@ void hww_blocked_req_error(Packet* out_packet, const Packet* in_packet)
     out_packet->data_addr[0] = HWW_RSP_BUSY;
 }
 
+void hww_abort_outstanding_op(void)
+{
+    Abort("Arbitration error, HWW should never block.");
+}
+
 void hww_process(void)
 {
-    /* Nothing to do here. */
+    /** Nothing to do. */
 }
 
 void hww_setup(void)

--- a/src/hww.h
+++ b/src/hww.h
@@ -51,4 +51,9 @@ void hww_blocked_req_error(Packet* out_packet, const Packet* in_packet);
  */
 void hww_process(void);
 
+/**
+ * Called to abort any operation that blocked the HWW stack.
+ */
+void hww_abort_outstanding_op(void);
+
 #endif

--- a/src/u2f.h
+++ b/src/u2f.h
@@ -43,4 +43,9 @@ void u2f_blocked_req_error(Packet* out_packet, const Packet* in_packet);
  */
 void u2f_process(void);
 
+/**
+ * Called to abort any operation that blocked the U2F stack.
+ */
+void u2f_abort_outstanding_op(void);
+
 #endif

--- a/src/u2f/u2f_app.h
+++ b/src/u2f/u2f_app.h
@@ -34,6 +34,9 @@ enum u2f_app_confirm_t {
 
 /**
  * User confirm auth/registration for a website given by the U2F app ID.
+ *
+ * FUTURE: transform this into a workflow.
+ *
  * @param[in] type show registration or authentication screen.
  * @param[in] app_id U2F app ID to identify the website.
  * @param[out] result true if the user accepts, false for rejection.
@@ -41,11 +44,21 @@ enum u2f_app_confirm_t {
  */
 void u2f_app_confirm_start(enum u2f_app_confirm_t type, const uint8_t* app_id);
 
+/**
+ * Polls an outstanding confirmation for completion.
+ *
+ * @param type  Type of confirmation. This is for sanity checks: it must match
+ *              the actual type of confirmation that is outstanding.
+ * @param app_id U2F AppId. This is for sanity checks: it must match
+ *              the actual AppId that is being confirmed.
+ */
 async_op_result_t u2f_app_confirm_retry(enum u2f_app_confirm_t type, const uint8_t* app_id);
 
 /**
- * Clears any outstanding confirmation.
+ * Clears any outstanding confirmation. Can only be called
+ * if there is a confirmation outstanding. Returns back immediately
+ * after aborting all open workflows related to this U2F confirm.
  */
-void u2f_app_confirm_finish(void);
+void u2f_app_confirm_abort(void);
 
 #endif

--- a/src/ui/workflow_stack.c
+++ b/src/ui/workflow_stack.c
@@ -68,6 +68,14 @@ void workflow_stack_stop_workflow(void)
     _workflow_stack_pop();
 }
 
+void workflow_stack_abort_workflow(workflow_t* wf)
+{
+    while (workflow_stack_top() != wf) {
+        workflow_stack_stop_workflow();
+    }
+    workflow_stack_stop_workflow();
+}
+
 void workflow_stack_clear(void)
 {
     while (_workflow_stack.size > 0) {

--- a/src/ui/workflow_stack.h
+++ b/src/ui/workflow_stack.h
@@ -23,7 +23,16 @@ workflow_t* workflow_stack_top(void);
 
 void workflow_stack_start_workflow(workflow_t* workflow);
 
+/**
+ * Stops the currently active workflow.
+ * This is only supposed to be called by the active workflow itself.
+ */
 void workflow_stack_stop_workflow(void);
+
+/**
+ * Forcefully closes the given workflow and any sub-workflow it has spawned.
+ */
+void workflow_stack_abort_workflow(workflow_t* wf);
 
 void workflow_stack_clear(void);
 

--- a/src/usb/usb_processing.h
+++ b/src/usb/usb_processing.h
@@ -68,6 +68,15 @@ void usb_processing_init(void);
 #if !defined(BOOTLOADER)
 void usb_processing_lock(struct usb_processing* ctx);
 
+/**
+ * Manually resets the USB lock watchdog.
+ * No traffic on the USB bus will make any locked operation
+ * timeout. However, if not receiving traffic is the
+ * expected behaviour, one can call this function to prevent
+ * the USB watchdog from aborting the outstanding operation.
+ */
+void usb_processing_timeout_reset(void);
+
 void usb_processing_unlock(void);
 #endif
 


### PR DESCRIPTION
When the USB stack is waiting for an asynchronous operation
to complete, a timer is started. If no traffic is received by the BB02
within 0.5s, the outstanding operation is forcefully aborted.