### PR TITLE
Remove async status workflow

### DIFF
--- a/src/reset.c
+++ b/src/reset.c
@@ -23,26 +23,6 @@
 #ifndef TESTING
 #include "securechip/securechip.h"
 #include <driver_init.h>
-#include <hal_delay.h>
-#include <ui/components/status.h>
-#include <ui/ugui/ugui.h>
-#endif
-
-#if !defined(TESTING)
-/*
- * Shows a centered "Device reset" label.
- * Waits for 3000ms, then exit.
- */
-static void _show_reset_label(bool status)
-{
-    const char* msg = "Device reset";
-    component_t* comp = status_create(msg, status, STATUS_DEFAULT_DELAY, NULL, NULL);
-    UG_ClearBuffer();
-    comp->f->render(comp);
-    UG_SendBuffer();
-    comp->f->cleanup(comp);
-    delay_ms(3000);
-}
 #endif
 
 void reset_reset(bool status)
@@ -64,9 +44,9 @@ void reset_reset(bool status)
 #if !defined(TESTING)
     /* Disable SmartEEPROM, so it will be erased on next reboot. */
     smarteeprom_disable();
-    _show_reset_label(status);
+#endif
+    workflow_status_blocking("Device reset", status);
+#if !defined(TESTING)
     _reset_mcu();
-#else
-    (void)status;
 #endif
 }

--- a/src/ui/components/status.c
+++ b/src/ui/components/status.c
@@ -23,10 +23,6 @@
 
 typedef struct {
     bool status;
-    int counter;
-    int delay;
-    void (*callback)(void*);
-    void* callback_param;
 } status_data_t;
 
 static void _render(component_t* component)
@@ -37,14 +33,6 @@ static void _render(component_t* component)
         image_checkmark(SCREEN_WIDTH / 6 * 5, SCREEN_HEIGHT / 2 - height / 2, height);
     } else {
         image_cross(SCREEN_WIDTH / 6 * 5, SCREEN_HEIGHT / 2 - height / 2, height);
-    }
-    if (data->callback != NULL) {
-        if (data->counter == data->delay) {
-            data->callback(data->callback_param);
-            data->callback = NULL;
-            data->counter = 0;
-        }
-        data->counter++;
     }
     ui_util_component_render_subcomponents(component);
 }
@@ -59,12 +47,7 @@ static const component_functions_t _component_functions = {
 
 /********************************** Create Instance **********************************/
 
-component_t* status_create(
-    const char* text,
-    bool status_success,
-    int delay,
-    void (*callback)(void*),
-    void* callback_param)
+component_t* status_create(const char* text, bool status_success)
 {
     component_t* status = malloc(sizeof(component_t));
     if (!status) {
@@ -78,9 +61,6 @@ component_t* status_create(
     memset(status, 0, sizeof(component_t));
 
     data->status = status_success;
-    data->delay = delay;
-    data->callback = callback;
-    data->callback_param = callback_param;
     status->data = data;
     status->f = &_component_functions;
     status->dimension.width = SCREEN_WIDTH;

--- a/src/ui/components/status.h
+++ b/src/ui/components/status.h
@@ -18,22 +18,13 @@
 #include <stdbool.h>
 #include <ui/component.h>
 
-#define STATUS_DEFAULT_DELAY 500 // counts
-
 /********************************** Create Instance **********************************/
 
 /**
  * Creates a status component with a given text. Calls the callback after delay.
  * @param[IN] text The text of the status screen.
  * @param[IN] status_success If true, indicates a success. Otherwise, false.
- * @param[IN] delay The time in counts that passes before the callback is called.
- * @param[IN] callback The callback that is called after <delay> time.
  */
-component_t* status_create(
-    const char* text,
-    bool status_success,
-    int delay,
-    void (*callback)(void*),
-    void* callback_param);
+component_t* status_create(const char* text, bool status_success);
 
 #endif

--- a/src/workflow/get_mnemonic_passphrase.c
+++ b/src/workflow/get_mnemonic_passphrase.c
@@ -112,7 +112,7 @@ static void _get_mnemonic_passphrase_spin(workflow_t* self)
         break;
     }
     case MNEMONIC_PASSPHRASE_TRY_AGAIN:
-        workflow_stack_start_workflow(workflow_status("Please try again", false, NULL, NULL));
+        workflow_status_blocking("Please try again", false);
         data->state = MNEMONIC_PASSPHRASE_PW_ENTER;
         break;
     case MNEMONIC_PASSPHRASE_FINISHED:

--- a/src/workflow/status.c
+++ b/src/workflow/status.c
@@ -25,7 +25,7 @@
  */
 void workflow_status_blocking(const char* msg, bool status_success)
 {
-    component_t* comp = status_create(msg, status_success, STATUS_DEFAULT_DELAY, NULL, NULL);
+    component_t* comp = status_create(msg, status_success);
     UG_ClearBuffer();
     comp->f->render(comp);
     UG_SendBuffer();

--- a/src/workflow/status.c
+++ b/src/workflow/status.c
@@ -14,75 +14,11 @@
 
 #include "status.h"
 
-#include "blocking.h"
-#include "workflow.h"
-
 #include <ui/components/status.h>
-#include <ui/screen_stack.h>
-#include <ui/workflow_stack.h>
 #include <ui/ugui/ugui.h>
-#include <util.h>
 #ifndef TESTING
 #include <hal_delay.h>
 #endif
-
-typedef struct {
-    char* msg;
-    bool status_success;
-    bool finished;
-    void (*callback)(void*);
-    void* callback_param;
-} data_t;
-
-/**
- * Invoked when the status expired.
- */
-static void _status_cb(void* param)
-{
-    data_t* data = (data_t*)param;
-    data->finished = true;
-}
-
-static void _workflow_status_init(workflow_t* self)
-{
-    data_t* data = (data_t*)self->data;
-    ui_screen_stack_push(
-        status_create(data->msg, data->status_success, STATUS_DEFAULT_DELAY, _status_cb, data));
-}
-
-static void _workflow_status_cleanup(workflow_t* self)
-{
-    data_t* data = (data_t*)self->data;
-    ui_screen_stack_pop();
-    free(data->msg);
-}
-
-static void _workflow_status_spin(workflow_t* self)
-{
-    data_t* data = (data_t*)self->data;
-    if (data->finished) {
-        if (data->callback) {
-            data->callback(data->callback_param);
-        }
-        workflow_stack_stop_workflow();
-    }
-}
-
-workflow_t* workflow_status(
-    const char* msg,
-    bool status_success,
-    void (*callback)(void*),
-    void* cb_param)
-{
-    workflow_t* result = workflow_allocate(
-        _workflow_status_init, _workflow_status_cleanup, _workflow_status_spin, sizeof(data_t));
-    data_t* data = (data_t*)result->data;
-    data->msg = util_strdup(msg);
-    data->status_success = status_success;
-    data->callback = callback;
-    data->callback_param = cb_param;
-    return result;
-}
 
 /**
  * Blocking wrapper for workflow_status().
@@ -92,7 +28,8 @@ void workflow_status_blocking(const char* msg, bool status_success)
     component_t* comp = status_create(msg, status_success, STATUS_DEFAULT_DELAY, NULL, NULL);
     UG_ClearBuffer();
     comp->f->render(comp);
-    UG_SendBuffer();comp->f->cleanup(comp);
+    UG_SendBuffer();
+    comp->f->cleanup(comp);
 #ifndef TESTING
     delay_ms(3000);
 #endif

--- a/src/workflow/status.h
+++ b/src/workflow/status.h
@@ -17,26 +17,6 @@
 
 #include <stdbool.h>
 
-#include "workflow.h"
-
-#include <util.h>
-
-/**
- * Create a centered label with a checkmark for success or a cross for failure.
- * @param msg Message to print. A copy of this parameter is made,
- *            there's no need for the caller to maintain the string for the lifetime
- *            of the workflow.
- * @param status_success true/false if screen should indicate success / failure
- * @param callback Callback to invoke when the workflow exits.
- * @param cb_param Parameter for the callback.
- */
-USE_RESULT
-workflow_t* workflow_status(
-    const char* msg,
-    bool status_success,
-    void (*callback)(void* param),
-    void* cb_param);
-
 /**
  * Shows a status screen for ~3000ms, blocking.
  *

--- a/src/workflow/status.h
+++ b/src/workflow/status.h
@@ -38,11 +38,10 @@ workflow_t* workflow_status(
     void* cb_param);
 
 /**
- * Blocking wrapper for workflow_status. This will start a new workflow_status
- * and wait until it completes.
+ * Shows a status screen for ~3000ms, blocking.
  *
- * @param msg See workflow_status.
- * @param status_success See workflow_status.
+ * @param msg See status_create.
+ * @param status_success See status_create.
  */
 void workflow_status_blocking(const char* msg, bool status_success);
 

--- a/src/workflow/unlock.c
+++ b/src/workflow/unlock.c
@@ -63,7 +63,7 @@ keystore_error_t workflow_unlock_and_handle_error(const char* password)
         } else {
             snprintf(msg, sizeof(msg), "Wrong password\n%d tries remain", remaining_attempts);
         }
-        workflow_stack_start_workflow(workflow_status(msg, false, NULL, NULL));
+        workflow_status_blocking(msg, false);
         break;
     }
     default:

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -231,7 +231,7 @@ set(TEST_LIST
    workflow_blocking
    "-Wl,--wrap=screen_process"
    workflow_status
-   "-Wl,--wrap=ui_screen_stack_push,--wrap=ui_screen_stack_pop,--wrap=status_create,--wrap=workflow_blocking_block,--wrap=workflow_blocking_unblock"
+   "-Wl,--wrap=status_create"
    workflow_cancel
    "-Wl,--wrap=ui_screen_stack_push,--wrap=ui_screen_stack_pop,--wrap=workflow_blocking_unblock,--wrap=workflow_blocking_block,--wrap=workflow_confirm_blocking,--wrap=workflow_status_blocking"
    ugui

--- a/test/unit-test/test_ui_components.c
+++ b/test/unit-test/test_ui_components.c
@@ -144,7 +144,7 @@ static void test_ui_components_keyboard_switch(void** state)
 
 static void test_ui_components_status(void** state)
 {
-    component_t* status = status_create("Password created", true, 10, NULL, NULL);
+    component_t* status = status_create("Password created", true);
     assert_non_null(status);
     assert_ui_component_functions(status);
     status->f->cleanup(status);

--- a/test/unit-test/test_workflow_status.c
+++ b/test/unit-test/test_workflow_status.c
@@ -26,22 +26,12 @@
 
 const char* _msg = "message foo";
 
-component_t* __real_status_create(
-    const char* text,
-    bool status_success,
-    int delay,
-    void (*callback)(void*),
-    void* callback_param);
-component_t* __wrap_status_create(
-    const char* text,
-    bool status_success,
-    int delay,
-    void (*callback)(void*),
-    void* callback_param)
+component_t* __real_status_create(const char* text, bool status_success);
+component_t* __wrap_status_create(const char* text, bool status_success)
 {
     assert_string_equal(text, _msg);
     check_expected(status_success);
-    return __real_status_create(text, status_success, delay, callback, callback_param);
+    return __real_status_create(text, status_success);
 }
 
 static void _test_workflow_status(void** state)

--- a/test/unit-test/test_workflow_status.c
+++ b/test/unit-test/test_workflow_status.c
@@ -26,7 +26,12 @@
 
 const char* _msg = "message foo";
 
-static component_t _component;
+component_t* __real_status_create(
+    const char* text,
+    bool status_success,
+    int delay,
+    void (*callback)(void*),
+    void* callback_param);
 component_t* __wrap_status_create(
     const char* text,
     bool status_success,
@@ -34,11 +39,9 @@ component_t* __wrap_status_create(
     void (*callback)(void*),
     void* callback_param)
 {
-    (void)callback_param;
     assert_string_equal(text, _msg);
     check_expected(status_success);
-    mock_blocking_set_unblock_func(callback, callback_param);
-    return &_component;
+    return __real_status_create(text, status_success, delay, callback, callback_param);
 }
 
 static void _test_workflow_status(void** state)
@@ -47,10 +50,7 @@ static void _test_workflow_status(void** state)
         const bool status = flags & 1;
 
         expect_value(__wrap_status_create, status_success, status);
-        expect_value(__wrap_ui_screen_stack_push, component, &_component);
         workflow_status_blocking(_msg, status);
-        mock_screen_stack_assert_clean();
-        assert_true(mock_blocking_is_unblocked());
     }
 }
 


### PR DESCRIPTION
The status workflow should always be blocking and never async. It is
not supposed to be ever cancellable (the user needs to see the
messages and they are relatively short anyway). This means that the
async machinery for this workflow is overkill and equivalent to a
simple blocking call.