### PR TITLE
clang-format: preserve include blocks when formatting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -12,6 +12,7 @@ BreakBeforeBraces: Linux
 IndentCaseLabels: false
 PenaltyReturnTypeOnItsOwnLine: 1000
 SpacesBeforeTrailingComments: 1
+IncludeBlocks: Preserve
 # cmocka must come after some std includes
 IncludeCategories:
   - Regex:           '^(<|")cmocka'


### PR DESCRIPTION
Without this change, some include blocks are merged together
making C code auto-formatting very annoying if not impossible.

See https://clang.llvm.org/docs/ClangFormatStyleOptions.html.