### PR TITLE
rust/bitbox02/ui: properly clean up callbacks

### DIFF
--- a/src/ui/components/confirm.h
+++ b/src/ui/components/confirm.h
@@ -44,7 +44,8 @@ typedef struct {
 /**
  * Creates a confirm screen.
  * @param[in] params see confirm_params_t for details.
- * @param[in] callback The callback triggered when the user accepts or rejects.
+ * @param[in] callback The callback triggered when the user accepts or rejects. Will be called at
+ * most once.
  * @param[in] callback_param passed through to the callback.
  */
 component_t* confirm_create(

--- a/src/ui/components/status.h
+++ b/src/ui/components/status.h
@@ -24,7 +24,7 @@
  * Creates a status component with a given text. Calls the callback after delay.
  * @param[IN] text The text of the status screen.
  * @param[IN] status_success If true, indicates a success. Otherwise, false.
- * @param[IN] callback The callback that is called after <delay> time.
+ * @param[IN] callback The callback that is called after <delay> time. Will be called at most once.
  */
 component_t* status_create(
     const char* text,

--- a/src/ui/components/trinary_input_string.c
+++ b/src/ui/components/trinary_input_string.c
@@ -286,7 +286,10 @@ static void _on_event(const event_t* event, component_t* component)
     data_t* data = (data_t*)component->data;
 
     if (event->id == EVENT_CONFIRM && data->can_confirm) {
-        data->confirm_cb(data->string, data->confirm_callback_param);
+        if (data->confirm_cb) {
+            data->confirm_cb(data->string, data->confirm_callback_param);
+            data->confirm_cb = NULL;
+        }
         return;
     }
 
@@ -317,6 +320,7 @@ static void _on_event(const event_t* event, component_t* component)
             }
         } else if (data->cancel_cb != NULL) {
             data->cancel_cb(data->cancel_callback_param);
+            data->cancel_cb = NULL;
         }
         _set_alphabet(component);
         _set_can_confirm(component);

--- a/src/ui/components/trinary_input_string.h
+++ b/src/ui/components/trinary_input_string.h
@@ -33,7 +33,8 @@
  * adjust automatically so only words from the wordlist can be entered. Must be sorted, with all
  * words being lowercase 'a-z'.
  * @param[in] wordlist_size number of words in the wordlist.
- * @param[in] confirm_cb The callback that is called when the user entered the string.
+ * @param[in] confirm_cb The callback that is called when the user entered the string. Will be
+ * called at most once.
  * @param[in] cancel_cb Called when the user cancels by hitting the back button.
  */
 component_t* trinary_input_string_create_wordlist(


### PR DESCRIPTION
into_raw makes Rust forget about the pointer. A corresponding from_raw
is needed to bring it back and clean it up properly.