### PR TITLE
components/status: remove unused param `delay`

### DIFF
--- a/src/reset.c
+++ b/src/reset.c
@@ -36,7 +36,7 @@
 static void _show_reset_label(bool status)
 {
     const char* msg = "Device reset";
-    component_t* comp = status_create(msg, status, STATUS_DEFAULT_DELAY, NULL, NULL);
+    component_t* comp = status_create(msg, status, NULL, NULL);
     UG_ClearBuffer();
     comp->f->render(comp);
     UG_SendBuffer();

--- a/src/ui/components/status.c
+++ b/src/ui/components/status.c
@@ -21,10 +21,11 @@
 #include <stdbool.h>
 #include <string.h>
 
+#define STATUS_DEFAULT_DELAY 500 // counts
+
 typedef struct {
     bool status;
     int counter;
-    int delay;
     void (*callback)(void*);
     void* callback_param;
 } status_data_t;
@@ -39,7 +40,7 @@ static void _render(component_t* component)
         image_cross(SCREEN_WIDTH / 6 * 5, SCREEN_HEIGHT / 2 - height / 2, height);
     }
     if (data->callback != NULL) {
-        if (data->counter == data->delay) {
+        if (data->counter == STATUS_DEFAULT_DELAY) {
             data->callback(data->callback_param);
             data->callback = NULL;
             data->counter = 0;
@@ -62,7 +63,6 @@ static const component_functions_t _component_functions = {
 component_t* status_create(
     const char* text,
     bool status_success,
-    int delay,
     void (*callback)(void*),
     void* callback_param)
 {
@@ -78,7 +78,6 @@ component_t* status_create(
     memset(status, 0, sizeof(component_t));
 
     data->status = status_success;
-    data->delay = delay;
     data->callback = callback;
     data->callback_param = callback_param;
     status->data = data;

--- a/src/ui/components/status.h
+++ b/src/ui/components/status.h
@@ -18,21 +18,17 @@
 #include <stdbool.h>
 #include <ui/component.h>
 
-#define STATUS_DEFAULT_DELAY 500 // counts
-
 /********************************** Create Instance **********************************/
 
 /**
  * Creates a status component with a given text. Calls the callback after delay.
  * @param[IN] text The text of the status screen.
  * @param[IN] status_success If true, indicates a success. Otherwise, false.
- * @param[IN] delay The time in counts that passes before the callback is called.
  * @param[IN] callback The callback that is called after <delay> time.
  */
 component_t* status_create(
     const char* text,
     bool status_success,
-    int delay,
     void (*callback)(void*),
     void* callback_param);
 

--- a/src/workflow/status.c
+++ b/src/workflow/status.c
@@ -42,8 +42,7 @@ static void _status_cb(void* param)
 static void _workflow_status_init(workflow_t* self)
 {
     data_t* data = (data_t*)self->data;
-    ui_screen_stack_push(
-        status_create(data->msg, data->status_success, STATUS_DEFAULT_DELAY, _status_cb, data));
+    ui_screen_stack_push(status_create(data->msg, data->status_success, _status_cb, data));
 }
 
 static void _workflow_status_cleanup(workflow_t* self)

--- a/test/unit-test/test_ui_components.c
+++ b/test/unit-test/test_ui_components.c
@@ -144,7 +144,7 @@ static void test_ui_components_keyboard_switch(void** state)
 
 static void test_ui_components_status(void** state)
 {
-    component_t* status = status_create("Password created", true, 10, NULL, NULL);
+    component_t* status = status_create("Password created", true, NULL, NULL);
     assert_non_null(status);
     assert_ui_component_functions(status);
     status->f->cleanup(status);

--- a/test/unit-test/test_workflow_status.c
+++ b/test/unit-test/test_workflow_status.c
@@ -30,7 +30,6 @@ static component_t _component;
 component_t* __wrap_status_create(
     const char* text,
     bool status_success,
-    int delay,
     void (*callback)(void*),
     void* callback_param)
 {


### PR DESCRIPTION
delay is the same for every invocation, and is unlikely to change.