### PR TITLE
hww.c: Turn OP_UNLOCK into an asynchronous operation.

### DIFF
--- a/src/hww.c
+++ b/src/hww.c
@@ -218,6 +218,10 @@ static void _process_packet(const in_buffer_t* in_req, hww_packet_rsp_t* out_rsp
                 out_rsp->buffer.data[0] = OP_STATUS_FAILURE_UNINITIALIZED;
                 out_rsp->buffer.len = 1;
                 return;
+            } else if (!keystore_is_locked()) {
+                out_rsp->buffer.data[0] = OP_STATUS_SUCCESS;
+                out_rsp->buffer.len = 1;
+                return;
             } else {
                 _state.unlock_wf = workflow_unlock(&_unlock_finished_cb, NULL);
                 workflow_stack_start_workflow(_state.unlock_wf);

--- a/src/hww.c
+++ b/src/hww.c
@@ -243,7 +243,6 @@ static void _process_packet(const in_buffer_t* in_req, hww_packet_rsp_t* out_rsp
     if (!bb_noise_process_msg(in_req, &out_rsp->buffer, commander)) {
         workflow_status_blocking("Could not\npair with app", false);
     }
-    return;
 }
 
 /**


### PR DESCRIPTION
Make the OP_UNLOCK hww opcode start the unlock workflow asynchonously.
Support the retry/cancel flow during unlock.