### PR TITLE
components/confirm: one callback instead of two

### DIFF
--- a/src/ui/components/confirm.h
+++ b/src/ui/components/confirm.h
@@ -44,14 +44,12 @@ typedef struct {
 /**
  * Creates a confirm screen.
  * @param[in] params see confirm_params_t for details.
- * @param[in] confirm_callback The callback triggered when the user pushes the confirm button.
- * @param[in] cancel_callback The callback triggered when the user pushes the cancel button.
+ * @param[in] callback The callback triggered when the user accepts or rejects.
+ * @param[in] callback_param passed through to the callback.
  */
 component_t* confirm_create(
     const confirm_params_t* params,
-    void (*confirm_callback)(void* param),
-    void* confirm_callback_param,
-    void (*cancel_callback)(void* param),
-    void* cancel_callback_param);
+    void (*callback)(bool, void* param),
+    void* callback_param);
 
 #endif

--- a/src/workflow/confirm.c
+++ b/src/workflow/confirm.c
@@ -36,19 +36,11 @@ typedef struct {
     char* body;
 } data_t;
 
-static void _confirm(void* param)
+static void _confirm_callback(bool result, void* param)
 {
     workflow_t* self = (workflow_t*)param;
     data_t* data = (data_t*)self->data;
-    data->result = true;
-    data->done = true;
-}
-
-static void _reject(void* param)
-{
-    workflow_t* self = (workflow_t*)param;
-    data_t* data = (data_t*)self->data;
-    data->result = false;
+    data->result = result;
     data->done = true;
 }
 
@@ -75,8 +67,7 @@ static void _workflow_confirm_init(workflow_t* self)
 {
     data_t* data = (data_t*)self->data;
     component_t* comp;
-    comp = confirm_create(
-        &data->params, _confirm, self, data->params.accept_only ? NULL : _reject, self);
+    comp = confirm_create(&data->params, _confirm_callback, self);
     ui_screen_stack_push(comp);
 }
 

--- a/src/workflow/workflow.c
+++ b/src/workflow/workflow.c
@@ -28,8 +28,9 @@
 #include <ui/workflow_stack.h>
 #include <util.h>
 
-static void _confirm_dismiss(void* param)
+static void _confirm_dismiss(bool result, void* param)
 {
+    (void)result;
     (void)param;
     ui_screen_stack_switch(waiting_create());
 }
@@ -39,8 +40,9 @@ void workflow_confirm_dismiss(const char* title, const char* body)
     const confirm_params_t params = {
         .title = title,
         .body = body,
+        .accept_only = true,
     };
-    ui_screen_stack_switch(confirm_create(&params, _confirm_dismiss, NULL, NULL, NULL));
+    ui_screen_stack_switch(confirm_create(&params, _confirm_dismiss, NULL));
 }
 
 workflow_t* workflow_allocate(

--- a/test/unit-test/test_ui_components.c
+++ b/test/unit-test/test_ui_components.c
@@ -99,14 +99,10 @@ static void test_ui_components_image(void** state)
     mock_component->f->cleanup(mock_component);
 }
 
-static void confirm_callback(void* param)
+static void confirm_callback(bool result, void* param)
 {
     (void)param;
-}
-
-static void cancel_callback(void* param)
-{
-    (void)param;
+    (void)result;
 }
 
 static void test_ui_components_confirm(void** state)
@@ -116,7 +112,7 @@ static void test_ui_components_confirm(void** state)
         .body = "CODE",
         .font = &font_monogram_5X9,
     };
-    component_t* confirm = confirm_create(&params, confirm_callback, NULL, cancel_callback, NULL);
+    component_t* confirm = confirm_create(&params, confirm_callback, NULL);
     assert_non_null(confirm);
     assert_ui_component_functions(confirm);
     confirm->f->cleanup(confirm);


### PR DESCRIPTION
Makes most call sites simpler.