### PR TITLE
Async enter password and confirm

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -342,6 +342,7 @@ add_custom_target(rust-bindgen
     --whitelist-function screen_print_debug
     --whitelist-function ui_screen_stack_push
     --whitelist-function ui_screen_stack_pop
+    --whitelist-function screen_process
     --whitelist-function label_create
     --whitelist-function bitboxbase_watchdog_reset
     --whitelist-function bitboxbase_screensaver_reset
@@ -355,6 +356,7 @@ add_custom_target(rust-bindgen
     --whitelist-var font_font_a_9X9
     --whitelist-var font_monogram_5X9
     --whitelist-var WALLY_OK
+    --whitelist-function trinary_input_string_create_password
     ${CMAKE_CURRENT_SOURCE_DIR}/rust/bitbox02-sys/wrapper.h --
     -DPB_NO_PACKED_STRUCTS=1 -DPB_FIELD_16BIT=1 -fshort-enums ${RUST_BINDGEN_FLAGS} ${RUST_INCLUDES}
   )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -344,6 +344,7 @@ add_custom_target(rust-bindgen
     --whitelist-function ui_screen_stack_pop
     --whitelist-function screen_process
     --whitelist-function label_create
+    --whitelist-function confirm_create
     --whitelist-function bitboxbase_watchdog_reset
     --whitelist-function bitboxbase_screensaver_reset
     --whitelist-function leds_turn_small_led

--- a/src/firmware_main_loop.c
+++ b/src/firmware_main_loop.c
@@ -24,9 +24,12 @@
 #include "usb/usb.h"
 #include "usb/usb_processing.h"
 #include "workflow/workflow.h"
+#include <rust/rust.h>
 
 void firmware_main_loop(void)
 {
+    rust_workflow_async_DEMO();
+    screen_print_debug("DONE", 5000);
     while (1) {
         workflow_t* workflow = workflow_stack_top();
         if (!workflow) {

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -20,6 +20,7 @@ name = "bitbox02"
 version = "0.1.0"
 dependencies = [
  "bitbox02-sys 0.1.0",
+ "util 0.1.0",
 ]
 
 [[package]]

--- a/src/rust/bitbox02-rust-c/src/lib.rs
+++ b/src/rust/bitbox02-rust-c/src/lib.rs
@@ -24,6 +24,7 @@ extern crate std;
 mod alloc;
 
 mod util;
+mod workflow;
 
 #[cfg(feature = "platform-bitboxbase")]
 pub mod bitboxbase;

--- a/src/rust/bitbox02-rust-c/src/workflow.rs
+++ b/src/rust/bitbox02-rust-c/src/workflow.rs
@@ -17,9 +17,20 @@ pub extern "C" fn rust_workflow_async_DEMO() {
     extern crate alloc;
     use bitbox02::password::Password;
     use bitbox02_rust::bb02_async::{spin, Task};
+    use bitbox02_rust::workflow::confirm::{confirm, Params};
     use bitbox02_rust::workflow::password_enter::password_enter;
 
     async fn demo() {
+        let params = Params {
+            title: "demo",
+            body: "Proceed to pw entry?",
+            ..Default::default()
+        };
+
+        if !confirm(&params).await {
+            return;
+        }
+
         let mut pw1 = Password::new();
         password_enter("Enter 1st PW", true, &mut pw1).await;
         bitbox02::screen_print_debug(

--- a/src/rust/bitbox02-rust-c/src/workflow.rs
+++ b/src/rust/bitbox02-rust-c/src/workflow.rs
@@ -1,0 +1,48 @@
+// Copyright 2020 Shift Cryptosecurity AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[no_mangle]
+pub extern "C" fn rust_workflow_async_DEMO() {
+    extern crate alloc;
+    use bitbox02::password::Password;
+    use bitbox02_rust::bb02_async::{spin, Task};
+    use bitbox02_rust::workflow::password_enter::password_enter;
+
+    async fn demo() {
+        let mut pw1 = Password::new();
+        password_enter("Enter 1st PW", true, &mut pw1).await;
+        bitbox02::screen_print_debug(
+            unsafe { core::str::from_utf8_unchecked(&pw1.as_ref()[..]) },
+            2000,
+        );
+        let mut pw2 = Password::new();
+        password_enter("Enter 2nd PW", false, &mut pw2).await;
+        bitbox02::screen_print_debug(
+            unsafe { core::str::from_utf8_unchecked(&pw2.as_ref()[..]) },
+            2000,
+        );
+    }
+
+    let future = demo();
+
+    let mut task: Task<()> = alloc::boxed::Box::pin(future);
+
+    // poll task in loop, processing screen asynchronously.
+    loop {
+        bitbox02::ui::screen_process();
+        if spin(&mut task).is_ready() {
+            break;
+        }
+    }
+}

--- a/src/rust/bitbox02-rust/src/bb02_async.rs
+++ b/src/rust/bitbox02-rust/src/bb02_async.rs
@@ -1,0 +1,52 @@
+// Copyright 2020 Shift Cryptosecurity AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate alloc;
+
+use alloc::boxed::Box;
+use core::pin::Pin;
+
+/// Task is the top-level future which can be polled by an executor.
+/// Note that other futures awaited inside do not have to be pinned.
+pub type Task<O> = Pin<Box<dyn core::future::Future<Output = O>>>;
+
+/// A primitive poll invocation for a task, with no waking functionality.
+pub fn spin<O>(task: &mut Task<O>) -> core::task::Poll<O> {
+    // TODO: statically allocate the context.
+    let waker = crate::waker_fn::waker_fn(|| {});
+    let context = &mut core::task::Context::from_waker(&waker);
+    task.as_mut().poll(context)
+}
+
+/// Implements the Option future, see `option()`.
+pub struct AsyncOption<'a, O>(&'a Option<O>);
+
+impl<O> core::future::Future for AsyncOption<'_, O> {
+    type Output = ();
+    fn poll(
+        self: core::pin::Pin<&mut Self>,
+        _cx: &mut core::task::Context<'_>,
+    ) -> core::task::Poll<Self::Output> {
+        match self.0 {
+            None => core::task::Poll::Pending,
+            Some(_) => core::task::Poll::Ready(()),
+        }
+    }
+}
+
+/// Waits for an option to contain a value and returns a copy of that value.
+/// E.g. `assert_eq!(option(&Some(42)).await, 42)`.
+pub fn option<'a, O>(option: &'a Option<O>) -> AsyncOption<'a, O> {
+    AsyncOption(&option)
+}

--- a/src/rust/bitbox02-rust/src/lib.rs
+++ b/src/rust/bitbox02-rust/src/lib.rs
@@ -20,9 +20,11 @@
 mod error;
 #[macro_use]
 pub mod general;
+pub mod bb02_async;
 pub mod commander;
 pub mod platform;
 pub mod util;
+mod waker_fn;
 pub mod workflow;
 
 // reexport arrayvec because it is used in our macro "print_debug"

--- a/src/rust/bitbox02-rust/src/waker_fn.rs
+++ b/src/rust/bitbox02-rust/src/waker_fn.rs
@@ -1,0 +1,48 @@
+// This file was taken from here:
+// https://github.com/async-rs/async-task/blob/b7a249680490991f92cc2144d4eff65e4effb3b7/src/waker_fn.rs
+// https://github.com/async-rs/async-task/blob/b7a249680490991f92cc2144d4eff65e4effb3b7/LICENSE-APACHE
+
+extern crate alloc;
+use alloc::sync::Arc;
+use core::mem::{self, ManuallyDrop};
+use core::task::{RawWaker, RawWakerVTable, Waker};
+
+/// Creates a waker from a wake function.
+///
+/// The function gets called every time the waker is woken.
+pub fn waker_fn<F: Fn() + Send + Sync + 'static>(f: F) -> Waker {
+    let raw = Arc::into_raw(Arc::new(f)) as *const ();
+    let vtable = &Helper::<F>::VTABLE;
+    unsafe { Waker::from_raw(RawWaker::new(raw, vtable)) }
+}
+
+struct Helper<F>(F);
+
+impl<F: Fn() + Send + Sync + 'static> Helper<F> {
+    const VTABLE: RawWakerVTable = RawWakerVTable::new(
+        Self::clone_waker,
+        Self::wake,
+        Self::wake_by_ref,
+        Self::drop_waker,
+    );
+
+    unsafe fn clone_waker(ptr: *const ()) -> RawWaker {
+        let arc = ManuallyDrop::new(Arc::from_raw(ptr as *const F));
+        mem::forget(arc.clone());
+        RawWaker::new(ptr, &Self::VTABLE)
+    }
+
+    unsafe fn wake(ptr: *const ()) {
+        let arc = Arc::from_raw(ptr as *const F);
+        (arc)();
+    }
+
+    unsafe fn wake_by_ref(ptr: *const ()) {
+        let arc = ManuallyDrop::new(Arc::from_raw(ptr as *const F));
+        (arc)();
+    }
+
+    unsafe fn drop_waker(ptr: *const ()) {
+        drop(Arc::from_raw(ptr as *const F));
+    }
+}

--- a/src/rust/bitbox02-rust/src/workflow/confirm.rs
+++ b/src/rust/bitbox02-rust/src/workflow/confirm.rs
@@ -1,0 +1,34 @@
+// Copyright 2020 Shift Cryptosecurity AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate alloc;
+use crate::bb02_async::option;
+use alloc::boxed::Box;
+use core::pin::Pin;
+
+pub use bitbox02::ui::ConfirmParams as Params;
+
+/// Returns true if the user accepts, false if the user rejects.
+pub async fn confirm(params: &Params<'_>) -> bool {
+    let mut result: Pin<Box<Option<bool>>> = Box::pin(None);
+
+    // The component will set the result when the user accepted/rejected.
+    let mut component = bitbox02::ui::confirm_create(&params, result.as_mut());
+
+    bitbox02::ui::screen_stack_push(&mut component);
+    option(&result).await;
+    bitbox02::ui::screen_stack_pop();
+
+    result.unwrap()
+}

--- a/src/rust/bitbox02-rust/src/workflow/mod.rs
+++ b/src/rust/bitbox02-rust/src/workflow/mod.rs
@@ -13,3 +13,4 @@
 // limitations under the License.
 
 pub mod pairing;
+pub mod password_enter;

--- a/src/rust/bitbox02-rust/src/workflow/mod.rs
+++ b/src/rust/bitbox02-rust/src/workflow/mod.rs
@@ -12,5 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod confirm;
 pub mod pairing;
 pub mod password_enter;

--- a/src/rust/bitbox02-rust/src/workflow/password_enter.rs
+++ b/src/rust/bitbox02-rust/src/workflow/password_enter.rs
@@ -1,0 +1,43 @@
+// Copyright 2020 Shift Cryptosecurity AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate alloc;
+use crate::bb02_async::option;
+use alloc::boxed::Box;
+use bitbox02::password::Password;
+use core::pin::Pin;
+
+/// Example:
+/// ```no_run
+/// let mut pw = Password::new();
+/// password_enter("Enter password", true, &mut pw).await;
+/// // use pw.
+/// ```
+pub async fn password_enter(title: &str, special_chars: bool, password_out: &mut Password) {
+    let mut result: Pin<Box<Option<Password>>> = Box::pin(None);
+
+    // The component will set the result password when the user entered it.
+    let mut component =
+        bitbox02::ui::trinary_input_string_create_password(title, special_chars, result.as_mut());
+
+    bitbox02::ui::screen_stack_push(&mut component);
+    // Wait for result to contain the password
+    option(&result).await;
+    bitbox02::ui::screen_stack_pop();
+
+    let result: &Option<Password> = &*result;
+    let result: Option<&Password> = result.as_ref();
+    let result: &Password = result.unwrap();
+    password_out.clone_from(&result);
+}

--- a/src/rust/bitbox02-sys/wrapper.h
+++ b/src/rust/bitbox02-sys/wrapper.h
@@ -18,6 +18,7 @@
 #include <commander/commander.h>
 #include <platform/bitboxbase/leds.h>
 #include <screen.h>
+#include <ui/components/confirm.h>
 #include <ui/components/label.h>
 #include <ui/components/trinary_input_string.h>
 #include <ui/fonts/font_a_9X9.h>

--- a/src/rust/bitbox02-sys/wrapper.h
+++ b/src/rust/bitbox02-sys/wrapper.h
@@ -19,9 +19,11 @@
 #include <platform/bitboxbase/leds.h>
 #include <screen.h>
 #include <ui/components/label.h>
+#include <ui/components/trinary_input_string.h>
 #include <ui/fonts/font_a_9X9.h>
 #include <ui/fonts/monogram_5X9.h>
 #include <ui/oled/oled.h>
+#include <ui/screen_process.h>
 #include <ui/screen_stack.h>
 #include <ui/ugui/ugui.h>
 #include <wally_crypto.h>

--- a/src/rust/bitbox02/Cargo.toml
+++ b/src/rust/bitbox02/Cargo.toml
@@ -26,3 +26,4 @@ panic = 'abort'
 
 [dependencies]
 bitbox02-sys = {path="../bitbox02-sys"}
+util = {path = "../util"}

--- a/src/rust/bitbox02/src/lib.rs
+++ b/src/rust/bitbox02/src/lib.rs
@@ -15,6 +15,7 @@
 // This crate contains safe wrappers around C functions provided by bitbox02_sys.
 #![no_std]
 
+pub mod password;
 use core::time::Duration;
 
 // Reexport the protobuf types

--- a/src/rust/bitbox02/src/lib.rs
+++ b/src/rust/bitbox02/src/lib.rs
@@ -16,6 +16,8 @@
 #![no_std]
 
 pub mod password;
+pub mod ui;
+
 use core::time::Duration;
 
 // Reexport the protobuf types

--- a/src/rust/bitbox02/src/password.rs
+++ b/src/rust/bitbox02/src/password.rs
@@ -1,0 +1,50 @@
+// Copyright 2020 Shift Cryptosecurity AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// C-style including null terminator, as it is used in C only so far.
+/// 150 corresponds to SET_PASSWORD_MAX_PASSWORD_LENGTH.
+/// Does *not* implement Copy, so that we can have a Drop to zero the contents.
+// TODO: use a reusable zero-on-drop buffer type
+pub struct Password([u8; 150]);
+
+impl Password {
+    /// Makes a password buffer filled with 0.
+    pub fn new() -> Password {
+        Password([0; 150])
+    }
+
+    /// Clones the password bytes from `source` without additional allocations.
+    pub fn clone_from(&mut self, source: &Self) {
+        self.0.copy_from_slice(&source.0[..]);
+    }
+}
+
+impl AsRef<[u8; 150]> for Password {
+    fn as_ref(&self) -> &[u8; 150] {
+        &self.0
+    }
+}
+
+impl AsMut<[u8; 150]> for Password {
+    fn as_mut(&mut self) -> &mut [u8; 150] {
+        &mut self.0
+    }
+}
+
+impl Drop for Password {
+    fn drop(&mut self) {
+        util::zero(&mut self.0[..]);
+        crate::screen_print_debug(".", 100);
+    }
+}

--- a/src/rust/bitbox02/src/ui.rs
+++ b/src/rust/bitbox02/src/ui.rs
@@ -1,0 +1,73 @@
+// Copyright 2020 Shift Cryptosecurity AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use util::c_types::{c_char, c_void};
+
+extern crate alloc;
+use crate::password::Password;
+use alloc::boxed::Box;
+use core::pin::Pin;
+
+/// Wraps the C component_t to be used in Rust.
+pub struct Component(*mut bitbox02_sys::component_t);
+
+/// Creates a password input component.
+/// `title` - Shown before any input is entered as the screen title. **Panics** if more than 100 bytes.
+/// `special_chars` - whether to enable the special characters keyboard.
+/// `result` - will be asynchronously set to `Some(<password>)` once the user confirms.
+pub fn trinary_input_string_create_password(
+    title: &str,
+    special_chars: bool,
+    result: Pin<&mut Option<Password>>,
+) -> Component {
+    extern "C" fn on_done_cb(password: *const c_char, param: *mut c_void) {
+        let mut out: Box<Pin<&mut Option<Password>>> = unsafe { Box::from_raw(param as *mut _) };
+        let mut password_out = Password::new();
+        let len = password_out.as_ref().len();
+        password_out
+            .as_mut()
+            .copy_from_slice(unsafe { core::slice::from_raw_parts(password, len) });
+        out.set(Some(password_out));
+    }
+
+    let component = unsafe {
+        bitbox02_sys::trinary_input_string_create_password(
+            crate::str_to_cstr_force!(title, 100).as_ptr(),
+            special_chars,
+            Some(on_done_cb),
+            Box::into_raw(Box::new(result)) as *mut _, // passed to on_done_cb as `param`.
+            None,
+            core::ptr::null_mut(),
+        )
+    };
+    Component(component)
+}
+
+pub fn screen_stack_push(component: &mut Component) {
+    unsafe {
+        bitbox02_sys::ui_screen_stack_push(component.0);
+    }
+}
+
+pub fn screen_stack_pop() {
+    unsafe {
+        bitbox02_sys::ui_screen_stack_pop();
+    }
+}
+
+pub fn screen_process() {
+    unsafe {
+        bitbox02_sys::screen_process();
+    }
+}

--- a/src/rust/bitbox02/src/ui.rs
+++ b/src/rust/bitbox02/src/ui.rs
@@ -54,6 +54,68 @@ pub fn trinary_input_string_create_password(
     Component(component)
 }
 
+#[derive(Default)]
+pub struct ConfirmParams<'a> {
+    /// The confirmation title of the screen. Max 200 chars, otherwise **panic**.
+    pub title: &'a str,
+    /// The confirmation body of the screen. Max 200 chars, otherwise **panic**.
+    pub body: &'a str,
+    /// If true, the body is horizontally scrollable.
+    pub scrollable: bool,
+    /// If true, require the hold gesture to confirm instead of tap.
+    pub longtouch: bool,
+    /// If true, the user can only confirm, not reject.
+    pub accept_only: bool,
+    /// if true, the accept icon is a right arrow instead of a checkmark (indicating going to the
+    /// "next" screen).
+    pub accept_is_nextarrow: bool,
+    /// if true, will only show first and last 32 bytes.
+    pub shorten_body: bool,
+    /// Print the value of this variable in the corner. Will not print when 0
+    pub display_size: usize,
+}
+
+/// Creates a user confirmation dialog screen.
+/// `result` - will be asynchronously set to `Some(bool)` once the user accets or rejects.
+pub fn confirm_create(params: &ConfirmParams, result: Pin<&mut Option<bool>>) -> Component {
+    let params = bitbox02_sys::confirm_params_t {
+        title: crate::str_to_cstr_force!(params.title, 200).as_ptr(),
+        body: crate::str_to_cstr_force!(params.body, 200).as_ptr(),
+        font: core::ptr::null(), // TODO
+        scrollable: params.scrollable,
+        longtouch: params.longtouch,
+        accept_only: params.accept_only,
+        accept_is_nextarrow: params.accept_is_nextarrow,
+        shorten_body: params.shorten_body,
+        display_size: params.display_size as u32,
+    };
+
+    extern "C" fn on_accept_cb(param: *mut c_void) {
+        let mut out: Box<Pin<&mut Option<bool>>> = unsafe { Box::from_raw(param as *mut _) };
+        out.set(Some(true));
+    }
+    extern "C" fn on_reject_cb(param: *mut c_void) {
+        let mut out: Box<Pin<&mut Option<bool>>> = unsafe { Box::from_raw(param as *mut _) };
+        out.set(Some(false));
+    }
+
+    let result_ptr = Box::into_raw(Box::new(result)) as *mut _; // passed to callbacks `param`.
+    let component = unsafe {
+        bitbox02_sys::confirm_create(
+            &params,
+            Some(on_accept_cb),
+            result_ptr,
+            if !params.accept_only {
+                Some(on_reject_cb)
+            } else {
+                None
+            },
+            result_ptr,
+        )
+    };
+    Component(component)
+}
+
 pub fn screen_stack_push(component: &mut Component) {
     unsafe {
         bitbox02_sys::ui_screen_stack_push(component.0);

--- a/src/rust/bitbox02/src/util.rs
+++ b/src/rust/bitbox02/src/util.rs
@@ -73,3 +73,13 @@ macro_rules! str_to_cstr {
         }
     }};
 }
+
+#[macro_export]
+macro_rules! str_to_cstr_force {
+    ($input:expr, $len:literal) => {
+        match $crate::str_to_cstr!($input, $len) {
+            Ok(buf) => buf,
+            Err(_) => panic!("str did not fit"),
+        }
+    };
+}


### PR DESCRIPTION
this adds
```
    rust_workflow_async_DEMO();
    screen_print_debug("DONE", 5000);
```

to `firmware_main_loop()` as a demo, which i will remove before merging.

The rest is implementing entering the password as a rust future, based on the trinary input string component. The C callback in the component is converted to a Rust future, which can be polled and used nicely, as seen in `rust_workflow_async_DEMO`.
