### PR TITLE
py/bitbox02: namespace all protos with package directive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ NOTES.md
 bitbox02.egg-info
 /py/bitbox02/build
 /py/bitbox02/dist
+/py/bitbox02/.proto
 
 # Git backup files created on merge conflicts
 *_BACKUP_*

--- a/py/bitbox02/Makefile
+++ b/py/bitbox02/Makefile
@@ -21,20 +21,35 @@ TARGETS=$(addprefix ${OUT_DIR}/, $(PROTO_FILES:.proto=_pb2.py))
 
 all: ${TARGETS}
 
+# To avoid protobuf name collisions with other packages used elsewhere like the
+# electrum app, the pb files for Python are generated from a copy
+# of ../../messages where all protos specify a non-empty package directive.
+# The proto files need not be committed to the repo. They are created at build time.
+PY_PROTO_DIR=.proto
+PY_PROTO=$(addprefix ${PY_PROTO_DIR}/,${PROTO_FILES})
+
 # Explicit rules cannot have multiple outputs (it will be interpreted as multiple rules and
 # therefore the same command will be executed multiple times)
 # Instead we create a single implicit rule. Implicit rules allow multiple outputs without executing
 # the same command multiple times when multiple threads are used.
 # https://stackoverflow.com/questions/19822435/multiple-targets-from-one-recipe-and-parallel-execution
 TMP_TARGETS=$(addprefix %/, $(PROTO_FILES:.proto=_pb2.py))
-${TMP_TARGETS}: $(addprefix ../../messages/,${PROTO_FILES})
+${TMP_TARGETS}: ${PY_PROTO}
 	mkdir -p ${OUT_DIR}
-	protoc --proto_path=../../messages --python_out=${OUT_DIR} --mypy_out=${OUT_DIR} $^
+	protoc --proto_path=${PY_PROTO_DIR} --python_out=${OUT_DIR} --mypy_out=${OUT_DIR} $^
 	touch ${@D}/__init__.py
 # The hack below is due to protobuf-python generating absolute paths (which are frowned upon) instead of relative paths.
 # https://github.com/protocolbuffers/protobuf/issues/1491
 	sed -i 's/^from \([^.]*_pb2\)/from .\1/g'  ${OUT_DIR}/*.pyi
 	sed -i 's/^import \([^.]*_pb2\) as \([^.]*__pb2\)/from . import \1 as \2/g' ${OUT_DIR}/*.py
+
+# Grab proto files and insert a package name in each one.
+# There can be only one "syntax = ..." directive in a proto file.
+# So, that's our anchor and a good place to put the package name at.
+${PY_PROTO}: $(addprefix ../../messages/,${PROTO_FILES})
+	mkdir -p ${PY_PROTO_DIR}
+	cp $^ ${PY_PROTO_DIR}
+	sed -i 's/^syntax =.*/&\npackage shiftcrypto.bitbox02;/' ${PY_PROTO_DIR}/*.proto
 
 release-test: all
 	rm -rf dist/*
@@ -48,3 +63,4 @@ release-live: all
 
 clean:
 	rm -f ${TARGETS}
+	rm -rf ${PY_PROTO_DIR}

--- a/py/bitbox02/bitbox02/bitbox02/__init__.py
+++ b/py/bitbox02/bitbox02/bitbox02/__init__.py
@@ -16,7 +16,7 @@
 from __future__ import print_function
 import sys
 
-__version__ = "2.0.1"
+__version__ = "2.0.2"
 
 if sys.version_info.major != 3 or sys.version_info.minor < 6:
     print(

--- a/py/bitbox02/bitbox02/communication/generated/backup_commands_pb2.py
+++ b/py/bitbox02/bitbox02/communication/generated/backup_commands_pb2.py
@@ -17,9 +17,9 @@ _sym_db = _symbol_database.Default()
 
 DESCRIPTOR = _descriptor.FileDescriptor(
   name='backup_commands.proto',
-  package='',
+  package='shiftcrypto.bitbox02',
   syntax='proto3',
-  serialized_pb=_b('\n\x15\x62\x61\x63kup_commands.proto\"$\n\x12\x43heckBackupRequest\x12\x0e\n\x06silent\x18\x01 \x01(\x08\"!\n\x13\x43heckBackupResponse\x12\n\n\x02id\x18\x01 \x01(\t\"A\n\x13\x43reateBackupRequest\x12\x11\n\ttimestamp\x18\x01 \x01(\r\x12\x17\n\x0ftimezone_offset\x18\x02 \x01(\x05\"\x14\n\x12ListBackupsRequest\"9\n\nBackupInfo\x12\n\n\x02id\x18\x01 \x01(\t\x12\x11\n\ttimestamp\x18\x02 \x01(\r\x12\x0c\n\x04name\x18\x04 \x01(\t\"0\n\x13ListBackupsResponse\x12\x19\n\x04info\x18\x01 \x03(\x0b\x32\x0b.BackupInfo\"N\n\x14RestoreBackupRequest\x12\n\n\x02id\x18\x01 \x01(\t\x12\x11\n\ttimestamp\x18\x02 \x01(\r\x12\x17\n\x0ftimezone_offset\x18\x03 \x01(\x05\x62\x06proto3')
+  serialized_pb=_b('\n\x15\x62\x61\x63kup_commands.proto\x12\x14shiftcrypto.bitbox02\"$\n\x12\x43heckBackupRequest\x12\x0e\n\x06silent\x18\x01 \x01(\x08\"!\n\x13\x43heckBackupResponse\x12\n\n\x02id\x18\x01 \x01(\t\"A\n\x13\x43reateBackupRequest\x12\x11\n\ttimestamp\x18\x01 \x01(\r\x12\x17\n\x0ftimezone_offset\x18\x02 \x01(\x05\"\x14\n\x12ListBackupsRequest\"9\n\nBackupInfo\x12\n\n\x02id\x18\x01 \x01(\t\x12\x11\n\ttimestamp\x18\x02 \x01(\r\x12\x0c\n\x04name\x18\x04 \x01(\t\"E\n\x13ListBackupsResponse\x12.\n\x04info\x18\x01 \x03(\x0b\x32 .shiftcrypto.bitbox02.BackupInfo\"N\n\x14RestoreBackupRequest\x12\n\n\x02id\x18\x01 \x01(\t\x12\x11\n\ttimestamp\x18\x02 \x01(\r\x12\x17\n\x0ftimezone_offset\x18\x03 \x01(\x05\x62\x06proto3')
 )
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
@@ -28,13 +28,13 @@ _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 _CHECKBACKUPREQUEST = _descriptor.Descriptor(
   name='CheckBackupRequest',
-  full_name='CheckBackupRequest',
+  full_name='shiftcrypto.bitbox02.CheckBackupRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='silent', full_name='CheckBackupRequest.silent', index=0,
+      name='silent', full_name='shiftcrypto.bitbox02.CheckBackupRequest.silent', index=0,
       number=1, type=8, cpp_type=7, label=1,
       has_default_value=False, default_value=False,
       message_type=None, enum_type=None, containing_type=None,
@@ -52,20 +52,20 @@ _CHECKBACKUPREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=25,
-  serialized_end=61,
+  serialized_start=47,
+  serialized_end=83,
 )
 
 
 _CHECKBACKUPRESPONSE = _descriptor.Descriptor(
   name='CheckBackupResponse',
-  full_name='CheckBackupResponse',
+  full_name='shiftcrypto.bitbox02.CheckBackupResponse',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='id', full_name='CheckBackupResponse.id', index=0,
+      name='id', full_name='shiftcrypto.bitbox02.CheckBackupResponse.id', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -83,27 +83,27 @@ _CHECKBACKUPRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=63,
-  serialized_end=96,
+  serialized_start=85,
+  serialized_end=118,
 )
 
 
 _CREATEBACKUPREQUEST = _descriptor.Descriptor(
   name='CreateBackupRequest',
-  full_name='CreateBackupRequest',
+  full_name='shiftcrypto.bitbox02.CreateBackupRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='timestamp', full_name='CreateBackupRequest.timestamp', index=0,
+      name='timestamp', full_name='shiftcrypto.bitbox02.CreateBackupRequest.timestamp', index=0,
       number=1, type=13, cpp_type=3, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='timezone_offset', full_name='CreateBackupRequest.timezone_offset', index=1,
+      name='timezone_offset', full_name='shiftcrypto.bitbox02.CreateBackupRequest.timezone_offset', index=1,
       number=2, type=5, cpp_type=1, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
@@ -121,14 +121,14 @@ _CREATEBACKUPREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=98,
-  serialized_end=163,
+  serialized_start=120,
+  serialized_end=185,
 )
 
 
 _LISTBACKUPSREQUEST = _descriptor.Descriptor(
   name='ListBackupsRequest',
-  full_name='ListBackupsRequest',
+  full_name='shiftcrypto.bitbox02.ListBackupsRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
@@ -145,34 +145,34 @@ _LISTBACKUPSREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=165,
-  serialized_end=185,
+  serialized_start=187,
+  serialized_end=207,
 )
 
 
 _BACKUPINFO = _descriptor.Descriptor(
   name='BackupInfo',
-  full_name='BackupInfo',
+  full_name='shiftcrypto.bitbox02.BackupInfo',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='id', full_name='BackupInfo.id', index=0,
+      name='id', full_name='shiftcrypto.bitbox02.BackupInfo.id', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='timestamp', full_name='BackupInfo.timestamp', index=1,
+      name='timestamp', full_name='shiftcrypto.bitbox02.BackupInfo.timestamp', index=1,
       number=2, type=13, cpp_type=3, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='name', full_name='BackupInfo.name', index=2,
+      name='name', full_name='shiftcrypto.bitbox02.BackupInfo.name', index=2,
       number=4, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -190,20 +190,20 @@ _BACKUPINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=187,
-  serialized_end=244,
+  serialized_start=209,
+  serialized_end=266,
 )
 
 
 _LISTBACKUPSRESPONSE = _descriptor.Descriptor(
   name='ListBackupsResponse',
-  full_name='ListBackupsResponse',
+  full_name='shiftcrypto.bitbox02.ListBackupsResponse',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='info', full_name='ListBackupsResponse.info', index=0,
+      name='info', full_name='shiftcrypto.bitbox02.ListBackupsResponse.info', index=0,
       number=1, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
@@ -221,34 +221,34 @@ _LISTBACKUPSRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=246,
-  serialized_end=294,
+  serialized_start=268,
+  serialized_end=337,
 )
 
 
 _RESTOREBACKUPREQUEST = _descriptor.Descriptor(
   name='RestoreBackupRequest',
-  full_name='RestoreBackupRequest',
+  full_name='shiftcrypto.bitbox02.RestoreBackupRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='id', full_name='RestoreBackupRequest.id', index=0,
+      name='id', full_name='shiftcrypto.bitbox02.RestoreBackupRequest.id', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='timestamp', full_name='RestoreBackupRequest.timestamp', index=1,
+      name='timestamp', full_name='shiftcrypto.bitbox02.RestoreBackupRequest.timestamp', index=1,
       number=2, type=13, cpp_type=3, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='timezone_offset', full_name='RestoreBackupRequest.timezone_offset', index=2,
+      name='timezone_offset', full_name='shiftcrypto.bitbox02.RestoreBackupRequest.timezone_offset', index=2,
       number=3, type=5, cpp_type=1, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
@@ -266,8 +266,8 @@ _RESTOREBACKUPREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=296,
-  serialized_end=374,
+  serialized_start=339,
+  serialized_end=417,
 )
 
 _LISTBACKUPSRESPONSE.fields_by_name['info'].message_type = _BACKUPINFO
@@ -282,49 +282,49 @@ DESCRIPTOR.message_types_by_name['RestoreBackupRequest'] = _RESTOREBACKUPREQUEST
 CheckBackupRequest = _reflection.GeneratedProtocolMessageType('CheckBackupRequest', (_message.Message,), dict(
   DESCRIPTOR = _CHECKBACKUPREQUEST,
   __module__ = 'backup_commands_pb2'
-  # @@protoc_insertion_point(class_scope:CheckBackupRequest)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.CheckBackupRequest)
   ))
 _sym_db.RegisterMessage(CheckBackupRequest)
 
 CheckBackupResponse = _reflection.GeneratedProtocolMessageType('CheckBackupResponse', (_message.Message,), dict(
   DESCRIPTOR = _CHECKBACKUPRESPONSE,
   __module__ = 'backup_commands_pb2'
-  # @@protoc_insertion_point(class_scope:CheckBackupResponse)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.CheckBackupResponse)
   ))
 _sym_db.RegisterMessage(CheckBackupResponse)
 
 CreateBackupRequest = _reflection.GeneratedProtocolMessageType('CreateBackupRequest', (_message.Message,), dict(
   DESCRIPTOR = _CREATEBACKUPREQUEST,
   __module__ = 'backup_commands_pb2'
-  # @@protoc_insertion_point(class_scope:CreateBackupRequest)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.CreateBackupRequest)
   ))
 _sym_db.RegisterMessage(CreateBackupRequest)
 
 ListBackupsRequest = _reflection.GeneratedProtocolMessageType('ListBackupsRequest', (_message.Message,), dict(
   DESCRIPTOR = _LISTBACKUPSREQUEST,
   __module__ = 'backup_commands_pb2'
-  # @@protoc_insertion_point(class_scope:ListBackupsRequest)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.ListBackupsRequest)
   ))
 _sym_db.RegisterMessage(ListBackupsRequest)
 
 BackupInfo = _reflection.GeneratedProtocolMessageType('BackupInfo', (_message.Message,), dict(
   DESCRIPTOR = _BACKUPINFO,
   __module__ = 'backup_commands_pb2'
-  # @@protoc_insertion_point(class_scope:BackupInfo)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.BackupInfo)
   ))
 _sym_db.RegisterMessage(BackupInfo)
 
 ListBackupsResponse = _reflection.GeneratedProtocolMessageType('ListBackupsResponse', (_message.Message,), dict(
   DESCRIPTOR = _LISTBACKUPSRESPONSE,
   __module__ = 'backup_commands_pb2'
-  # @@protoc_insertion_point(class_scope:ListBackupsResponse)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.ListBackupsResponse)
   ))
 _sym_db.RegisterMessage(ListBackupsResponse)
 
 RestoreBackupRequest = _reflection.GeneratedProtocolMessageType('RestoreBackupRequest', (_message.Message,), dict(
   DESCRIPTOR = _RESTOREBACKUPREQUEST,
   __module__ = 'backup_commands_pb2'
-  # @@protoc_insertion_point(class_scope:RestoreBackupRequest)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.RestoreBackupRequest)
   ))
 _sym_db.RegisterMessage(RestoreBackupRequest)
 

--- a/py/bitbox02/bitbox02/communication/generated/bitbox02_system_pb2.py
+++ b/py/bitbox02/bitbox02/communication/generated/bitbox02_system_pb2.py
@@ -17,9 +17,9 @@ _sym_db = _symbol_database.Default()
 
 DESCRIPTOR = _descriptor.FileDescriptor(
   name='bitbox02_system.proto',
-  package='',
+  package='shiftcrypto.bitbox02',
   syntax='proto3',
-  serialized_pb=_b('\n\x15\x62itbox02_system.proto\"\x14\n\x12\x43heckSDCardRequest\"\'\n\x13\x43heckSDCardResponse\x12\x10\n\x08inserted\x18\x01 \x01(\x08\"\x13\n\x11\x44\x65viceInfoRequest\"\x95\x01\n\x12\x44\x65viceInfoResponse\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0binitialized\x18\x02 \x01(\x08\x12\x0f\n\x07version\x18\x03 \x01(\t\x12#\n\x1bmnemonic_passphrase_enabled\x18\x04 \x01(\x08\x12&\n\x1emonotonic_increments_remaining\x18\x05 \x01(\r\"\x86\x01\n\x19InsertRemoveSDCardRequest\x12\x37\n\x06\x61\x63tion\x18\x01 \x01(\x0e\x32\'.InsertRemoveSDCardRequest.SDCardAction\"0\n\x0cSDCardAction\x12\x0f\n\x0bREMOVE_CARD\x10\x00\x12\x0f\n\x0bINSERT_CARD\x10\x01\"\x0e\n\x0cResetRequest\",\n\x18SetDeviceLanguageRequest\x12\x10\n\x08language\x18\x01 \x01(\t\"$\n\x14SetDeviceNameRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\"%\n\x12SetPasswordRequest\x12\x0f\n\x07\x65ntropy\x18\x01 \x01(\x0c\x62\x06proto3')
+  serialized_pb=_b('\n\x15\x62itbox02_system.proto\x12\x14shiftcrypto.bitbox02\"\x14\n\x12\x43heckSDCardRequest\"\'\n\x13\x43heckSDCardResponse\x12\x10\n\x08inserted\x18\x01 \x01(\x08\"\x13\n\x11\x44\x65viceInfoRequest\"\x95\x01\n\x12\x44\x65viceInfoResponse\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0binitialized\x18\x02 \x01(\x08\x12\x0f\n\x07version\x18\x03 \x01(\t\x12#\n\x1bmnemonic_passphrase_enabled\x18\x04 \x01(\x08\x12&\n\x1emonotonic_increments_remaining\x18\x05 \x01(\r\"\x9b\x01\n\x19InsertRemoveSDCardRequest\x12L\n\x06\x61\x63tion\x18\x01 \x01(\x0e\x32<.shiftcrypto.bitbox02.InsertRemoveSDCardRequest.SDCardAction\"0\n\x0cSDCardAction\x12\x0f\n\x0bREMOVE_CARD\x10\x00\x12\x0f\n\x0bINSERT_CARD\x10\x01\"\x0e\n\x0cResetRequest\",\n\x18SetDeviceLanguageRequest\x12\x10\n\x08language\x18\x01 \x01(\t\"$\n\x14SetDeviceNameRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\"%\n\x12SetPasswordRequest\x12\x0f\n\x07\x65ntropy\x18\x01 \x01(\x0c\x62\x06proto3')
 )
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
@@ -27,7 +27,7 @@ _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 _INSERTREMOVESDCARDREQUEST_SDCARDACTION = _descriptor.EnumDescriptor(
   name='SDCardAction',
-  full_name='InsertRemoveSDCardRequest.SDCardAction',
+  full_name='shiftcrypto.bitbox02.InsertRemoveSDCardRequest.SDCardAction',
   filename=None,
   file=DESCRIPTOR,
   values=[
@@ -42,15 +42,15 @@ _INSERTREMOVESDCARDREQUEST_SDCARDACTION = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=348,
-  serialized_end=396,
+  serialized_start=391,
+  serialized_end=439,
 )
 _sym_db.RegisterEnumDescriptor(_INSERTREMOVESDCARDREQUEST_SDCARDACTION)
 
 
 _CHECKSDCARDREQUEST = _descriptor.Descriptor(
   name='CheckSDCardRequest',
-  full_name='CheckSDCardRequest',
+  full_name='shiftcrypto.bitbox02.CheckSDCardRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
@@ -67,20 +67,20 @@ _CHECKSDCARDREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=25,
-  serialized_end=45,
+  serialized_start=47,
+  serialized_end=67,
 )
 
 
 _CHECKSDCARDRESPONSE = _descriptor.Descriptor(
   name='CheckSDCardResponse',
-  full_name='CheckSDCardResponse',
+  full_name='shiftcrypto.bitbox02.CheckSDCardResponse',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='inserted', full_name='CheckSDCardResponse.inserted', index=0,
+      name='inserted', full_name='shiftcrypto.bitbox02.CheckSDCardResponse.inserted', index=0,
       number=1, type=8, cpp_type=7, label=1,
       has_default_value=False, default_value=False,
       message_type=None, enum_type=None, containing_type=None,
@@ -98,14 +98,14 @@ _CHECKSDCARDRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=47,
-  serialized_end=86,
+  serialized_start=69,
+  serialized_end=108,
 )
 
 
 _DEVICEINFOREQUEST = _descriptor.Descriptor(
   name='DeviceInfoRequest',
-  full_name='DeviceInfoRequest',
+  full_name='shiftcrypto.bitbox02.DeviceInfoRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
@@ -122,48 +122,48 @@ _DEVICEINFOREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=88,
-  serialized_end=107,
+  serialized_start=110,
+  serialized_end=129,
 )
 
 
 _DEVICEINFORESPONSE = _descriptor.Descriptor(
   name='DeviceInfoResponse',
-  full_name='DeviceInfoResponse',
+  full_name='shiftcrypto.bitbox02.DeviceInfoResponse',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='name', full_name='DeviceInfoResponse.name', index=0,
+      name='name', full_name='shiftcrypto.bitbox02.DeviceInfoResponse.name', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='initialized', full_name='DeviceInfoResponse.initialized', index=1,
+      name='initialized', full_name='shiftcrypto.bitbox02.DeviceInfoResponse.initialized', index=1,
       number=2, type=8, cpp_type=7, label=1,
       has_default_value=False, default_value=False,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='version', full_name='DeviceInfoResponse.version', index=2,
+      name='version', full_name='shiftcrypto.bitbox02.DeviceInfoResponse.version', index=2,
       number=3, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='mnemonic_passphrase_enabled', full_name='DeviceInfoResponse.mnemonic_passphrase_enabled', index=3,
+      name='mnemonic_passphrase_enabled', full_name='shiftcrypto.bitbox02.DeviceInfoResponse.mnemonic_passphrase_enabled', index=3,
       number=4, type=8, cpp_type=7, label=1,
       has_default_value=False, default_value=False,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='monotonic_increments_remaining', full_name='DeviceInfoResponse.monotonic_increments_remaining', index=4,
+      name='monotonic_increments_remaining', full_name='shiftcrypto.bitbox02.DeviceInfoResponse.monotonic_increments_remaining', index=4,
       number=5, type=13, cpp_type=3, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
@@ -181,20 +181,20 @@ _DEVICEINFORESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=110,
-  serialized_end=259,
+  serialized_start=132,
+  serialized_end=281,
 )
 
 
 _INSERTREMOVESDCARDREQUEST = _descriptor.Descriptor(
   name='InsertRemoveSDCardRequest',
-  full_name='InsertRemoveSDCardRequest',
+  full_name='shiftcrypto.bitbox02.InsertRemoveSDCardRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='action', full_name='InsertRemoveSDCardRequest.action', index=0,
+      name='action', full_name='shiftcrypto.bitbox02.InsertRemoveSDCardRequest.action', index=0,
       number=1, type=14, cpp_type=8, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
@@ -213,14 +213,14 @@ _INSERTREMOVESDCARDREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=262,
-  serialized_end=396,
+  serialized_start=284,
+  serialized_end=439,
 )
 
 
 _RESETREQUEST = _descriptor.Descriptor(
   name='ResetRequest',
-  full_name='ResetRequest',
+  full_name='shiftcrypto.bitbox02.ResetRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
@@ -237,20 +237,20 @@ _RESETREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=398,
-  serialized_end=412,
+  serialized_start=441,
+  serialized_end=455,
 )
 
 
 _SETDEVICELANGUAGEREQUEST = _descriptor.Descriptor(
   name='SetDeviceLanguageRequest',
-  full_name='SetDeviceLanguageRequest',
+  full_name='shiftcrypto.bitbox02.SetDeviceLanguageRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='language', full_name='SetDeviceLanguageRequest.language', index=0,
+      name='language', full_name='shiftcrypto.bitbox02.SetDeviceLanguageRequest.language', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -268,20 +268,20 @@ _SETDEVICELANGUAGEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=414,
-  serialized_end=458,
+  serialized_start=457,
+  serialized_end=501,
 )
 
 
 _SETDEVICENAMEREQUEST = _descriptor.Descriptor(
   name='SetDeviceNameRequest',
-  full_name='SetDeviceNameRequest',
+  full_name='shiftcrypto.bitbox02.SetDeviceNameRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='name', full_name='SetDeviceNameRequest.name', index=0,
+      name='name', full_name='shiftcrypto.bitbox02.SetDeviceNameRequest.name', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -299,20 +299,20 @@ _SETDEVICENAMEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=460,
-  serialized_end=496,
+  serialized_start=503,
+  serialized_end=539,
 )
 
 
 _SETPASSWORDREQUEST = _descriptor.Descriptor(
   name='SetPasswordRequest',
-  full_name='SetPasswordRequest',
+  full_name='shiftcrypto.bitbox02.SetPasswordRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='entropy', full_name='SetPasswordRequest.entropy', index=0,
+      name='entropy', full_name='shiftcrypto.bitbox02.SetPasswordRequest.entropy', index=0,
       number=1, type=12, cpp_type=9, label=1,
       has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
@@ -330,8 +330,8 @@ _SETPASSWORDREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=498,
-  serialized_end=535,
+  serialized_start=541,
+  serialized_end=578,
 )
 
 _INSERTREMOVESDCARDREQUEST.fields_by_name['action'].enum_type = _INSERTREMOVESDCARDREQUEST_SDCARDACTION
@@ -349,63 +349,63 @@ DESCRIPTOR.message_types_by_name['SetPasswordRequest'] = _SETPASSWORDREQUEST
 CheckSDCardRequest = _reflection.GeneratedProtocolMessageType('CheckSDCardRequest', (_message.Message,), dict(
   DESCRIPTOR = _CHECKSDCARDREQUEST,
   __module__ = 'bitbox02_system_pb2'
-  # @@protoc_insertion_point(class_scope:CheckSDCardRequest)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.CheckSDCardRequest)
   ))
 _sym_db.RegisterMessage(CheckSDCardRequest)
 
 CheckSDCardResponse = _reflection.GeneratedProtocolMessageType('CheckSDCardResponse', (_message.Message,), dict(
   DESCRIPTOR = _CHECKSDCARDRESPONSE,
   __module__ = 'bitbox02_system_pb2'
-  # @@protoc_insertion_point(class_scope:CheckSDCardResponse)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.CheckSDCardResponse)
   ))
 _sym_db.RegisterMessage(CheckSDCardResponse)
 
 DeviceInfoRequest = _reflection.GeneratedProtocolMessageType('DeviceInfoRequest', (_message.Message,), dict(
   DESCRIPTOR = _DEVICEINFOREQUEST,
   __module__ = 'bitbox02_system_pb2'
-  # @@protoc_insertion_point(class_scope:DeviceInfoRequest)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.DeviceInfoRequest)
   ))
 _sym_db.RegisterMessage(DeviceInfoRequest)
 
 DeviceInfoResponse = _reflection.GeneratedProtocolMessageType('DeviceInfoResponse', (_message.Message,), dict(
   DESCRIPTOR = _DEVICEINFORESPONSE,
   __module__ = 'bitbox02_system_pb2'
-  # @@protoc_insertion_point(class_scope:DeviceInfoResponse)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.DeviceInfoResponse)
   ))
 _sym_db.RegisterMessage(DeviceInfoResponse)
 
 InsertRemoveSDCardRequest = _reflection.GeneratedProtocolMessageType('InsertRemoveSDCardRequest', (_message.Message,), dict(
   DESCRIPTOR = _INSERTREMOVESDCARDREQUEST,
   __module__ = 'bitbox02_system_pb2'
-  # @@protoc_insertion_point(class_scope:InsertRemoveSDCardRequest)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.InsertRemoveSDCardRequest)
   ))
 _sym_db.RegisterMessage(InsertRemoveSDCardRequest)
 
 ResetRequest = _reflection.GeneratedProtocolMessageType('ResetRequest', (_message.Message,), dict(
   DESCRIPTOR = _RESETREQUEST,
   __module__ = 'bitbox02_system_pb2'
-  # @@protoc_insertion_point(class_scope:ResetRequest)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.ResetRequest)
   ))
 _sym_db.RegisterMessage(ResetRequest)
 
 SetDeviceLanguageRequest = _reflection.GeneratedProtocolMessageType('SetDeviceLanguageRequest', (_message.Message,), dict(
   DESCRIPTOR = _SETDEVICELANGUAGEREQUEST,
   __module__ = 'bitbox02_system_pb2'
-  # @@protoc_insertion_point(class_scope:SetDeviceLanguageRequest)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.SetDeviceLanguageRequest)
   ))
 _sym_db.RegisterMessage(SetDeviceLanguageRequest)
 
 SetDeviceNameRequest = _reflection.GeneratedProtocolMessageType('SetDeviceNameRequest', (_message.Message,), dict(
   DESCRIPTOR = _SETDEVICENAMEREQUEST,
   __module__ = 'bitbox02_system_pb2'
-  # @@protoc_insertion_point(class_scope:SetDeviceNameRequest)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.SetDeviceNameRequest)
   ))
 _sym_db.RegisterMessage(SetDeviceNameRequest)
 
 SetPasswordRequest = _reflection.GeneratedProtocolMessageType('SetPasswordRequest', (_message.Message,), dict(
   DESCRIPTOR = _SETPASSWORDREQUEST,
   __module__ = 'bitbox02_system_pb2'
-  # @@protoc_insertion_point(class_scope:SetPasswordRequest)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.SetPasswordRequest)
   ))
 _sym_db.RegisterMessage(SetPasswordRequest)
 

--- a/py/bitbox02/bitbox02/communication/generated/bitboxbase_pb2.py
+++ b/py/bitbox02/bitbox02/communication/generated/bitboxbase_pb2.py
@@ -17,9 +17,9 @@ _sym_db = _symbol_database.Default()
 
 DESCRIPTOR = _descriptor.FileDescriptor(
   name='bitboxbase.proto',
-  package='',
+  package='shiftcrypto.bitbox02',
   syntax='proto3',
-  serialized_pb=_b('\n\x10\x62itboxbase.proto\"\x96\x03\n\x1a\x42itBoxBaseHeartbeatRequest\x12\x39\n\nstate_code\x18\x01 \x01(\x0e\x32%.BitBoxBaseHeartbeatRequest.StateCode\x12\x45\n\x10\x64\x65scription_code\x18\x02 \x01(\x0e\x32+.BitBoxBaseHeartbeatRequest.DescriptionCode\":\n\tStateCode\x12\x08\n\x04IDLE\x10\x00\x12\x0b\n\x07WORKING\x10\x01\x12\x0b\n\x07WARNING\x10\x02\x12\t\n\x05\x45RROR\x10\x03\"\xb9\x01\n\x0f\x44\x65scriptionCode\x12\t\n\x05\x45MPTY\x10\x00\x12\x16\n\x12INITIAL_BLOCK_SYNC\x10\x01\x12\x13\n\x0f\x44OWNLOAD_UPDATE\x10\x02\x12\x15\n\x11OUT_OF_DISK_SPACE\x10\x03\x12\x0f\n\x0bREDIS_ERROR\x10\x04\x12\n\n\x06REBOOT\x10\x05\x12\x0c\n\x08SHUTDOWN\x10\x06\x12\x11\n\rUPDATE_FAILED\x10\x07\x12\x19\n\x15NO_NETWORK_CONNECTION\x10\x08\".\n\x1f\x42itBoxBaseConfirmPairingRequest\x12\x0b\n\x03msg\x18\x01 \x01(\x0c\"\x9c\x03\n\x1a\x42itBoxBaseSetConfigRequest\x12\x42\n\x0fstatus_led_mode\x18\x01 \x01(\x0e\x32).BitBoxBaseSetConfigRequest.StatusLedMode\x12H\n\x12status_screen_mode\x18\x02 \x01(\x0e\x32,.BitBoxBaseSetConfigRequest.StatusScreenMode\x12\x0c\n\x02ip\x18\x03 \x01(\x0cH\x00\x12\x10\n\x08hostname\x18\x04 \x01(\t\"Y\n\rStatusLedMode\x12\x0e\n\nLED_ALWAYS\x10\x00\x12\x12\n\x0eLED_ON_WORKING\x10\x01\x12\x12\n\x0eLED_ON_WARNING\x10\x02\x12\x10\n\x0cLED_ON_ERROR\x10\x03\"h\n\x10StatusScreenMode\x12\x11\n\rSCREEN_ALWAYS\x10\x00\x12\x15\n\x11SCREEN_ON_WORKING\x10\x01\x12\x15\n\x11SCREEN_ON_WARNING\x10\x02\x12\x13\n\x0fSCREEN_ON_ERROR\x10\x03\x42\x0b\n\tip_option\"2\n\x1e\x42itBoxBaseDisplayStatusRequest\x12\x10\n\x08\x64uration\x18\x01 \x01(\r\"\xfb\x01\n\x11\x42itBoxBaseRequest\x12\x30\n\theartbeat\x18\x01 \x01(\x0b\x32\x1b.BitBoxBaseHeartbeatRequestH\x00\x12\x31\n\nset_config\x18\x02 \x01(\x0b\x32\x1b.BitBoxBaseSetConfigRequestH\x00\x12;\n\x0f\x63onfirm_pairing\x18\x03 \x01(\x0b\x32 .BitBoxBaseConfirmPairingRequestH\x00\x12\x39\n\x0e\x64isplay_status\x18\x04 \x01(\x0b\x32\x1f.BitBoxBaseDisplayStatusRequestH\x00\x42\t\n\x07requestb\x06proto3')
+  serialized_pb=_b('\n\x10\x62itboxbase.proto\x12\x14shiftcrypto.bitbox02\"\xc0\x03\n\x1a\x42itBoxBaseHeartbeatRequest\x12N\n\nstate_code\x18\x01 \x01(\x0e\x32:.shiftcrypto.bitbox02.BitBoxBaseHeartbeatRequest.StateCode\x12Z\n\x10\x64\x65scription_code\x18\x02 \x01(\x0e\x32@.shiftcrypto.bitbox02.BitBoxBaseHeartbeatRequest.DescriptionCode\":\n\tStateCode\x12\x08\n\x04IDLE\x10\x00\x12\x0b\n\x07WORKING\x10\x01\x12\x0b\n\x07WARNING\x10\x02\x12\t\n\x05\x45RROR\x10\x03\"\xb9\x01\n\x0f\x44\x65scriptionCode\x12\t\n\x05\x45MPTY\x10\x00\x12\x16\n\x12INITIAL_BLOCK_SYNC\x10\x01\x12\x13\n\x0f\x44OWNLOAD_UPDATE\x10\x02\x12\x15\n\x11OUT_OF_DISK_SPACE\x10\x03\x12\x0f\n\x0bREDIS_ERROR\x10\x04\x12\n\n\x06REBOOT\x10\x05\x12\x0c\n\x08SHUTDOWN\x10\x06\x12\x11\n\rUPDATE_FAILED\x10\x07\x12\x19\n\x15NO_NETWORK_CONNECTION\x10\x08\".\n\x1f\x42itBoxBaseConfirmPairingRequest\x12\x0b\n\x03msg\x18\x01 \x01(\x0c\"\xc6\x03\n\x1a\x42itBoxBaseSetConfigRequest\x12W\n\x0fstatus_led_mode\x18\x01 \x01(\x0e\x32>.shiftcrypto.bitbox02.BitBoxBaseSetConfigRequest.StatusLedMode\x12]\n\x12status_screen_mode\x18\x02 \x01(\x0e\x32\x41.shiftcrypto.bitbox02.BitBoxBaseSetConfigRequest.StatusScreenMode\x12\x0c\n\x02ip\x18\x03 \x01(\x0cH\x00\x12\x10\n\x08hostname\x18\x04 \x01(\t\"Y\n\rStatusLedMode\x12\x0e\n\nLED_ALWAYS\x10\x00\x12\x12\n\x0eLED_ON_WORKING\x10\x01\x12\x12\n\x0eLED_ON_WARNING\x10\x02\x12\x10\n\x0cLED_ON_ERROR\x10\x03\"h\n\x10StatusScreenMode\x12\x11\n\rSCREEN_ALWAYS\x10\x00\x12\x15\n\x11SCREEN_ON_WORKING\x10\x01\x12\x15\n\x11SCREEN_ON_WARNING\x10\x02\x12\x13\n\x0fSCREEN_ON_ERROR\x10\x03\x42\x0b\n\tip_option\"2\n\x1e\x42itBoxBaseDisplayStatusRequest\x12\x10\n\x08\x64uration\x18\x01 \x01(\r\"\xcf\x02\n\x11\x42itBoxBaseRequest\x12\x45\n\theartbeat\x18\x01 \x01(\x0b\x32\x30.shiftcrypto.bitbox02.BitBoxBaseHeartbeatRequestH\x00\x12\x46\n\nset_config\x18\x02 \x01(\x0b\x32\x30.shiftcrypto.bitbox02.BitBoxBaseSetConfigRequestH\x00\x12P\n\x0f\x63onfirm_pairing\x18\x03 \x01(\x0b\x32\x35.shiftcrypto.bitbox02.BitBoxBaseConfirmPairingRequestH\x00\x12N\n\x0e\x64isplay_status\x18\x04 \x01(\x0b\x32\x34.shiftcrypto.bitbox02.BitBoxBaseDisplayStatusRequestH\x00\x42\t\n\x07requestb\x06proto3')
 )
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
@@ -27,7 +27,7 @@ _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 _BITBOXBASEHEARTBEATREQUEST_STATECODE = _descriptor.EnumDescriptor(
   name='StateCode',
-  full_name='BitBoxBaseHeartbeatRequest.StateCode',
+  full_name='shiftcrypto.bitbox02.BitBoxBaseHeartbeatRequest.StateCode',
   filename=None,
   file=DESCRIPTOR,
   values=[
@@ -50,14 +50,14 @@ _BITBOXBASEHEARTBEATREQUEST_STATECODE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=181,
-  serialized_end=239,
+  serialized_start=245,
+  serialized_end=303,
 )
 _sym_db.RegisterEnumDescriptor(_BITBOXBASEHEARTBEATREQUEST_STATECODE)
 
 _BITBOXBASEHEARTBEATREQUEST_DESCRIPTIONCODE = _descriptor.EnumDescriptor(
   name='DescriptionCode',
-  full_name='BitBoxBaseHeartbeatRequest.DescriptionCode',
+  full_name='shiftcrypto.bitbox02.BitBoxBaseHeartbeatRequest.DescriptionCode',
   filename=None,
   file=DESCRIPTOR,
   values=[
@@ -100,14 +100,14 @@ _BITBOXBASEHEARTBEATREQUEST_DESCRIPTIONCODE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=242,
-  serialized_end=427,
+  serialized_start=306,
+  serialized_end=491,
 )
 _sym_db.RegisterEnumDescriptor(_BITBOXBASEHEARTBEATREQUEST_DESCRIPTIONCODE)
 
 _BITBOXBASESETCONFIGREQUEST_STATUSLEDMODE = _descriptor.EnumDescriptor(
   name='StatusLedMode',
-  full_name='BitBoxBaseSetConfigRequest.StatusLedMode',
+  full_name='shiftcrypto.bitbox02.BitBoxBaseSetConfigRequest.StatusLedMode',
   filename=None,
   file=DESCRIPTOR,
   values=[
@@ -130,14 +130,14 @@ _BITBOXBASESETCONFIGREQUEST_STATUSLEDMODE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=682,
-  serialized_end=771,
+  serialized_start=788,
+  serialized_end=877,
 )
 _sym_db.RegisterEnumDescriptor(_BITBOXBASESETCONFIGREQUEST_STATUSLEDMODE)
 
 _BITBOXBASESETCONFIGREQUEST_STATUSSCREENMODE = _descriptor.EnumDescriptor(
   name='StatusScreenMode',
-  full_name='BitBoxBaseSetConfigRequest.StatusScreenMode',
+  full_name='shiftcrypto.bitbox02.BitBoxBaseSetConfigRequest.StatusScreenMode',
   filename=None,
   file=DESCRIPTOR,
   values=[
@@ -160,28 +160,28 @@ _BITBOXBASESETCONFIGREQUEST_STATUSSCREENMODE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=773,
-  serialized_end=877,
+  serialized_start=879,
+  serialized_end=983,
 )
 _sym_db.RegisterEnumDescriptor(_BITBOXBASESETCONFIGREQUEST_STATUSSCREENMODE)
 
 
 _BITBOXBASEHEARTBEATREQUEST = _descriptor.Descriptor(
   name='BitBoxBaseHeartbeatRequest',
-  full_name='BitBoxBaseHeartbeatRequest',
+  full_name='shiftcrypto.bitbox02.BitBoxBaseHeartbeatRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='state_code', full_name='BitBoxBaseHeartbeatRequest.state_code', index=0,
+      name='state_code', full_name='shiftcrypto.bitbox02.BitBoxBaseHeartbeatRequest.state_code', index=0,
       number=1, type=14, cpp_type=8, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='description_code', full_name='BitBoxBaseHeartbeatRequest.description_code', index=1,
+      name='description_code', full_name='shiftcrypto.bitbox02.BitBoxBaseHeartbeatRequest.description_code', index=1,
       number=2, type=14, cpp_type=8, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
@@ -201,20 +201,20 @@ _BITBOXBASEHEARTBEATREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=21,
-  serialized_end=427,
+  serialized_start=43,
+  serialized_end=491,
 )
 
 
 _BITBOXBASECONFIRMPAIRINGREQUEST = _descriptor.Descriptor(
   name='BitBoxBaseConfirmPairingRequest',
-  full_name='BitBoxBaseConfirmPairingRequest',
+  full_name='shiftcrypto.bitbox02.BitBoxBaseConfirmPairingRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='msg', full_name='BitBoxBaseConfirmPairingRequest.msg', index=0,
+      name='msg', full_name='shiftcrypto.bitbox02.BitBoxBaseConfirmPairingRequest.msg', index=0,
       number=1, type=12, cpp_type=9, label=1,
       has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
@@ -232,41 +232,41 @@ _BITBOXBASECONFIRMPAIRINGREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=429,
-  serialized_end=475,
+  serialized_start=493,
+  serialized_end=539,
 )
 
 
 _BITBOXBASESETCONFIGREQUEST = _descriptor.Descriptor(
   name='BitBoxBaseSetConfigRequest',
-  full_name='BitBoxBaseSetConfigRequest',
+  full_name='shiftcrypto.bitbox02.BitBoxBaseSetConfigRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='status_led_mode', full_name='BitBoxBaseSetConfigRequest.status_led_mode', index=0,
+      name='status_led_mode', full_name='shiftcrypto.bitbox02.BitBoxBaseSetConfigRequest.status_led_mode', index=0,
       number=1, type=14, cpp_type=8, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='status_screen_mode', full_name='BitBoxBaseSetConfigRequest.status_screen_mode', index=1,
+      name='status_screen_mode', full_name='shiftcrypto.bitbox02.BitBoxBaseSetConfigRequest.status_screen_mode', index=1,
       number=2, type=14, cpp_type=8, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='ip', full_name='BitBoxBaseSetConfigRequest.ip', index=2,
+      name='ip', full_name='shiftcrypto.bitbox02.BitBoxBaseSetConfigRequest.ip', index=2,
       number=3, type=12, cpp_type=9, label=1,
       has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='hostname', full_name='BitBoxBaseSetConfigRequest.hostname', index=3,
+      name='hostname', full_name='shiftcrypto.bitbox02.BitBoxBaseSetConfigRequest.hostname', index=3,
       number=4, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -286,23 +286,23 @@ _BITBOXBASESETCONFIGREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
     _descriptor.OneofDescriptor(
-      name='ip_option', full_name='BitBoxBaseSetConfigRequest.ip_option',
+      name='ip_option', full_name='shiftcrypto.bitbox02.BitBoxBaseSetConfigRequest.ip_option',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=478,
-  serialized_end=890,
+  serialized_start=542,
+  serialized_end=996,
 )
 
 
 _BITBOXBASEDISPLAYSTATUSREQUEST = _descriptor.Descriptor(
   name='BitBoxBaseDisplayStatusRequest',
-  full_name='BitBoxBaseDisplayStatusRequest',
+  full_name='shiftcrypto.bitbox02.BitBoxBaseDisplayStatusRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='duration', full_name='BitBoxBaseDisplayStatusRequest.duration', index=0,
+      name='duration', full_name='shiftcrypto.bitbox02.BitBoxBaseDisplayStatusRequest.duration', index=0,
       number=1, type=13, cpp_type=3, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
@@ -320,41 +320,41 @@ _BITBOXBASEDISPLAYSTATUSREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=892,
-  serialized_end=942,
+  serialized_start=998,
+  serialized_end=1048,
 )
 
 
 _BITBOXBASEREQUEST = _descriptor.Descriptor(
   name='BitBoxBaseRequest',
-  full_name='BitBoxBaseRequest',
+  full_name='shiftcrypto.bitbox02.BitBoxBaseRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='heartbeat', full_name='BitBoxBaseRequest.heartbeat', index=0,
+      name='heartbeat', full_name='shiftcrypto.bitbox02.BitBoxBaseRequest.heartbeat', index=0,
       number=1, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='set_config', full_name='BitBoxBaseRequest.set_config', index=1,
+      name='set_config', full_name='shiftcrypto.bitbox02.BitBoxBaseRequest.set_config', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='confirm_pairing', full_name='BitBoxBaseRequest.confirm_pairing', index=2,
+      name='confirm_pairing', full_name='shiftcrypto.bitbox02.BitBoxBaseRequest.confirm_pairing', index=2,
       number=3, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='display_status', full_name='BitBoxBaseRequest.display_status', index=3,
+      name='display_status', full_name='shiftcrypto.bitbox02.BitBoxBaseRequest.display_status', index=3,
       number=4, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
@@ -372,11 +372,11 @@ _BITBOXBASEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
     _descriptor.OneofDescriptor(
-      name='request', full_name='BitBoxBaseRequest.request',
+      name='request', full_name='shiftcrypto.bitbox02.BitBoxBaseRequest.request',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=945,
-  serialized_end=1196,
+  serialized_start=1051,
+  serialized_end=1386,
 )
 
 _BITBOXBASEHEARTBEATREQUEST.fields_by_name['state_code'].enum_type = _BITBOXBASEHEARTBEATREQUEST_STATECODE
@@ -415,35 +415,35 @@ DESCRIPTOR.message_types_by_name['BitBoxBaseRequest'] = _BITBOXBASEREQUEST
 BitBoxBaseHeartbeatRequest = _reflection.GeneratedProtocolMessageType('BitBoxBaseHeartbeatRequest', (_message.Message,), dict(
   DESCRIPTOR = _BITBOXBASEHEARTBEATREQUEST,
   __module__ = 'bitboxbase_pb2'
-  # @@protoc_insertion_point(class_scope:BitBoxBaseHeartbeatRequest)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.BitBoxBaseHeartbeatRequest)
   ))
 _sym_db.RegisterMessage(BitBoxBaseHeartbeatRequest)
 
 BitBoxBaseConfirmPairingRequest = _reflection.GeneratedProtocolMessageType('BitBoxBaseConfirmPairingRequest', (_message.Message,), dict(
   DESCRIPTOR = _BITBOXBASECONFIRMPAIRINGREQUEST,
   __module__ = 'bitboxbase_pb2'
-  # @@protoc_insertion_point(class_scope:BitBoxBaseConfirmPairingRequest)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.BitBoxBaseConfirmPairingRequest)
   ))
 _sym_db.RegisterMessage(BitBoxBaseConfirmPairingRequest)
 
 BitBoxBaseSetConfigRequest = _reflection.GeneratedProtocolMessageType('BitBoxBaseSetConfigRequest', (_message.Message,), dict(
   DESCRIPTOR = _BITBOXBASESETCONFIGREQUEST,
   __module__ = 'bitboxbase_pb2'
-  # @@protoc_insertion_point(class_scope:BitBoxBaseSetConfigRequest)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.BitBoxBaseSetConfigRequest)
   ))
 _sym_db.RegisterMessage(BitBoxBaseSetConfigRequest)
 
 BitBoxBaseDisplayStatusRequest = _reflection.GeneratedProtocolMessageType('BitBoxBaseDisplayStatusRequest', (_message.Message,), dict(
   DESCRIPTOR = _BITBOXBASEDISPLAYSTATUSREQUEST,
   __module__ = 'bitboxbase_pb2'
-  # @@protoc_insertion_point(class_scope:BitBoxBaseDisplayStatusRequest)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.BitBoxBaseDisplayStatusRequest)
   ))
 _sym_db.RegisterMessage(BitBoxBaseDisplayStatusRequest)
 
 BitBoxBaseRequest = _reflection.GeneratedProtocolMessageType('BitBoxBaseRequest', (_message.Message,), dict(
   DESCRIPTOR = _BITBOXBASEREQUEST,
   __module__ = 'bitboxbase_pb2'
-  # @@protoc_insertion_point(class_scope:BitBoxBaseRequest)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.BitBoxBaseRequest)
   ))
 _sym_db.RegisterMessage(BitBoxBaseRequest)
 

--- a/py/bitbox02/bitbox02/communication/generated/btc_pb2.py
+++ b/py/bitbox02/bitbox02/communication/generated/btc_pb2.py
@@ -19,16 +19,16 @@ from . import common_pb2 as common__pb2
 
 DESCRIPTOR = _descriptor.FileDescriptor(
   name='btc.proto',
-  package='',
+  package='shiftcrypto.bitbox02',
   syntax='proto3',
-  serialized_pb=_b('\n\tbtc.proto\x1a\x0c\x63ommon.proto\"\xf6\x01\n\x0f\x42TCScriptConfig\x12\x32\n\x0bsimple_type\x18\x01 \x01(\x0e\x32\x1b.BTCScriptConfig.SimpleTypeH\x00\x12-\n\x08multisig\x18\x02 \x01(\x0b\x32\x19.BTCScriptConfig.MultisigH\x00\x1aK\n\x08Multisig\x12\x11\n\tthreshold\x18\x01 \x01(\r\x12\x14\n\x05xpubs\x18\x02 \x03(\x0b\x32\x05.XPub\x12\x16\n\x0eour_xpub_index\x18\x03 \x01(\r\")\n\nSimpleType\x12\x0f\n\x0bP2WPKH_P2SH\x10\x00\x12\n\n\x06P2WPKH\x10\x01\x42\x08\n\x06\x63onfig\"\x98\x02\n\rBTCPubRequest\x12\x16\n\x04\x63oin\x18\x01 \x01(\x0e\x32\x08.BTCCoin\x12\x0f\n\x07keypath\x18\x02 \x03(\r\x12,\n\txpub_type\x18\x03 \x01(\x0e\x32\x17.BTCPubRequest.XPubTypeH\x00\x12)\n\rscript_config\x18\x04 \x01(\x0b\x32\x10.BTCScriptConfigH\x00\x12\x0f\n\x07\x64isplay\x18\x05 \x01(\x08\"j\n\x08XPubType\x12\x08\n\x04TPUB\x10\x00\x12\x08\n\x04XPUB\x10\x01\x12\x08\n\x04YPUB\x10\x02\x12\x08\n\x04ZPUB\x10\x03\x12\x08\n\x04VPUB\x10\x04\x12\x08\n\x04UPUB\x10\x05\x12\x10\n\x0c\x43\x41PITAL_VPUB\x10\x06\x12\x10\n\x0c\x43\x41PITAL_ZPUB\x10\x07\x42\x08\n\x06output\"\xba\x01\n\x12\x42TCSignInitRequest\x12\x16\n\x04\x63oin\x18\x01 \x01(\x0e\x32\x08.BTCCoin\x12\'\n\rscript_config\x18\x02 \x01(\x0b\x32\x10.BTCScriptConfig\x12\x17\n\x0fkeypath_account\x18\x03 \x03(\r\x12\x0f\n\x07version\x18\x04 \x01(\r\x12\x12\n\nnum_inputs\x18\x05 \x01(\r\x12\x13\n\x0bnum_outputs\x18\x06 \x01(\r\x12\x10\n\x08locktime\x18\x07 \x01(\r\"\xa0\x01\n\x13\x42TCSignNextResponse\x12\'\n\x04type\x18\x01 \x01(\x0e\x32\x19.BTCSignNextResponse.Type\x12\r\n\x05index\x18\x02 \x01(\r\x12\x15\n\rhas_signature\x18\x03 \x01(\x08\x12\x11\n\tsignature\x18\x04 \x01(\x0c\"\'\n\x04Type\x12\t\n\x05INPUT\x10\x00\x12\n\n\x06OUTPUT\x10\x01\x12\x08\n\x04\x44ONE\x10\x02\"y\n\x13\x42TCSignInputRequest\x12\x13\n\x0bprevOutHash\x18\x01 \x01(\x0c\x12\x14\n\x0cprevOutIndex\x18\x02 \x01(\r\x12\x14\n\x0cprevOutValue\x18\x03 \x01(\x04\x12\x10\n\x08sequence\x18\x04 \x01(\r\x12\x0f\n\x07keypath\x18\x06 \x03(\r\"p\n\x14\x42TCSignOutputRequest\x12\x0c\n\x04ours\x18\x01 \x01(\x08\x12\x1c\n\x04type\x18\x02 \x01(\x0e\x32\x0e.BTCOutputType\x12\r\n\x05value\x18\x03 \x01(\x04\x12\x0c\n\x04hash\x18\x04 \x01(\x0c\x12\x0f\n\x07keypath\x18\x05 \x03(\r\"o\n\x1b\x42TCScriptConfigRegistration\x12\x16\n\x04\x63oin\x18\x01 \x01(\x0e\x32\x08.BTCCoin\x12\'\n\rscript_config\x18\x02 \x01(\x0b\x32\x10.BTCScriptConfig\x12\x0f\n\x07keypath\x18\x03 \x03(\r\"\x0c\n\nBTCSuccess\"X\n\"BTCIsScriptConfigRegisteredRequest\x12\x32\n\x0cregistration\x18\x01 \x01(\x0b\x32\x1c.BTCScriptConfigRegistration\"<\n#BTCIsScriptConfigRegisteredResponse\x12\x15\n\ris_registered\x18\x01 \x01(\x08\"b\n\x1e\x42TCRegisterScriptConfigRequest\x12\x32\n\x0cregistration\x18\x01 \x01(\x0b\x32\x1c.BTCScriptConfigRegistration\x12\x0c\n\x04name\x18\x02 \x01(\t\"\xa6\x01\n\nBTCRequest\x12J\n\x1bis_script_config_registered\x18\x01 \x01(\x0b\x32#.BTCIsScriptConfigRegisteredRequestH\x00\x12\x41\n\x16register_script_config\x18\x02 \x01(\x0b\x32\x1f.BTCRegisterScriptConfigRequestH\x00\x42\t\n\x07request\"\x86\x01\n\x0b\x42TCResponse\x12\x1e\n\x07success\x18\x01 \x01(\x0b\x32\x0b.BTCSuccessH\x00\x12K\n\x1bis_script_config_registered\x18\x02 \x01(\x0b\x32$.BTCIsScriptConfigRegisteredResponseH\x00\x42\n\n\x08response*/\n\x07\x42TCCoin\x12\x07\n\x03\x42TC\x10\x00\x12\x08\n\x04TBTC\x10\x01\x12\x07\n\x03LTC\x10\x02\x12\x08\n\x04TLTC\x10\x03*H\n\rBTCOutputType\x12\x0b\n\x07UNKNOWN\x10\x00\x12\t\n\x05P2PKH\x10\x01\x12\x08\n\x04P2SH\x10\x02\x12\n\n\x06P2WPKH\x10\x03\x12\t\n\x05P2WSH\x10\x04\x62\x06proto3')
+  serialized_pb=_b('\n\tbtc.proto\x12\x14shiftcrypto.bitbox02\x1a\x0c\x63ommon.proto\"\xb5\x02\n\x0f\x42TCScriptConfig\x12G\n\x0bsimple_type\x18\x01 \x01(\x0e\x32\x30.shiftcrypto.bitbox02.BTCScriptConfig.SimpleTypeH\x00\x12\x42\n\x08multisig\x18\x02 \x01(\x0b\x32..shiftcrypto.bitbox02.BTCScriptConfig.MultisigH\x00\x1a`\n\x08Multisig\x12\x11\n\tthreshold\x18\x01 \x01(\r\x12)\n\x05xpubs\x18\x02 \x03(\x0b\x32\x1a.shiftcrypto.bitbox02.XPub\x12\x16\n\x0eour_xpub_index\x18\x03 \x01(\r\")\n\nSimpleType\x12\x0f\n\x0bP2WPKH_P2SH\x10\x00\x12\n\n\x06P2WPKH\x10\x01\x42\x08\n\x06\x63onfig\"\xd7\x02\n\rBTCPubRequest\x12+\n\x04\x63oin\x18\x01 \x01(\x0e\x32\x1d.shiftcrypto.bitbox02.BTCCoin\x12\x0f\n\x07keypath\x18\x02 \x03(\r\x12\x41\n\txpub_type\x18\x03 \x01(\x0e\x32,.shiftcrypto.bitbox02.BTCPubRequest.XPubTypeH\x00\x12>\n\rscript_config\x18\x04 \x01(\x0b\x32%.shiftcrypto.bitbox02.BTCScriptConfigH\x00\x12\x0f\n\x07\x64isplay\x18\x05 \x01(\x08\"j\n\x08XPubType\x12\x08\n\x04TPUB\x10\x00\x12\x08\n\x04XPUB\x10\x01\x12\x08\n\x04YPUB\x10\x02\x12\x08\n\x04ZPUB\x10\x03\x12\x08\n\x04VPUB\x10\x04\x12\x08\n\x04UPUB\x10\x05\x12\x10\n\x0c\x43\x41PITAL_VPUB\x10\x06\x12\x10\n\x0c\x43\x41PITAL_ZPUB\x10\x07\x42\x08\n\x06output\"\xe4\x01\n\x12\x42TCSignInitRequest\x12+\n\x04\x63oin\x18\x01 \x01(\x0e\x32\x1d.shiftcrypto.bitbox02.BTCCoin\x12<\n\rscript_config\x18\x02 \x01(\x0b\x32%.shiftcrypto.bitbox02.BTCScriptConfig\x12\x17\n\x0fkeypath_account\x18\x03 \x03(\r\x12\x0f\n\x07version\x18\x04 \x01(\r\x12\x12\n\nnum_inputs\x18\x05 \x01(\r\x12\x13\n\x0bnum_outputs\x18\x06 \x01(\r\x12\x10\n\x08locktime\x18\x07 \x01(\r\"\xb5\x01\n\x13\x42TCSignNextResponse\x12<\n\x04type\x18\x01 \x01(\x0e\x32..shiftcrypto.bitbox02.BTCSignNextResponse.Type\x12\r\n\x05index\x18\x02 \x01(\r\x12\x15\n\rhas_signature\x18\x03 \x01(\x08\x12\x11\n\tsignature\x18\x04 \x01(\x0c\"\'\n\x04Type\x12\t\n\x05INPUT\x10\x00\x12\n\n\x06OUTPUT\x10\x01\x12\x08\n\x04\x44ONE\x10\x02\"y\n\x13\x42TCSignInputRequest\x12\x13\n\x0bprevOutHash\x18\x01 \x01(\x0c\x12\x14\n\x0cprevOutIndex\x18\x02 \x01(\r\x12\x14\n\x0cprevOutValue\x18\x03 \x01(\x04\x12\x10\n\x08sequence\x18\x04 \x01(\r\x12\x0f\n\x07keypath\x18\x06 \x03(\r\"\x85\x01\n\x14\x42TCSignOutputRequest\x12\x0c\n\x04ours\x18\x01 \x01(\x08\x12\x31\n\x04type\x18\x02 \x01(\x0e\x32#.shiftcrypto.bitbox02.BTCOutputType\x12\r\n\x05value\x18\x03 \x01(\x04\x12\x0c\n\x04hash\x18\x04 \x01(\x0c\x12\x0f\n\x07keypath\x18\x05 \x03(\r\"\x99\x01\n\x1b\x42TCScriptConfigRegistration\x12+\n\x04\x63oin\x18\x01 \x01(\x0e\x32\x1d.shiftcrypto.bitbox02.BTCCoin\x12<\n\rscript_config\x18\x02 \x01(\x0b\x32%.shiftcrypto.bitbox02.BTCScriptConfig\x12\x0f\n\x07keypath\x18\x03 \x03(\r\"\x0c\n\nBTCSuccess\"m\n\"BTCIsScriptConfigRegisteredRequest\x12G\n\x0cregistration\x18\x01 \x01(\x0b\x32\x31.shiftcrypto.bitbox02.BTCScriptConfigRegistration\"<\n#BTCIsScriptConfigRegisteredResponse\x12\x15\n\ris_registered\x18\x01 \x01(\x08\"w\n\x1e\x42TCRegisterScriptConfigRequest\x12G\n\x0cregistration\x18\x01 \x01(\x0b\x32\x31.shiftcrypto.bitbox02.BTCScriptConfigRegistration\x12\x0c\n\x04name\x18\x02 \x01(\t\"\xd0\x01\n\nBTCRequest\x12_\n\x1bis_script_config_registered\x18\x01 \x01(\x0b\x32\x38.shiftcrypto.bitbox02.BTCIsScriptConfigRegisteredRequestH\x00\x12V\n\x16register_script_config\x18\x02 \x01(\x0b\x32\x34.shiftcrypto.bitbox02.BTCRegisterScriptConfigRequestH\x00\x42\t\n\x07request\"\xb0\x01\n\x0b\x42TCResponse\x12\x33\n\x07success\x18\x01 \x01(\x0b\x32 .shiftcrypto.bitbox02.BTCSuccessH\x00\x12`\n\x1bis_script_config_registered\x18\x02 \x01(\x0b\x32\x39.shiftcrypto.bitbox02.BTCIsScriptConfigRegisteredResponseH\x00\x42\n\n\x08response*/\n\x07\x42TCCoin\x12\x07\n\x03\x42TC\x10\x00\x12\x08\n\x04TBTC\x10\x01\x12\x07\n\x03LTC\x10\x02\x12\x08\n\x04TLTC\x10\x03*H\n\rBTCOutputType\x12\x0b\n\x07UNKNOWN\x10\x00\x12\t\n\x05P2PKH\x10\x01\x12\x08\n\x04P2SH\x10\x02\x12\n\n\x06P2WPKH\x10\x03\x12\t\n\x05P2WSH\x10\x04\x62\x06proto3')
   ,
   dependencies=[common__pb2.DESCRIPTOR,])
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 _BTCCOIN = _descriptor.EnumDescriptor(
   name='BTCCoin',
-  full_name='BTCCoin',
+  full_name='shiftcrypto.bitbox02.BTCCoin',
   filename=None,
   file=DESCRIPTOR,
   values=[
@@ -51,15 +51,15 @@ _BTCCOIN = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=1833,
-  serialized_end=1880,
+  serialized_start=2235,
+  serialized_end=2282,
 )
 _sym_db.RegisterEnumDescriptor(_BTCCOIN)
 
 BTCCoin = enum_type_wrapper.EnumTypeWrapper(_BTCCOIN)
 _BTCOUTPUTTYPE = _descriptor.EnumDescriptor(
   name='BTCOutputType',
-  full_name='BTCOutputType',
+  full_name='shiftcrypto.bitbox02.BTCOutputType',
   filename=None,
   file=DESCRIPTOR,
   values=[
@@ -86,8 +86,8 @@ _BTCOUTPUTTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=1882,
-  serialized_end=1954,
+  serialized_start=2284,
+  serialized_end=2356,
 )
 _sym_db.RegisterEnumDescriptor(_BTCOUTPUTTYPE)
 
@@ -105,7 +105,7 @@ P2WSH = 4
 
 _BTCSCRIPTCONFIG_SIMPLETYPE = _descriptor.EnumDescriptor(
   name='SimpleType',
-  full_name='BTCScriptConfig.SimpleType',
+  full_name='shiftcrypto.bitbox02.BTCScriptConfig.SimpleType',
   filename=None,
   file=DESCRIPTOR,
   values=[
@@ -120,14 +120,14 @@ _BTCSCRIPTCONFIG_SIMPLETYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=223,
-  serialized_end=264,
+  serialized_start=308,
+  serialized_end=349,
 )
 _sym_db.RegisterEnumDescriptor(_BTCSCRIPTCONFIG_SIMPLETYPE)
 
 _BTCPUBREQUEST_XPUBTYPE = _descriptor.EnumDescriptor(
   name='XPubType',
-  full_name='BTCPubRequest.XPubType',
+  full_name='shiftcrypto.bitbox02.BTCPubRequest.XPubType',
   filename=None,
   file=DESCRIPTOR,
   values=[
@@ -166,14 +166,14 @@ _BTCPUBREQUEST_XPUBTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=441,
-  serialized_end=547,
+  serialized_start=589,
+  serialized_end=695,
 )
 _sym_db.RegisterEnumDescriptor(_BTCPUBREQUEST_XPUBTYPE)
 
 _BTCSIGNNEXTRESPONSE_TYPE = _descriptor.EnumDescriptor(
   name='Type',
-  full_name='BTCSignNextResponse.Type',
+  full_name='shiftcrypto.bitbox02.BTCSignNextResponse.Type',
   filename=None,
   file=DESCRIPTOR,
   values=[
@@ -192,35 +192,35 @@ _BTCSIGNNEXTRESPONSE_TYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=870,
-  serialized_end=909,
+  serialized_start=1081,
+  serialized_end=1120,
 )
 _sym_db.RegisterEnumDescriptor(_BTCSIGNNEXTRESPONSE_TYPE)
 
 
 _BTCSCRIPTCONFIG_MULTISIG = _descriptor.Descriptor(
   name='Multisig',
-  full_name='BTCScriptConfig.Multisig',
+  full_name='shiftcrypto.bitbox02.BTCScriptConfig.Multisig',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='threshold', full_name='BTCScriptConfig.Multisig.threshold', index=0,
+      name='threshold', full_name='shiftcrypto.bitbox02.BTCScriptConfig.Multisig.threshold', index=0,
       number=1, type=13, cpp_type=3, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='xpubs', full_name='BTCScriptConfig.Multisig.xpubs', index=1,
+      name='xpubs', full_name='shiftcrypto.bitbox02.BTCScriptConfig.Multisig.xpubs', index=1,
       number=2, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='our_xpub_index', full_name='BTCScriptConfig.Multisig.our_xpub_index', index=2,
+      name='our_xpub_index', full_name='shiftcrypto.bitbox02.BTCScriptConfig.Multisig.our_xpub_index', index=2,
       number=3, type=13, cpp_type=3, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
@@ -238,26 +238,26 @@ _BTCSCRIPTCONFIG_MULTISIG = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=146,
-  serialized_end=221,
+  serialized_start=210,
+  serialized_end=306,
 )
 
 _BTCSCRIPTCONFIG = _descriptor.Descriptor(
   name='BTCScriptConfig',
-  full_name='BTCScriptConfig',
+  full_name='shiftcrypto.bitbox02.BTCScriptConfig',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='simple_type', full_name='BTCScriptConfig.simple_type', index=0,
+      name='simple_type', full_name='shiftcrypto.bitbox02.BTCScriptConfig.simple_type', index=0,
       number=1, type=14, cpp_type=8, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='multisig', full_name='BTCScriptConfig.multisig', index=1,
+      name='multisig', full_name='shiftcrypto.bitbox02.BTCScriptConfig.multisig', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
@@ -276,51 +276,51 @@ _BTCSCRIPTCONFIG = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
     _descriptor.OneofDescriptor(
-      name='config', full_name='BTCScriptConfig.config',
+      name='config', full_name='shiftcrypto.bitbox02.BTCScriptConfig.config',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=28,
-  serialized_end=274,
+  serialized_start=50,
+  serialized_end=359,
 )
 
 
 _BTCPUBREQUEST = _descriptor.Descriptor(
   name='BTCPubRequest',
-  full_name='BTCPubRequest',
+  full_name='shiftcrypto.bitbox02.BTCPubRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='coin', full_name='BTCPubRequest.coin', index=0,
+      name='coin', full_name='shiftcrypto.bitbox02.BTCPubRequest.coin', index=0,
       number=1, type=14, cpp_type=8, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='keypath', full_name='BTCPubRequest.keypath', index=1,
+      name='keypath', full_name='shiftcrypto.bitbox02.BTCPubRequest.keypath', index=1,
       number=2, type=13, cpp_type=3, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='xpub_type', full_name='BTCPubRequest.xpub_type', index=2,
+      name='xpub_type', full_name='shiftcrypto.bitbox02.BTCPubRequest.xpub_type', index=2,
       number=3, type=14, cpp_type=8, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='script_config', full_name='BTCPubRequest.script_config', index=3,
+      name='script_config', full_name='shiftcrypto.bitbox02.BTCPubRequest.script_config', index=3,
       number=4, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='display', full_name='BTCPubRequest.display', index=4,
+      name='display', full_name='shiftcrypto.bitbox02.BTCPubRequest.display', index=4,
       number=5, type=8, cpp_type=7, label=1,
       has_default_value=False, default_value=False,
       message_type=None, enum_type=None, containing_type=None,
@@ -339,65 +339,65 @@ _BTCPUBREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
     _descriptor.OneofDescriptor(
-      name='output', full_name='BTCPubRequest.output',
+      name='output', full_name='shiftcrypto.bitbox02.BTCPubRequest.output',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=277,
-  serialized_end=557,
+  serialized_start=362,
+  serialized_end=705,
 )
 
 
 _BTCSIGNINITREQUEST = _descriptor.Descriptor(
   name='BTCSignInitRequest',
-  full_name='BTCSignInitRequest',
+  full_name='shiftcrypto.bitbox02.BTCSignInitRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='coin', full_name='BTCSignInitRequest.coin', index=0,
+      name='coin', full_name='shiftcrypto.bitbox02.BTCSignInitRequest.coin', index=0,
       number=1, type=14, cpp_type=8, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='script_config', full_name='BTCSignInitRequest.script_config', index=1,
+      name='script_config', full_name='shiftcrypto.bitbox02.BTCSignInitRequest.script_config', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='keypath_account', full_name='BTCSignInitRequest.keypath_account', index=2,
+      name='keypath_account', full_name='shiftcrypto.bitbox02.BTCSignInitRequest.keypath_account', index=2,
       number=3, type=13, cpp_type=3, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='version', full_name='BTCSignInitRequest.version', index=3,
+      name='version', full_name='shiftcrypto.bitbox02.BTCSignInitRequest.version', index=3,
       number=4, type=13, cpp_type=3, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='num_inputs', full_name='BTCSignInitRequest.num_inputs', index=4,
+      name='num_inputs', full_name='shiftcrypto.bitbox02.BTCSignInitRequest.num_inputs', index=4,
       number=5, type=13, cpp_type=3, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='num_outputs', full_name='BTCSignInitRequest.num_outputs', index=5,
+      name='num_outputs', full_name='shiftcrypto.bitbox02.BTCSignInitRequest.num_outputs', index=5,
       number=6, type=13, cpp_type=3, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='locktime', full_name='BTCSignInitRequest.locktime', index=6,
+      name='locktime', full_name='shiftcrypto.bitbox02.BTCSignInitRequest.locktime', index=6,
       number=7, type=13, cpp_type=3, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
@@ -415,41 +415,41 @@ _BTCSIGNINITREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=560,
-  serialized_end=746,
+  serialized_start=708,
+  serialized_end=936,
 )
 
 
 _BTCSIGNNEXTRESPONSE = _descriptor.Descriptor(
   name='BTCSignNextResponse',
-  full_name='BTCSignNextResponse',
+  full_name='shiftcrypto.bitbox02.BTCSignNextResponse',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='type', full_name='BTCSignNextResponse.type', index=0,
+      name='type', full_name='shiftcrypto.bitbox02.BTCSignNextResponse.type', index=0,
       number=1, type=14, cpp_type=8, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='index', full_name='BTCSignNextResponse.index', index=1,
+      name='index', full_name='shiftcrypto.bitbox02.BTCSignNextResponse.index', index=1,
       number=2, type=13, cpp_type=3, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='has_signature', full_name='BTCSignNextResponse.has_signature', index=2,
+      name='has_signature', full_name='shiftcrypto.bitbox02.BTCSignNextResponse.has_signature', index=2,
       number=3, type=8, cpp_type=7, label=1,
       has_default_value=False, default_value=False,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='signature', full_name='BTCSignNextResponse.signature', index=3,
+      name='signature', full_name='shiftcrypto.bitbox02.BTCSignNextResponse.signature', index=3,
       number=4, type=12, cpp_type=9, label=1,
       has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
@@ -468,48 +468,48 @@ _BTCSIGNNEXTRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=749,
-  serialized_end=909,
+  serialized_start=939,
+  serialized_end=1120,
 )
 
 
 _BTCSIGNINPUTREQUEST = _descriptor.Descriptor(
   name='BTCSignInputRequest',
-  full_name='BTCSignInputRequest',
+  full_name='shiftcrypto.bitbox02.BTCSignInputRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='prevOutHash', full_name='BTCSignInputRequest.prevOutHash', index=0,
+      name='prevOutHash', full_name='shiftcrypto.bitbox02.BTCSignInputRequest.prevOutHash', index=0,
       number=1, type=12, cpp_type=9, label=1,
       has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='prevOutIndex', full_name='BTCSignInputRequest.prevOutIndex', index=1,
+      name='prevOutIndex', full_name='shiftcrypto.bitbox02.BTCSignInputRequest.prevOutIndex', index=1,
       number=2, type=13, cpp_type=3, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='prevOutValue', full_name='BTCSignInputRequest.prevOutValue', index=2,
+      name='prevOutValue', full_name='shiftcrypto.bitbox02.BTCSignInputRequest.prevOutValue', index=2,
       number=3, type=4, cpp_type=4, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='sequence', full_name='BTCSignInputRequest.sequence', index=3,
+      name='sequence', full_name='shiftcrypto.bitbox02.BTCSignInputRequest.sequence', index=3,
       number=4, type=13, cpp_type=3, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='keypath', full_name='BTCSignInputRequest.keypath', index=4,
+      name='keypath', full_name='shiftcrypto.bitbox02.BTCSignInputRequest.keypath', index=4,
       number=6, type=13, cpp_type=3, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
@@ -527,48 +527,48 @@ _BTCSIGNINPUTREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=911,
-  serialized_end=1032,
+  serialized_start=1122,
+  serialized_end=1243,
 )
 
 
 _BTCSIGNOUTPUTREQUEST = _descriptor.Descriptor(
   name='BTCSignOutputRequest',
-  full_name='BTCSignOutputRequest',
+  full_name='shiftcrypto.bitbox02.BTCSignOutputRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='ours', full_name='BTCSignOutputRequest.ours', index=0,
+      name='ours', full_name='shiftcrypto.bitbox02.BTCSignOutputRequest.ours', index=0,
       number=1, type=8, cpp_type=7, label=1,
       has_default_value=False, default_value=False,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='type', full_name='BTCSignOutputRequest.type', index=1,
+      name='type', full_name='shiftcrypto.bitbox02.BTCSignOutputRequest.type', index=1,
       number=2, type=14, cpp_type=8, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='value', full_name='BTCSignOutputRequest.value', index=2,
+      name='value', full_name='shiftcrypto.bitbox02.BTCSignOutputRequest.value', index=2,
       number=3, type=4, cpp_type=4, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='hash', full_name='BTCSignOutputRequest.hash', index=3,
+      name='hash', full_name='shiftcrypto.bitbox02.BTCSignOutputRequest.hash', index=3,
       number=4, type=12, cpp_type=9, label=1,
       has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='keypath', full_name='BTCSignOutputRequest.keypath', index=4,
+      name='keypath', full_name='shiftcrypto.bitbox02.BTCSignOutputRequest.keypath', index=4,
       number=5, type=13, cpp_type=3, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
@@ -586,34 +586,34 @@ _BTCSIGNOUTPUTREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1034,
-  serialized_end=1146,
+  serialized_start=1246,
+  serialized_end=1379,
 )
 
 
 _BTCSCRIPTCONFIGREGISTRATION = _descriptor.Descriptor(
   name='BTCScriptConfigRegistration',
-  full_name='BTCScriptConfigRegistration',
+  full_name='shiftcrypto.bitbox02.BTCScriptConfigRegistration',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='coin', full_name='BTCScriptConfigRegistration.coin', index=0,
+      name='coin', full_name='shiftcrypto.bitbox02.BTCScriptConfigRegistration.coin', index=0,
       number=1, type=14, cpp_type=8, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='script_config', full_name='BTCScriptConfigRegistration.script_config', index=1,
+      name='script_config', full_name='shiftcrypto.bitbox02.BTCScriptConfigRegistration.script_config', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='keypath', full_name='BTCScriptConfigRegistration.keypath', index=2,
+      name='keypath', full_name='shiftcrypto.bitbox02.BTCScriptConfigRegistration.keypath', index=2,
       number=3, type=13, cpp_type=3, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
@@ -631,14 +631,14 @@ _BTCSCRIPTCONFIGREGISTRATION = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1148,
-  serialized_end=1259,
+  serialized_start=1382,
+  serialized_end=1535,
 )
 
 
 _BTCSUCCESS = _descriptor.Descriptor(
   name='BTCSuccess',
-  full_name='BTCSuccess',
+  full_name='shiftcrypto.bitbox02.BTCSuccess',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
@@ -655,20 +655,20 @@ _BTCSUCCESS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1261,
-  serialized_end=1273,
+  serialized_start=1537,
+  serialized_end=1549,
 )
 
 
 _BTCISSCRIPTCONFIGREGISTEREDREQUEST = _descriptor.Descriptor(
   name='BTCIsScriptConfigRegisteredRequest',
-  full_name='BTCIsScriptConfigRegisteredRequest',
+  full_name='shiftcrypto.bitbox02.BTCIsScriptConfigRegisteredRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='registration', full_name='BTCIsScriptConfigRegisteredRequest.registration', index=0,
+      name='registration', full_name='shiftcrypto.bitbox02.BTCIsScriptConfigRegisteredRequest.registration', index=0,
       number=1, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
@@ -686,20 +686,20 @@ _BTCISSCRIPTCONFIGREGISTEREDREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1275,
-  serialized_end=1363,
+  serialized_start=1551,
+  serialized_end=1660,
 )
 
 
 _BTCISSCRIPTCONFIGREGISTEREDRESPONSE = _descriptor.Descriptor(
   name='BTCIsScriptConfigRegisteredResponse',
-  full_name='BTCIsScriptConfigRegisteredResponse',
+  full_name='shiftcrypto.bitbox02.BTCIsScriptConfigRegisteredResponse',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='is_registered', full_name='BTCIsScriptConfigRegisteredResponse.is_registered', index=0,
+      name='is_registered', full_name='shiftcrypto.bitbox02.BTCIsScriptConfigRegisteredResponse.is_registered', index=0,
       number=1, type=8, cpp_type=7, label=1,
       has_default_value=False, default_value=False,
       message_type=None, enum_type=None, containing_type=None,
@@ -717,27 +717,27 @@ _BTCISSCRIPTCONFIGREGISTEREDRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1365,
-  serialized_end=1425,
+  serialized_start=1662,
+  serialized_end=1722,
 )
 
 
 _BTCREGISTERSCRIPTCONFIGREQUEST = _descriptor.Descriptor(
   name='BTCRegisterScriptConfigRequest',
-  full_name='BTCRegisterScriptConfigRequest',
+  full_name='shiftcrypto.bitbox02.BTCRegisterScriptConfigRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='registration', full_name='BTCRegisterScriptConfigRequest.registration', index=0,
+      name='registration', full_name='shiftcrypto.bitbox02.BTCRegisterScriptConfigRequest.registration', index=0,
       number=1, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='name', full_name='BTCRegisterScriptConfigRequest.name', index=1,
+      name='name', full_name='shiftcrypto.bitbox02.BTCRegisterScriptConfigRequest.name', index=1,
       number=2, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -755,27 +755,27 @@ _BTCREGISTERSCRIPTCONFIGREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1427,
-  serialized_end=1525,
+  serialized_start=1724,
+  serialized_end=1843,
 )
 
 
 _BTCREQUEST = _descriptor.Descriptor(
   name='BTCRequest',
-  full_name='BTCRequest',
+  full_name='shiftcrypto.bitbox02.BTCRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='is_script_config_registered', full_name='BTCRequest.is_script_config_registered', index=0,
+      name='is_script_config_registered', full_name='shiftcrypto.bitbox02.BTCRequest.is_script_config_registered', index=0,
       number=1, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='register_script_config', full_name='BTCRequest.register_script_config', index=1,
+      name='register_script_config', full_name='shiftcrypto.bitbox02.BTCRequest.register_script_config', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
@@ -793,30 +793,30 @@ _BTCREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
     _descriptor.OneofDescriptor(
-      name='request', full_name='BTCRequest.request',
+      name='request', full_name='shiftcrypto.bitbox02.BTCRequest.request',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=1528,
-  serialized_end=1694,
+  serialized_start=1846,
+  serialized_end=2054,
 )
 
 
 _BTCRESPONSE = _descriptor.Descriptor(
   name='BTCResponse',
-  full_name='BTCResponse',
+  full_name='shiftcrypto.bitbox02.BTCResponse',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='success', full_name='BTCResponse.success', index=0,
+      name='success', full_name='shiftcrypto.bitbox02.BTCResponse.success', index=0,
       number=1, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='is_script_config_registered', full_name='BTCResponse.is_script_config_registered', index=1,
+      name='is_script_config_registered', full_name='shiftcrypto.bitbox02.BTCResponse.is_script_config_registered', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
@@ -834,11 +834,11 @@ _BTCRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
     _descriptor.OneofDescriptor(
-      name='response', full_name='BTCResponse.response',
+      name='response', full_name='shiftcrypto.bitbox02.BTCResponse.response',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=1697,
-  serialized_end=1831,
+  serialized_start=2057,
+  serialized_end=2233,
 )
 
 _BTCSCRIPTCONFIG_MULTISIG.fields_by_name['xpubs'].message_type = common__pb2._XPUB
@@ -908,12 +908,12 @@ BTCScriptConfig = _reflection.GeneratedProtocolMessageType('BTCScriptConfig', (_
   Multisig = _reflection.GeneratedProtocolMessageType('Multisig', (_message.Message,), dict(
     DESCRIPTOR = _BTCSCRIPTCONFIG_MULTISIG,
     __module__ = 'btc_pb2'
-    # @@protoc_insertion_point(class_scope:BTCScriptConfig.Multisig)
+    # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.BTCScriptConfig.Multisig)
     ))
   ,
   DESCRIPTOR = _BTCSCRIPTCONFIG,
   __module__ = 'btc_pb2'
-  # @@protoc_insertion_point(class_scope:BTCScriptConfig)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.BTCScriptConfig)
   ))
 _sym_db.RegisterMessage(BTCScriptConfig)
 _sym_db.RegisterMessage(BTCScriptConfig.Multisig)
@@ -921,84 +921,84 @@ _sym_db.RegisterMessage(BTCScriptConfig.Multisig)
 BTCPubRequest = _reflection.GeneratedProtocolMessageType('BTCPubRequest', (_message.Message,), dict(
   DESCRIPTOR = _BTCPUBREQUEST,
   __module__ = 'btc_pb2'
-  # @@protoc_insertion_point(class_scope:BTCPubRequest)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.BTCPubRequest)
   ))
 _sym_db.RegisterMessage(BTCPubRequest)
 
 BTCSignInitRequest = _reflection.GeneratedProtocolMessageType('BTCSignInitRequest', (_message.Message,), dict(
   DESCRIPTOR = _BTCSIGNINITREQUEST,
   __module__ = 'btc_pb2'
-  # @@protoc_insertion_point(class_scope:BTCSignInitRequest)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.BTCSignInitRequest)
   ))
 _sym_db.RegisterMessage(BTCSignInitRequest)
 
 BTCSignNextResponse = _reflection.GeneratedProtocolMessageType('BTCSignNextResponse', (_message.Message,), dict(
   DESCRIPTOR = _BTCSIGNNEXTRESPONSE,
   __module__ = 'btc_pb2'
-  # @@protoc_insertion_point(class_scope:BTCSignNextResponse)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.BTCSignNextResponse)
   ))
 _sym_db.RegisterMessage(BTCSignNextResponse)
 
 BTCSignInputRequest = _reflection.GeneratedProtocolMessageType('BTCSignInputRequest', (_message.Message,), dict(
   DESCRIPTOR = _BTCSIGNINPUTREQUEST,
   __module__ = 'btc_pb2'
-  # @@protoc_insertion_point(class_scope:BTCSignInputRequest)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.BTCSignInputRequest)
   ))
 _sym_db.RegisterMessage(BTCSignInputRequest)
 
 BTCSignOutputRequest = _reflection.GeneratedProtocolMessageType('BTCSignOutputRequest', (_message.Message,), dict(
   DESCRIPTOR = _BTCSIGNOUTPUTREQUEST,
   __module__ = 'btc_pb2'
-  # @@protoc_insertion_point(class_scope:BTCSignOutputRequest)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.BTCSignOutputRequest)
   ))
 _sym_db.RegisterMessage(BTCSignOutputRequest)
 
 BTCScriptConfigRegistration = _reflection.GeneratedProtocolMessageType('BTCScriptConfigRegistration', (_message.Message,), dict(
   DESCRIPTOR = _BTCSCRIPTCONFIGREGISTRATION,
   __module__ = 'btc_pb2'
-  # @@protoc_insertion_point(class_scope:BTCScriptConfigRegistration)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.BTCScriptConfigRegistration)
   ))
 _sym_db.RegisterMessage(BTCScriptConfigRegistration)
 
 BTCSuccess = _reflection.GeneratedProtocolMessageType('BTCSuccess', (_message.Message,), dict(
   DESCRIPTOR = _BTCSUCCESS,
   __module__ = 'btc_pb2'
-  # @@protoc_insertion_point(class_scope:BTCSuccess)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.BTCSuccess)
   ))
 _sym_db.RegisterMessage(BTCSuccess)
 
 BTCIsScriptConfigRegisteredRequest = _reflection.GeneratedProtocolMessageType('BTCIsScriptConfigRegisteredRequest', (_message.Message,), dict(
   DESCRIPTOR = _BTCISSCRIPTCONFIGREGISTEREDREQUEST,
   __module__ = 'btc_pb2'
-  # @@protoc_insertion_point(class_scope:BTCIsScriptConfigRegisteredRequest)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.BTCIsScriptConfigRegisteredRequest)
   ))
 _sym_db.RegisterMessage(BTCIsScriptConfigRegisteredRequest)
 
 BTCIsScriptConfigRegisteredResponse = _reflection.GeneratedProtocolMessageType('BTCIsScriptConfigRegisteredResponse', (_message.Message,), dict(
   DESCRIPTOR = _BTCISSCRIPTCONFIGREGISTEREDRESPONSE,
   __module__ = 'btc_pb2'
-  # @@protoc_insertion_point(class_scope:BTCIsScriptConfigRegisteredResponse)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.BTCIsScriptConfigRegisteredResponse)
   ))
 _sym_db.RegisterMessage(BTCIsScriptConfigRegisteredResponse)
 
 BTCRegisterScriptConfigRequest = _reflection.GeneratedProtocolMessageType('BTCRegisterScriptConfigRequest', (_message.Message,), dict(
   DESCRIPTOR = _BTCREGISTERSCRIPTCONFIGREQUEST,
   __module__ = 'btc_pb2'
-  # @@protoc_insertion_point(class_scope:BTCRegisterScriptConfigRequest)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.BTCRegisterScriptConfigRequest)
   ))
 _sym_db.RegisterMessage(BTCRegisterScriptConfigRequest)
 
 BTCRequest = _reflection.GeneratedProtocolMessageType('BTCRequest', (_message.Message,), dict(
   DESCRIPTOR = _BTCREQUEST,
   __module__ = 'btc_pb2'
-  # @@protoc_insertion_point(class_scope:BTCRequest)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.BTCRequest)
   ))
 _sym_db.RegisterMessage(BTCRequest)
 
 BTCResponse = _reflection.GeneratedProtocolMessageType('BTCResponse', (_message.Message,), dict(
   DESCRIPTOR = _BTCRESPONSE,
   __module__ = 'btc_pb2'
-  # @@protoc_insertion_point(class_scope:BTCResponse)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.BTCResponse)
   ))
 _sym_db.RegisterMessage(BTCResponse)
 

--- a/py/bitbox02/bitbox02/communication/generated/common_pb2.py
+++ b/py/bitbox02/bitbox02/communication/generated/common_pb2.py
@@ -17,9 +17,9 @@ _sym_db = _symbol_database.Default()
 
 DESCRIPTOR = _descriptor.FileDescriptor(
   name='common.proto',
-  package='',
+  package='shiftcrypto.bitbox02',
   syntax='proto3',
-  serialized_pb=_b('\n\x0c\x63ommon.proto\"\x1a\n\x0bPubResponse\x12\x0b\n\x03pub\x18\x01 \x01(\t\"\x18\n\x16RootFingerprintRequest\".\n\x17RootFingerprintResponse\x12\x13\n\x0b\x66ingerprint\x18\x01 \x01(\x0c\"l\n\x04XPub\x12\r\n\x05\x64\x65pth\x18\x01 \x01(\x0c\x12\x1a\n\x12parent_fingerprint\x18\x02 \x01(\x0c\x12\x11\n\tchild_num\x18\x03 \x01(\r\x12\x12\n\nchain_code\x18\x04 \x01(\x0c\x12\x12\n\npublic_key\x18\x05 \x01(\x0c\x62\x06proto3')
+  serialized_pb=_b('\n\x0c\x63ommon.proto\x12\x14shiftcrypto.bitbox02\"\x1a\n\x0bPubResponse\x12\x0b\n\x03pub\x18\x01 \x01(\t\"\x18\n\x16RootFingerprintRequest\".\n\x17RootFingerprintResponse\x12\x13\n\x0b\x66ingerprint\x18\x01 \x01(\x0c\"l\n\x04XPub\x12\r\n\x05\x64\x65pth\x18\x01 \x01(\x0c\x12\x1a\n\x12parent_fingerprint\x18\x02 \x01(\x0c\x12\x11\n\tchild_num\x18\x03 \x01(\r\x12\x12\n\nchain_code\x18\x04 \x01(\x0c\x12\x12\n\npublic_key\x18\x05 \x01(\x0c\x62\x06proto3')
 )
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
@@ -28,13 +28,13 @@ _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 _PUBRESPONSE = _descriptor.Descriptor(
   name='PubResponse',
-  full_name='PubResponse',
+  full_name='shiftcrypto.bitbox02.PubResponse',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='pub', full_name='PubResponse.pub', index=0,
+      name='pub', full_name='shiftcrypto.bitbox02.PubResponse.pub', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -52,14 +52,14 @@ _PUBRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=16,
-  serialized_end=42,
+  serialized_start=38,
+  serialized_end=64,
 )
 
 
 _ROOTFINGERPRINTREQUEST = _descriptor.Descriptor(
   name='RootFingerprintRequest',
-  full_name='RootFingerprintRequest',
+  full_name='shiftcrypto.bitbox02.RootFingerprintRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
@@ -76,20 +76,20 @@ _ROOTFINGERPRINTREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=44,
-  serialized_end=68,
+  serialized_start=66,
+  serialized_end=90,
 )
 
 
 _ROOTFINGERPRINTRESPONSE = _descriptor.Descriptor(
   name='RootFingerprintResponse',
-  full_name='RootFingerprintResponse',
+  full_name='shiftcrypto.bitbox02.RootFingerprintResponse',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='fingerprint', full_name='RootFingerprintResponse.fingerprint', index=0,
+      name='fingerprint', full_name='shiftcrypto.bitbox02.RootFingerprintResponse.fingerprint', index=0,
       number=1, type=12, cpp_type=9, label=1,
       has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
@@ -107,48 +107,48 @@ _ROOTFINGERPRINTRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=70,
-  serialized_end=116,
+  serialized_start=92,
+  serialized_end=138,
 )
 
 
 _XPUB = _descriptor.Descriptor(
   name='XPub',
-  full_name='XPub',
+  full_name='shiftcrypto.bitbox02.XPub',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='depth', full_name='XPub.depth', index=0,
+      name='depth', full_name='shiftcrypto.bitbox02.XPub.depth', index=0,
       number=1, type=12, cpp_type=9, label=1,
       has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='parent_fingerprint', full_name='XPub.parent_fingerprint', index=1,
+      name='parent_fingerprint', full_name='shiftcrypto.bitbox02.XPub.parent_fingerprint', index=1,
       number=2, type=12, cpp_type=9, label=1,
       has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='child_num', full_name='XPub.child_num', index=2,
+      name='child_num', full_name='shiftcrypto.bitbox02.XPub.child_num', index=2,
       number=3, type=13, cpp_type=3, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='chain_code', full_name='XPub.chain_code', index=3,
+      name='chain_code', full_name='shiftcrypto.bitbox02.XPub.chain_code', index=3,
       number=4, type=12, cpp_type=9, label=1,
       has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='public_key', full_name='XPub.public_key', index=4,
+      name='public_key', full_name='shiftcrypto.bitbox02.XPub.public_key', index=4,
       number=5, type=12, cpp_type=9, label=1,
       has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
@@ -166,8 +166,8 @@ _XPUB = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=118,
-  serialized_end=226,
+  serialized_start=140,
+  serialized_end=248,
 )
 
 DESCRIPTOR.message_types_by_name['PubResponse'] = _PUBRESPONSE
@@ -178,28 +178,28 @@ DESCRIPTOR.message_types_by_name['XPub'] = _XPUB
 PubResponse = _reflection.GeneratedProtocolMessageType('PubResponse', (_message.Message,), dict(
   DESCRIPTOR = _PUBRESPONSE,
   __module__ = 'common_pb2'
-  # @@protoc_insertion_point(class_scope:PubResponse)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.PubResponse)
   ))
 _sym_db.RegisterMessage(PubResponse)
 
 RootFingerprintRequest = _reflection.GeneratedProtocolMessageType('RootFingerprintRequest', (_message.Message,), dict(
   DESCRIPTOR = _ROOTFINGERPRINTREQUEST,
   __module__ = 'common_pb2'
-  # @@protoc_insertion_point(class_scope:RootFingerprintRequest)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.RootFingerprintRequest)
   ))
 _sym_db.RegisterMessage(RootFingerprintRequest)
 
 RootFingerprintResponse = _reflection.GeneratedProtocolMessageType('RootFingerprintResponse', (_message.Message,), dict(
   DESCRIPTOR = _ROOTFINGERPRINTRESPONSE,
   __module__ = 'common_pb2'
-  # @@protoc_insertion_point(class_scope:RootFingerprintResponse)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.RootFingerprintResponse)
   ))
 _sym_db.RegisterMessage(RootFingerprintResponse)
 
 XPub = _reflection.GeneratedProtocolMessageType('XPub', (_message.Message,), dict(
   DESCRIPTOR = _XPUB,
   __module__ = 'common_pb2'
-  # @@protoc_insertion_point(class_scope:XPub)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.XPub)
   ))
 _sym_db.RegisterMessage(XPub)
 

--- a/py/bitbox02/bitbox02/communication/generated/eth_pb2.py
+++ b/py/bitbox02/bitbox02/communication/generated/eth_pb2.py
@@ -19,16 +19,16 @@ from . import common_pb2 as common__pb2
 
 DESCRIPTOR = _descriptor.FileDescriptor(
   name='eth.proto',
-  package='',
+  package='shiftcrypto.bitbox02',
   syntax='proto3',
-  serialized_pb=_b('\n\teth.proto\x1a\x0c\x63ommon.proto\"\xb8\x01\n\rETHPubRequest\x12\x0f\n\x07keypath\x18\x01 \x03(\r\x12\x16\n\x04\x63oin\x18\x02 \x01(\x0e\x32\x08.ETHCoin\x12.\n\x0boutput_type\x18\x03 \x01(\x0e\x32\x19.ETHPubRequest.OutputType\x12\x0f\n\x07\x64isplay\x18\x04 \x01(\x08\x12\x18\n\x10\x63ontract_address\x18\x05 \x01(\x0c\"#\n\nOutputType\x12\x0b\n\x07\x41\x44\x44RESS\x10\x00\x12\x08\n\x04XPUB\x10\x01\"\x9e\x01\n\x0e\x45THSignRequest\x12\x16\n\x04\x63oin\x18\x01 \x01(\x0e\x32\x08.ETHCoin\x12\x0f\n\x07keypath\x18\x02 \x03(\r\x12\r\n\x05nonce\x18\x03 \x01(\x0c\x12\x11\n\tgas_price\x18\x04 \x01(\x0c\x12\x11\n\tgas_limit\x18\x05 \x01(\x0c\x12\x11\n\trecipient\x18\x06 \x01(\x0c\x12\r\n\x05value\x18\x07 \x01(\x0c\x12\x0c\n\x04\x64\x61ta\x18\x08 \x01(\x0c\"M\n\x15\x45THSignMessageRequest\x12\x16\n\x04\x63oin\x18\x01 \x01(\x0e\x32\x08.ETHCoin\x12\x0f\n\x07keypath\x18\x02 \x03(\r\x12\x0b\n\x03msg\x18\x03 \x01(\x0c\"$\n\x0f\x45THSignResponse\x12\x11\n\tsignature\x18\x01 \x01(\x0c\"\x83\x01\n\nETHRequest\x12\x1d\n\x03pub\x18\x01 \x01(\x0b\x32\x0e.ETHPubRequestH\x00\x12\x1f\n\x04sign\x18\x02 \x01(\x0b\x32\x0f.ETHSignRequestH\x00\x12*\n\x08sign_msg\x18\x03 \x01(\x0b\x32\x16.ETHSignMessageRequestH\x00\x42\t\n\x07request\"X\n\x0b\x45THResponse\x12\x1b\n\x03pub\x18\x01 \x01(\x0b\x32\x0c.PubResponseH\x00\x12 \n\x04sign\x18\x02 \x01(\x0b\x32\x10.ETHSignResponseH\x00\x42\n\n\x08response*2\n\x07\x45THCoin\x12\x07\n\x03\x45TH\x10\x00\x12\x0e\n\nRopstenETH\x10\x01\x12\x0e\n\nRinkebyETH\x10\x02\x62\x06proto3')
+  serialized_pb=_b('\n\teth.proto\x12\x14shiftcrypto.bitbox02\x1a\x0c\x63ommon.proto\"\xe2\x01\n\rETHPubRequest\x12\x0f\n\x07keypath\x18\x01 \x03(\r\x12+\n\x04\x63oin\x18\x02 \x01(\x0e\x32\x1d.shiftcrypto.bitbox02.ETHCoin\x12\x43\n\x0boutput_type\x18\x03 \x01(\x0e\x32..shiftcrypto.bitbox02.ETHPubRequest.OutputType\x12\x0f\n\x07\x64isplay\x18\x04 \x01(\x08\x12\x18\n\x10\x63ontract_address\x18\x05 \x01(\x0c\"#\n\nOutputType\x12\x0b\n\x07\x41\x44\x44RESS\x10\x00\x12\x08\n\x04XPUB\x10\x01\"\xb3\x01\n\x0e\x45THSignRequest\x12+\n\x04\x63oin\x18\x01 \x01(\x0e\x32\x1d.shiftcrypto.bitbox02.ETHCoin\x12\x0f\n\x07keypath\x18\x02 \x03(\r\x12\r\n\x05nonce\x18\x03 \x01(\x0c\x12\x11\n\tgas_price\x18\x04 \x01(\x0c\x12\x11\n\tgas_limit\x18\x05 \x01(\x0c\x12\x11\n\trecipient\x18\x06 \x01(\x0c\x12\r\n\x05value\x18\x07 \x01(\x0c\x12\x0c\n\x04\x64\x61ta\x18\x08 \x01(\x0c\"b\n\x15\x45THSignMessageRequest\x12+\n\x04\x63oin\x18\x01 \x01(\x0e\x32\x1d.shiftcrypto.bitbox02.ETHCoin\x12\x0f\n\x07keypath\x18\x02 \x03(\r\x12\x0b\n\x03msg\x18\x03 \x01(\x0c\"$\n\x0f\x45THSignResponse\x12\x11\n\tsignature\x18\x01 \x01(\x0c\"\xc2\x01\n\nETHRequest\x12\x32\n\x03pub\x18\x01 \x01(\x0b\x32#.shiftcrypto.bitbox02.ETHPubRequestH\x00\x12\x34\n\x04sign\x18\x02 \x01(\x0b\x32$.shiftcrypto.bitbox02.ETHSignRequestH\x00\x12?\n\x08sign_msg\x18\x03 \x01(\x0b\x32+.shiftcrypto.bitbox02.ETHSignMessageRequestH\x00\x42\t\n\x07request\"\x82\x01\n\x0b\x45THResponse\x12\x30\n\x03pub\x18\x01 \x01(\x0b\x32!.shiftcrypto.bitbox02.PubResponseH\x00\x12\x35\n\x04sign\x18\x02 \x01(\x0b\x32%.shiftcrypto.bitbox02.ETHSignResponseH\x00\x42\n\n\x08response*2\n\x07\x45THCoin\x12\x07\n\x03\x45TH\x10\x00\x12\x0e\n\nRopstenETH\x10\x01\x12\x0e\n\nRinkebyETH\x10\x02\x62\x06proto3')
   ,
   dependencies=[common__pb2.DESCRIPTOR,])
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 _ETHCOIN = _descriptor.EnumDescriptor(
   name='ETHCoin',
-  full_name='ETHCoin',
+  full_name='shiftcrypto.bitbox02.ETHCoin',
   filename=None,
   file=DESCRIPTOR,
   values=[
@@ -47,8 +47,8 @@ _ETHCOIN = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=716,
-  serialized_end=766,
+  serialized_start=928,
+  serialized_end=978,
 )
 _sym_db.RegisterEnumDescriptor(_ETHCOIN)
 
@@ -60,7 +60,7 @@ RinkebyETH = 2
 
 _ETHPUBREQUEST_OUTPUTTYPE = _descriptor.EnumDescriptor(
   name='OutputType',
-  full_name='ETHPubRequest.OutputType',
+  full_name='shiftcrypto.bitbox02.ETHPubRequest.OutputType',
   filename=None,
   file=DESCRIPTOR,
   values=[
@@ -75,49 +75,49 @@ _ETHPUBREQUEST_OUTPUTTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=177,
-  serialized_end=212,
+  serialized_start=241,
+  serialized_end=276,
 )
 _sym_db.RegisterEnumDescriptor(_ETHPUBREQUEST_OUTPUTTYPE)
 
 
 _ETHPUBREQUEST = _descriptor.Descriptor(
   name='ETHPubRequest',
-  full_name='ETHPubRequest',
+  full_name='shiftcrypto.bitbox02.ETHPubRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='keypath', full_name='ETHPubRequest.keypath', index=0,
+      name='keypath', full_name='shiftcrypto.bitbox02.ETHPubRequest.keypath', index=0,
       number=1, type=13, cpp_type=3, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='coin', full_name='ETHPubRequest.coin', index=1,
+      name='coin', full_name='shiftcrypto.bitbox02.ETHPubRequest.coin', index=1,
       number=2, type=14, cpp_type=8, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='output_type', full_name='ETHPubRequest.output_type', index=2,
+      name='output_type', full_name='shiftcrypto.bitbox02.ETHPubRequest.output_type', index=2,
       number=3, type=14, cpp_type=8, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='display', full_name='ETHPubRequest.display', index=3,
+      name='display', full_name='shiftcrypto.bitbox02.ETHPubRequest.display', index=3,
       number=4, type=8, cpp_type=7, label=1,
       has_default_value=False, default_value=False,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='contract_address', full_name='ETHPubRequest.contract_address', index=4,
+      name='contract_address', full_name='shiftcrypto.bitbox02.ETHPubRequest.contract_address', index=4,
       number=5, type=12, cpp_type=9, label=1,
       has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
@@ -136,69 +136,69 @@ _ETHPUBREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=28,
-  serialized_end=212,
+  serialized_start=50,
+  serialized_end=276,
 )
 
 
 _ETHSIGNREQUEST = _descriptor.Descriptor(
   name='ETHSignRequest',
-  full_name='ETHSignRequest',
+  full_name='shiftcrypto.bitbox02.ETHSignRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='coin', full_name='ETHSignRequest.coin', index=0,
+      name='coin', full_name='shiftcrypto.bitbox02.ETHSignRequest.coin', index=0,
       number=1, type=14, cpp_type=8, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='keypath', full_name='ETHSignRequest.keypath', index=1,
+      name='keypath', full_name='shiftcrypto.bitbox02.ETHSignRequest.keypath', index=1,
       number=2, type=13, cpp_type=3, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='nonce', full_name='ETHSignRequest.nonce', index=2,
+      name='nonce', full_name='shiftcrypto.bitbox02.ETHSignRequest.nonce', index=2,
       number=3, type=12, cpp_type=9, label=1,
       has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='gas_price', full_name='ETHSignRequest.gas_price', index=3,
+      name='gas_price', full_name='shiftcrypto.bitbox02.ETHSignRequest.gas_price', index=3,
       number=4, type=12, cpp_type=9, label=1,
       has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='gas_limit', full_name='ETHSignRequest.gas_limit', index=4,
+      name='gas_limit', full_name='shiftcrypto.bitbox02.ETHSignRequest.gas_limit', index=4,
       number=5, type=12, cpp_type=9, label=1,
       has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='recipient', full_name='ETHSignRequest.recipient', index=5,
+      name='recipient', full_name='shiftcrypto.bitbox02.ETHSignRequest.recipient', index=5,
       number=6, type=12, cpp_type=9, label=1,
       has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='value', full_name='ETHSignRequest.value', index=6,
+      name='value', full_name='shiftcrypto.bitbox02.ETHSignRequest.value', index=6,
       number=7, type=12, cpp_type=9, label=1,
       has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='data', full_name='ETHSignRequest.data', index=7,
+      name='data', full_name='shiftcrypto.bitbox02.ETHSignRequest.data', index=7,
       number=8, type=12, cpp_type=9, label=1,
       has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
@@ -216,34 +216,34 @@ _ETHSIGNREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=215,
-  serialized_end=373,
+  serialized_start=279,
+  serialized_end=458,
 )
 
 
 _ETHSIGNMESSAGEREQUEST = _descriptor.Descriptor(
   name='ETHSignMessageRequest',
-  full_name='ETHSignMessageRequest',
+  full_name='shiftcrypto.bitbox02.ETHSignMessageRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='coin', full_name='ETHSignMessageRequest.coin', index=0,
+      name='coin', full_name='shiftcrypto.bitbox02.ETHSignMessageRequest.coin', index=0,
       number=1, type=14, cpp_type=8, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='keypath', full_name='ETHSignMessageRequest.keypath', index=1,
+      name='keypath', full_name='shiftcrypto.bitbox02.ETHSignMessageRequest.keypath', index=1,
       number=2, type=13, cpp_type=3, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='msg', full_name='ETHSignMessageRequest.msg', index=2,
+      name='msg', full_name='shiftcrypto.bitbox02.ETHSignMessageRequest.msg', index=2,
       number=3, type=12, cpp_type=9, label=1,
       has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
@@ -261,20 +261,20 @@ _ETHSIGNMESSAGEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=375,
-  serialized_end=452,
+  serialized_start=460,
+  serialized_end=558,
 )
 
 
 _ETHSIGNRESPONSE = _descriptor.Descriptor(
   name='ETHSignResponse',
-  full_name='ETHSignResponse',
+  full_name='shiftcrypto.bitbox02.ETHSignResponse',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='signature', full_name='ETHSignResponse.signature', index=0,
+      name='signature', full_name='shiftcrypto.bitbox02.ETHSignResponse.signature', index=0,
       number=1, type=12, cpp_type=9, label=1,
       has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
@@ -292,34 +292,34 @@ _ETHSIGNRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=454,
-  serialized_end=490,
+  serialized_start=560,
+  serialized_end=596,
 )
 
 
 _ETHREQUEST = _descriptor.Descriptor(
   name='ETHRequest',
-  full_name='ETHRequest',
+  full_name='shiftcrypto.bitbox02.ETHRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='pub', full_name='ETHRequest.pub', index=0,
+      name='pub', full_name='shiftcrypto.bitbox02.ETHRequest.pub', index=0,
       number=1, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='sign', full_name='ETHRequest.sign', index=1,
+      name='sign', full_name='shiftcrypto.bitbox02.ETHRequest.sign', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='sign_msg', full_name='ETHRequest.sign_msg', index=2,
+      name='sign_msg', full_name='shiftcrypto.bitbox02.ETHRequest.sign_msg', index=2,
       number=3, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
@@ -337,30 +337,30 @@ _ETHREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
     _descriptor.OneofDescriptor(
-      name='request', full_name='ETHRequest.request',
+      name='request', full_name='shiftcrypto.bitbox02.ETHRequest.request',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=493,
-  serialized_end=624,
+  serialized_start=599,
+  serialized_end=793,
 )
 
 
 _ETHRESPONSE = _descriptor.Descriptor(
   name='ETHResponse',
-  full_name='ETHResponse',
+  full_name='shiftcrypto.bitbox02.ETHResponse',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='pub', full_name='ETHResponse.pub', index=0,
+      name='pub', full_name='shiftcrypto.bitbox02.ETHResponse.pub', index=0,
       number=1, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='sign', full_name='ETHResponse.sign', index=1,
+      name='sign', full_name='shiftcrypto.bitbox02.ETHResponse.sign', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
@@ -378,11 +378,11 @@ _ETHRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
     _descriptor.OneofDescriptor(
-      name='response', full_name='ETHResponse.response',
+      name='response', full_name='shiftcrypto.bitbox02.ETHResponse.response',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=626,
-  serialized_end=714,
+  serialized_start=796,
+  serialized_end=926,
 )
 
 _ETHPUBREQUEST.fields_by_name['coin'].enum_type = _ETHCOIN
@@ -421,42 +421,42 @@ DESCRIPTOR.enum_types_by_name['ETHCoin'] = _ETHCOIN
 ETHPubRequest = _reflection.GeneratedProtocolMessageType('ETHPubRequest', (_message.Message,), dict(
   DESCRIPTOR = _ETHPUBREQUEST,
   __module__ = 'eth_pb2'
-  # @@protoc_insertion_point(class_scope:ETHPubRequest)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.ETHPubRequest)
   ))
 _sym_db.RegisterMessage(ETHPubRequest)
 
 ETHSignRequest = _reflection.GeneratedProtocolMessageType('ETHSignRequest', (_message.Message,), dict(
   DESCRIPTOR = _ETHSIGNREQUEST,
   __module__ = 'eth_pb2'
-  # @@protoc_insertion_point(class_scope:ETHSignRequest)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.ETHSignRequest)
   ))
 _sym_db.RegisterMessage(ETHSignRequest)
 
 ETHSignMessageRequest = _reflection.GeneratedProtocolMessageType('ETHSignMessageRequest', (_message.Message,), dict(
   DESCRIPTOR = _ETHSIGNMESSAGEREQUEST,
   __module__ = 'eth_pb2'
-  # @@protoc_insertion_point(class_scope:ETHSignMessageRequest)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.ETHSignMessageRequest)
   ))
 _sym_db.RegisterMessage(ETHSignMessageRequest)
 
 ETHSignResponse = _reflection.GeneratedProtocolMessageType('ETHSignResponse', (_message.Message,), dict(
   DESCRIPTOR = _ETHSIGNRESPONSE,
   __module__ = 'eth_pb2'
-  # @@protoc_insertion_point(class_scope:ETHSignResponse)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.ETHSignResponse)
   ))
 _sym_db.RegisterMessage(ETHSignResponse)
 
 ETHRequest = _reflection.GeneratedProtocolMessageType('ETHRequest', (_message.Message,), dict(
   DESCRIPTOR = _ETHREQUEST,
   __module__ = 'eth_pb2'
-  # @@protoc_insertion_point(class_scope:ETHRequest)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.ETHRequest)
   ))
 _sym_db.RegisterMessage(ETHRequest)
 
 ETHResponse = _reflection.GeneratedProtocolMessageType('ETHResponse', (_message.Message,), dict(
   DESCRIPTOR = _ETHRESPONSE,
   __module__ = 'eth_pb2'
-  # @@protoc_insertion_point(class_scope:ETHResponse)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.ETHResponse)
   ))
 _sym_db.RegisterMessage(ETHResponse)
 

--- a/py/bitbox02/bitbox02/communication/generated/hww_pb2.py
+++ b/py/bitbox02/bitbox02/communication/generated/hww_pb2.py
@@ -28,9 +28,9 @@ from . import perform_attestation_pb2 as perform__attestation__pb2
 
 DESCRIPTOR = _descriptor.FileDescriptor(
   name='hww.proto',
-  package='',
+  package='shiftcrypto.bitbox02',
   syntax='proto3',
-  serialized_pb=_b('\n\thww.proto\x1a\x0c\x63ommon.proto\x1a\x15\x62\x61\x63kup_commands.proto\x1a\x15\x62itbox02_system.proto\x1a\x10\x62itboxbase.proto\x1a\tbtc.proto\x1a\teth.proto\x1a\x0ekeystore.proto\x1a\x0emnemonic.proto\x1a\x13random_number.proto\x1a\x0csystem.proto\x1a\x19perform_attestation.proto\"&\n\x05\x45rror\x12\x0c\n\x04\x63ode\x18\x01 \x01(\x05\x12\x0f\n\x07message\x18\x02 \x01(\t\"\t\n\x07Success\"\xe4\t\n\x07Request\x12-\n\rrandom_number\x18\x01 \x01(\x0b\x32\x14.RandomNumberRequestH\x00\x12,\n\x0b\x64\x65vice_name\x18\x02 \x01(\x0b\x32\x15.SetDeviceNameRequestH\x00\x12\x34\n\x0f\x64\x65vice_language\x18\x03 \x01(\x0b\x32\x19.SetDeviceLanguageRequestH\x00\x12)\n\x0b\x64\x65vice_info\x18\x04 \x01(\x0b\x32\x12.DeviceInfoRequestH\x00\x12+\n\x0cset_password\x18\x05 \x01(\x0b\x32\x13.SetPasswordRequestH\x00\x12-\n\rcreate_backup\x18\x06 \x01(\x0b\x32\x14.CreateBackupRequestH\x00\x12-\n\rshow_mnemonic\x18\x07 \x01(\x0b\x32\x14.ShowMnemonicRequestH\x00\x12!\n\x07\x62tc_pub\x18\x08 \x01(\x0b\x32\x0e.BTCPubRequestH\x00\x12,\n\rbtc_sign_init\x18\t \x01(\x0b\x32\x13.BTCSignInitRequestH\x00\x12.\n\x0e\x62tc_sign_input\x18\n \x01(\x0b\x32\x14.BTCSignInputRequestH\x00\x12\x30\n\x0f\x62tc_sign_output\x18\x0b \x01(\x0b\x32\x15.BTCSignOutputRequestH\x00\x12:\n\x14insert_remove_sdcard\x18\x0c \x01(\x0b\x32\x1a.InsertRemoveSDCardRequestH\x00\x12+\n\x0c\x63heck_sdcard\x18\r \x01(\x0b\x32\x13.CheckSDCardRequestH\x00\x12O\n\x1fset_mnemonic_passphrase_enabled\x18\x0e \x01(\x0b\x32$.SetMnemonicPassphraseEnabledRequestH\x00\x12+\n\x0clist_backups\x18\x0f \x01(\x0b\x32\x13.ListBackupsRequestH\x00\x12/\n\x0erestore_backup\x18\x10 \x01(\x0b\x32\x15.RestoreBackupRequestH\x00\x12\x39\n\x13perform_attestation\x18\x11 \x01(\x0b\x32\x1a.PerformAttestationRequestH\x00\x12 \n\x06reboot\x18\x12 \x01(\x0b\x32\x0e.RebootRequestH\x00\x12+\n\x0c\x63heck_backup\x18\x13 \x01(\x0b\x32\x13.CheckBackupRequestH\x00\x12\x1a\n\x03\x65th\x18\x14 \x01(\x0b\x32\x0b.ETHRequestH\x00\x12\x1e\n\x05reset\x18\x15 \x01(\x0b\x32\r.ResetRequestH\x00\x12<\n\x15restore_from_mnemonic\x18\x16 \x01(\x0b\x32\x1b.RestoreFromMnemonicRequestH\x00\x12(\n\nbitboxbase\x18\x17 \x01(\x0b\x32\x12.BitBoxBaseRequestH\x00\x12.\n\x0b\x66ingerprint\x18\x18 \x01(\x0b\x32\x17.RootFingerprintRequestH\x00\x12\x1a\n\x03\x62tc\x18\x19 \x01(\x0b\x32\x0b.BTCRequestH\x00\x12@\n\x17\x65lectrum_encryption_key\x18\x1a \x01(\x0b\x32\x1d.ElectrumEncryptionKeyRequestH\x00\x42\t\n\x07request\"\xe8\x04\n\x08Response\x12\x1b\n\x07success\x18\x01 \x01(\x0b\x32\x08.SuccessH\x00\x12\x17\n\x05\x65rror\x18\x02 \x01(\x0b\x32\x06.ErrorH\x00\x12.\n\rrandom_number\x18\x03 \x01(\x0b\x32\x15.RandomNumberResponseH\x00\x12*\n\x0b\x64\x65vice_info\x18\x04 \x01(\x0b\x32\x13.DeviceInfoResponseH\x00\x12\x1b\n\x03pub\x18\x05 \x01(\x0b\x32\x0c.PubResponseH\x00\x12-\n\rbtc_sign_next\x18\x06 \x01(\x0b\x32\x14.BTCSignNextResponseH\x00\x12,\n\x0clist_backups\x18\x07 \x01(\x0b\x32\x14.ListBackupsResponseH\x00\x12,\n\x0c\x63heck_backup\x18\x08 \x01(\x0b\x32\x14.CheckBackupResponseH\x00\x12:\n\x13perform_attestation\x18\t \x01(\x0b\x32\x1b.PerformAttestationResponseH\x00\x12,\n\x0c\x63heck_sdcard\x18\n \x01(\x0b\x32\x14.CheckSDCardResponseH\x00\x12\x1b\n\x03\x65th\x18\x0b \x01(\x0b\x32\x0c.ETHResponseH\x00\x12/\n\x0b\x66ingerprint\x18\x0c \x01(\x0b\x32\x18.RootFingerprintResponseH\x00\x12\x1b\n\x03\x62tc\x18\r \x01(\x0b\x32\x0c.BTCResponseH\x00\x12\x41\n\x17\x65lectrum_encryption_key\x18\x0e \x01(\x0b\x32\x1e.ElectrumEncryptionKeyResponseH\x00\x42\n\n\x08responseb\x06proto3')
+  serialized_pb=_b('\n\thww.proto\x12\x14shiftcrypto.bitbox02\x1a\x0c\x63ommon.proto\x1a\x15\x62\x61\x63kup_commands.proto\x1a\x15\x62itbox02_system.proto\x1a\x10\x62itboxbase.proto\x1a\tbtc.proto\x1a\teth.proto\x1a\x0ekeystore.proto\x1a\x0emnemonic.proto\x1a\x13random_number.proto\x1a\x0csystem.proto\x1a\x19perform_attestation.proto\"&\n\x05\x45rror\x12\x0c\n\x04\x63ode\x18\x01 \x01(\x05\x12\x0f\n\x07message\x18\x02 \x01(\t\"\t\n\x07Success\"\x86\x0e\n\x07Request\x12\x42\n\rrandom_number\x18\x01 \x01(\x0b\x32).shiftcrypto.bitbox02.RandomNumberRequestH\x00\x12\x41\n\x0b\x64\x65vice_name\x18\x02 \x01(\x0b\x32*.shiftcrypto.bitbox02.SetDeviceNameRequestH\x00\x12I\n\x0f\x64\x65vice_language\x18\x03 \x01(\x0b\x32..shiftcrypto.bitbox02.SetDeviceLanguageRequestH\x00\x12>\n\x0b\x64\x65vice_info\x18\x04 \x01(\x0b\x32\'.shiftcrypto.bitbox02.DeviceInfoRequestH\x00\x12@\n\x0cset_password\x18\x05 \x01(\x0b\x32(.shiftcrypto.bitbox02.SetPasswordRequestH\x00\x12\x42\n\rcreate_backup\x18\x06 \x01(\x0b\x32).shiftcrypto.bitbox02.CreateBackupRequestH\x00\x12\x42\n\rshow_mnemonic\x18\x07 \x01(\x0b\x32).shiftcrypto.bitbox02.ShowMnemonicRequestH\x00\x12\x36\n\x07\x62tc_pub\x18\x08 \x01(\x0b\x32#.shiftcrypto.bitbox02.BTCPubRequestH\x00\x12\x41\n\rbtc_sign_init\x18\t \x01(\x0b\x32(.shiftcrypto.bitbox02.BTCSignInitRequestH\x00\x12\x43\n\x0e\x62tc_sign_input\x18\n \x01(\x0b\x32).shiftcrypto.bitbox02.BTCSignInputRequestH\x00\x12\x45\n\x0f\x62tc_sign_output\x18\x0b \x01(\x0b\x32*.shiftcrypto.bitbox02.BTCSignOutputRequestH\x00\x12O\n\x14insert_remove_sdcard\x18\x0c \x01(\x0b\x32/.shiftcrypto.bitbox02.InsertRemoveSDCardRequestH\x00\x12@\n\x0c\x63heck_sdcard\x18\r \x01(\x0b\x32(.shiftcrypto.bitbox02.CheckSDCardRequestH\x00\x12\x64\n\x1fset_mnemonic_passphrase_enabled\x18\x0e \x01(\x0b\x32\x39.shiftcrypto.bitbox02.SetMnemonicPassphraseEnabledRequestH\x00\x12@\n\x0clist_backups\x18\x0f \x01(\x0b\x32(.shiftcrypto.bitbox02.ListBackupsRequestH\x00\x12\x44\n\x0erestore_backup\x18\x10 \x01(\x0b\x32*.shiftcrypto.bitbox02.RestoreBackupRequestH\x00\x12N\n\x13perform_attestation\x18\x11 \x01(\x0b\x32/.shiftcrypto.bitbox02.PerformAttestationRequestH\x00\x12\x35\n\x06reboot\x18\x12 \x01(\x0b\x32#.shiftcrypto.bitbox02.RebootRequestH\x00\x12@\n\x0c\x63heck_backup\x18\x13 \x01(\x0b\x32(.shiftcrypto.bitbox02.CheckBackupRequestH\x00\x12/\n\x03\x65th\x18\x14 \x01(\x0b\x32 .shiftcrypto.bitbox02.ETHRequestH\x00\x12\x33\n\x05reset\x18\x15 \x01(\x0b\x32\".shiftcrypto.bitbox02.ResetRequestH\x00\x12Q\n\x15restore_from_mnemonic\x18\x16 \x01(\x0b\x32\x30.shiftcrypto.bitbox02.RestoreFromMnemonicRequestH\x00\x12=\n\nbitboxbase\x18\x17 \x01(\x0b\x32\'.shiftcrypto.bitbox02.BitBoxBaseRequestH\x00\x12\x43\n\x0b\x66ingerprint\x18\x18 \x01(\x0b\x32,.shiftcrypto.bitbox02.RootFingerprintRequestH\x00\x12/\n\x03\x62tc\x18\x19 \x01(\x0b\x32 .shiftcrypto.bitbox02.BTCRequestH\x00\x12U\n\x17\x65lectrum_encryption_key\x18\x1a \x01(\x0b\x32\x32.shiftcrypto.bitbox02.ElectrumEncryptionKeyRequestH\x00\x42\t\n\x07request\"\x8e\x07\n\x08Response\x12\x30\n\x07success\x18\x01 \x01(\x0b\x32\x1d.shiftcrypto.bitbox02.SuccessH\x00\x12,\n\x05\x65rror\x18\x02 \x01(\x0b\x32\x1b.shiftcrypto.bitbox02.ErrorH\x00\x12\x43\n\rrandom_number\x18\x03 \x01(\x0b\x32*.shiftcrypto.bitbox02.RandomNumberResponseH\x00\x12?\n\x0b\x64\x65vice_info\x18\x04 \x01(\x0b\x32(.shiftcrypto.bitbox02.DeviceInfoResponseH\x00\x12\x30\n\x03pub\x18\x05 \x01(\x0b\x32!.shiftcrypto.bitbox02.PubResponseH\x00\x12\x42\n\rbtc_sign_next\x18\x06 \x01(\x0b\x32).shiftcrypto.bitbox02.BTCSignNextResponseH\x00\x12\x41\n\x0clist_backups\x18\x07 \x01(\x0b\x32).shiftcrypto.bitbox02.ListBackupsResponseH\x00\x12\x41\n\x0c\x63heck_backup\x18\x08 \x01(\x0b\x32).shiftcrypto.bitbox02.CheckBackupResponseH\x00\x12O\n\x13perform_attestation\x18\t \x01(\x0b\x32\x30.shiftcrypto.bitbox02.PerformAttestationResponseH\x00\x12\x41\n\x0c\x63heck_sdcard\x18\n \x01(\x0b\x32).shiftcrypto.bitbox02.CheckSDCardResponseH\x00\x12\x30\n\x03\x65th\x18\x0b \x01(\x0b\x32!.shiftcrypto.bitbox02.ETHResponseH\x00\x12\x44\n\x0b\x66ingerprint\x18\x0c \x01(\x0b\x32-.shiftcrypto.bitbox02.RootFingerprintResponseH\x00\x12\x30\n\x03\x62tc\x18\r \x01(\x0b\x32!.shiftcrypto.bitbox02.BTCResponseH\x00\x12V\n\x17\x65lectrum_encryption_key\x18\x0e \x01(\x0b\x32\x33.shiftcrypto.bitbox02.ElectrumEncryptionKeyResponseH\x00\x42\n\n\x08responseb\x06proto3')
   ,
   dependencies=[common__pb2.DESCRIPTOR,backup__commands__pb2.DESCRIPTOR,bitbox02__system__pb2.DESCRIPTOR,bitboxbase__pb2.DESCRIPTOR,btc__pb2.DESCRIPTOR,eth__pb2.DESCRIPTOR,keystore__pb2.DESCRIPTOR,mnemonic__pb2.DESCRIPTOR,random__number__pb2.DESCRIPTOR,system__pb2.DESCRIPTOR,perform__attestation__pb2.DESCRIPTOR,])
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
@@ -40,20 +40,20 @@ _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 _ERROR = _descriptor.Descriptor(
   name='Error',
-  full_name='Error',
+  full_name='shiftcrypto.bitbox02.Error',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='code', full_name='Error.code', index=0,
+      name='code', full_name='shiftcrypto.bitbox02.Error.code', index=0,
       number=1, type=5, cpp_type=1, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='message', full_name='Error.message', index=1,
+      name='message', full_name='shiftcrypto.bitbox02.Error.message', index=1,
       number=2, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -71,14 +71,14 @@ _ERROR = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=207,
-  serialized_end=245,
+  serialized_start=229,
+  serialized_end=267,
 )
 
 
 _SUCCESS = _descriptor.Descriptor(
   name='Success',
-  full_name='Success',
+  full_name='shiftcrypto.bitbox02.Success',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
@@ -95,195 +95,195 @@ _SUCCESS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=247,
-  serialized_end=256,
+  serialized_start=269,
+  serialized_end=278,
 )
 
 
 _REQUEST = _descriptor.Descriptor(
   name='Request',
-  full_name='Request',
+  full_name='shiftcrypto.bitbox02.Request',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='random_number', full_name='Request.random_number', index=0,
+      name='random_number', full_name='shiftcrypto.bitbox02.Request.random_number', index=0,
       number=1, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='device_name', full_name='Request.device_name', index=1,
+      name='device_name', full_name='shiftcrypto.bitbox02.Request.device_name', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='device_language', full_name='Request.device_language', index=2,
+      name='device_language', full_name='shiftcrypto.bitbox02.Request.device_language', index=2,
       number=3, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='device_info', full_name='Request.device_info', index=3,
+      name='device_info', full_name='shiftcrypto.bitbox02.Request.device_info', index=3,
       number=4, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='set_password', full_name='Request.set_password', index=4,
+      name='set_password', full_name='shiftcrypto.bitbox02.Request.set_password', index=4,
       number=5, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='create_backup', full_name='Request.create_backup', index=5,
+      name='create_backup', full_name='shiftcrypto.bitbox02.Request.create_backup', index=5,
       number=6, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='show_mnemonic', full_name='Request.show_mnemonic', index=6,
+      name='show_mnemonic', full_name='shiftcrypto.bitbox02.Request.show_mnemonic', index=6,
       number=7, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='btc_pub', full_name='Request.btc_pub', index=7,
+      name='btc_pub', full_name='shiftcrypto.bitbox02.Request.btc_pub', index=7,
       number=8, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='btc_sign_init', full_name='Request.btc_sign_init', index=8,
+      name='btc_sign_init', full_name='shiftcrypto.bitbox02.Request.btc_sign_init', index=8,
       number=9, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='btc_sign_input', full_name='Request.btc_sign_input', index=9,
+      name='btc_sign_input', full_name='shiftcrypto.bitbox02.Request.btc_sign_input', index=9,
       number=10, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='btc_sign_output', full_name='Request.btc_sign_output', index=10,
+      name='btc_sign_output', full_name='shiftcrypto.bitbox02.Request.btc_sign_output', index=10,
       number=11, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='insert_remove_sdcard', full_name='Request.insert_remove_sdcard', index=11,
+      name='insert_remove_sdcard', full_name='shiftcrypto.bitbox02.Request.insert_remove_sdcard', index=11,
       number=12, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='check_sdcard', full_name='Request.check_sdcard', index=12,
+      name='check_sdcard', full_name='shiftcrypto.bitbox02.Request.check_sdcard', index=12,
       number=13, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='set_mnemonic_passphrase_enabled', full_name='Request.set_mnemonic_passphrase_enabled', index=13,
+      name='set_mnemonic_passphrase_enabled', full_name='shiftcrypto.bitbox02.Request.set_mnemonic_passphrase_enabled', index=13,
       number=14, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='list_backups', full_name='Request.list_backups', index=14,
+      name='list_backups', full_name='shiftcrypto.bitbox02.Request.list_backups', index=14,
       number=15, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='restore_backup', full_name='Request.restore_backup', index=15,
+      name='restore_backup', full_name='shiftcrypto.bitbox02.Request.restore_backup', index=15,
       number=16, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='perform_attestation', full_name='Request.perform_attestation', index=16,
+      name='perform_attestation', full_name='shiftcrypto.bitbox02.Request.perform_attestation', index=16,
       number=17, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='reboot', full_name='Request.reboot', index=17,
+      name='reboot', full_name='shiftcrypto.bitbox02.Request.reboot', index=17,
       number=18, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='check_backup', full_name='Request.check_backup', index=18,
+      name='check_backup', full_name='shiftcrypto.bitbox02.Request.check_backup', index=18,
       number=19, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='eth', full_name='Request.eth', index=19,
+      name='eth', full_name='shiftcrypto.bitbox02.Request.eth', index=19,
       number=20, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='reset', full_name='Request.reset', index=20,
+      name='reset', full_name='shiftcrypto.bitbox02.Request.reset', index=20,
       number=21, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='restore_from_mnemonic', full_name='Request.restore_from_mnemonic', index=21,
+      name='restore_from_mnemonic', full_name='shiftcrypto.bitbox02.Request.restore_from_mnemonic', index=21,
       number=22, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='bitboxbase', full_name='Request.bitboxbase', index=22,
+      name='bitboxbase', full_name='shiftcrypto.bitbox02.Request.bitboxbase', index=22,
       number=23, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='fingerprint', full_name='Request.fingerprint', index=23,
+      name='fingerprint', full_name='shiftcrypto.bitbox02.Request.fingerprint', index=23,
       number=24, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='btc', full_name='Request.btc', index=24,
+      name='btc', full_name='shiftcrypto.bitbox02.Request.btc', index=24,
       number=25, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='electrum_encryption_key', full_name='Request.electrum_encryption_key', index=25,
+      name='electrum_encryption_key', full_name='shiftcrypto.bitbox02.Request.electrum_encryption_key', index=25,
       number=26, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
@@ -301,114 +301,114 @@ _REQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
     _descriptor.OneofDescriptor(
-      name='request', full_name='Request.request',
+      name='request', full_name='shiftcrypto.bitbox02.Request.request',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=259,
-  serialized_end=1511,
+  serialized_start=281,
+  serialized_end=2079,
 )
 
 
 _RESPONSE = _descriptor.Descriptor(
   name='Response',
-  full_name='Response',
+  full_name='shiftcrypto.bitbox02.Response',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='success', full_name='Response.success', index=0,
+      name='success', full_name='shiftcrypto.bitbox02.Response.success', index=0,
       number=1, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='error', full_name='Response.error', index=1,
+      name='error', full_name='shiftcrypto.bitbox02.Response.error', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='random_number', full_name='Response.random_number', index=2,
+      name='random_number', full_name='shiftcrypto.bitbox02.Response.random_number', index=2,
       number=3, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='device_info', full_name='Response.device_info', index=3,
+      name='device_info', full_name='shiftcrypto.bitbox02.Response.device_info', index=3,
       number=4, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='pub', full_name='Response.pub', index=4,
+      name='pub', full_name='shiftcrypto.bitbox02.Response.pub', index=4,
       number=5, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='btc_sign_next', full_name='Response.btc_sign_next', index=5,
+      name='btc_sign_next', full_name='shiftcrypto.bitbox02.Response.btc_sign_next', index=5,
       number=6, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='list_backups', full_name='Response.list_backups', index=6,
+      name='list_backups', full_name='shiftcrypto.bitbox02.Response.list_backups', index=6,
       number=7, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='check_backup', full_name='Response.check_backup', index=7,
+      name='check_backup', full_name='shiftcrypto.bitbox02.Response.check_backup', index=7,
       number=8, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='perform_attestation', full_name='Response.perform_attestation', index=8,
+      name='perform_attestation', full_name='shiftcrypto.bitbox02.Response.perform_attestation', index=8,
       number=9, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='check_sdcard', full_name='Response.check_sdcard', index=9,
+      name='check_sdcard', full_name='shiftcrypto.bitbox02.Response.check_sdcard', index=9,
       number=10, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='eth', full_name='Response.eth', index=10,
+      name='eth', full_name='shiftcrypto.bitbox02.Response.eth', index=10,
       number=11, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='fingerprint', full_name='Response.fingerprint', index=11,
+      name='fingerprint', full_name='shiftcrypto.bitbox02.Response.fingerprint', index=11,
       number=12, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='btc', full_name='Response.btc', index=12,
+      name='btc', full_name='shiftcrypto.bitbox02.Response.btc', index=12,
       number=13, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='electrum_encryption_key', full_name='Response.electrum_encryption_key', index=13,
+      name='electrum_encryption_key', full_name='shiftcrypto.bitbox02.Response.electrum_encryption_key', index=13,
       number=14, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
@@ -426,11 +426,11 @@ _RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
     _descriptor.OneofDescriptor(
-      name='response', full_name='Response.response',
+      name='response', full_name='shiftcrypto.bitbox02.Response.response',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=1514,
-  serialized_end=2130,
+  serialized_start=2082,
+  serialized_end=2992,
 )
 
 _REQUEST.fields_by_name['random_number'].message_type = random__number__pb2._RANDOMNUMBERREQUEST
@@ -601,28 +601,28 @@ DESCRIPTOR.message_types_by_name['Response'] = _RESPONSE
 Error = _reflection.GeneratedProtocolMessageType('Error', (_message.Message,), dict(
   DESCRIPTOR = _ERROR,
   __module__ = 'hww_pb2'
-  # @@protoc_insertion_point(class_scope:Error)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.Error)
   ))
 _sym_db.RegisterMessage(Error)
 
 Success = _reflection.GeneratedProtocolMessageType('Success', (_message.Message,), dict(
   DESCRIPTOR = _SUCCESS,
   __module__ = 'hww_pb2'
-  # @@protoc_insertion_point(class_scope:Success)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.Success)
   ))
 _sym_db.RegisterMessage(Success)
 
 Request = _reflection.GeneratedProtocolMessageType('Request', (_message.Message,), dict(
   DESCRIPTOR = _REQUEST,
   __module__ = 'hww_pb2'
-  # @@protoc_insertion_point(class_scope:Request)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.Request)
   ))
 _sym_db.RegisterMessage(Request)
 
 Response = _reflection.GeneratedProtocolMessageType('Response', (_message.Message,), dict(
   DESCRIPTOR = _RESPONSE,
   __module__ = 'hww_pb2'
-  # @@protoc_insertion_point(class_scope:Response)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.Response)
   ))
 _sym_db.RegisterMessage(Response)
 

--- a/py/bitbox02/bitbox02/communication/generated/keystore_pb2.py
+++ b/py/bitbox02/bitbox02/communication/generated/keystore_pb2.py
@@ -17,9 +17,9 @@ _sym_db = _symbol_database.Default()
 
 DESCRIPTOR = _descriptor.FileDescriptor(
   name='keystore.proto',
-  package='',
+  package='shiftcrypto.bitbox02',
   syntax='proto3',
-  serialized_pb=_b('\n\x0ekeystore.proto\"/\n\x1c\x45lectrumEncryptionKeyRequest\x12\x0f\n\x07keypath\x18\x01 \x03(\r\",\n\x1d\x45lectrumEncryptionKeyResponse\x12\x0b\n\x03key\x18\x01 \x01(\tb\x06proto3')
+  serialized_pb=_b('\n\x0ekeystore.proto\x12\x14shiftcrypto.bitbox02\"/\n\x1c\x45lectrumEncryptionKeyRequest\x12\x0f\n\x07keypath\x18\x01 \x03(\r\",\n\x1d\x45lectrumEncryptionKeyResponse\x12\x0b\n\x03key\x18\x01 \x01(\tb\x06proto3')
 )
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
@@ -28,13 +28,13 @@ _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 _ELECTRUMENCRYPTIONKEYREQUEST = _descriptor.Descriptor(
   name='ElectrumEncryptionKeyRequest',
-  full_name='ElectrumEncryptionKeyRequest',
+  full_name='shiftcrypto.bitbox02.ElectrumEncryptionKeyRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='keypath', full_name='ElectrumEncryptionKeyRequest.keypath', index=0,
+      name='keypath', full_name='shiftcrypto.bitbox02.ElectrumEncryptionKeyRequest.keypath', index=0,
       number=1, type=13, cpp_type=3, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
@@ -52,20 +52,20 @@ _ELECTRUMENCRYPTIONKEYREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=18,
-  serialized_end=65,
+  serialized_start=40,
+  serialized_end=87,
 )
 
 
 _ELECTRUMENCRYPTIONKEYRESPONSE = _descriptor.Descriptor(
   name='ElectrumEncryptionKeyResponse',
-  full_name='ElectrumEncryptionKeyResponse',
+  full_name='shiftcrypto.bitbox02.ElectrumEncryptionKeyResponse',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='key', full_name='ElectrumEncryptionKeyResponse.key', index=0,
+      name='key', full_name='shiftcrypto.bitbox02.ElectrumEncryptionKeyResponse.key', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -83,8 +83,8 @@ _ELECTRUMENCRYPTIONKEYRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=67,
-  serialized_end=111,
+  serialized_start=89,
+  serialized_end=133,
 )
 
 DESCRIPTOR.message_types_by_name['ElectrumEncryptionKeyRequest'] = _ELECTRUMENCRYPTIONKEYREQUEST
@@ -93,14 +93,14 @@ DESCRIPTOR.message_types_by_name['ElectrumEncryptionKeyResponse'] = _ELECTRUMENC
 ElectrumEncryptionKeyRequest = _reflection.GeneratedProtocolMessageType('ElectrumEncryptionKeyRequest', (_message.Message,), dict(
   DESCRIPTOR = _ELECTRUMENCRYPTIONKEYREQUEST,
   __module__ = 'keystore_pb2'
-  # @@protoc_insertion_point(class_scope:ElectrumEncryptionKeyRequest)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.ElectrumEncryptionKeyRequest)
   ))
 _sym_db.RegisterMessage(ElectrumEncryptionKeyRequest)
 
 ElectrumEncryptionKeyResponse = _reflection.GeneratedProtocolMessageType('ElectrumEncryptionKeyResponse', (_message.Message,), dict(
   DESCRIPTOR = _ELECTRUMENCRYPTIONKEYRESPONSE,
   __module__ = 'keystore_pb2'
-  # @@protoc_insertion_point(class_scope:ElectrumEncryptionKeyResponse)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.ElectrumEncryptionKeyResponse)
   ))
 _sym_db.RegisterMessage(ElectrumEncryptionKeyResponse)
 

--- a/py/bitbox02/bitbox02/communication/generated/mnemonic_pb2.py
+++ b/py/bitbox02/bitbox02/communication/generated/mnemonic_pb2.py
@@ -17,9 +17,9 @@ _sym_db = _symbol_database.Default()
 
 DESCRIPTOR = _descriptor.FileDescriptor(
   name='mnemonic.proto',
-  package='',
+  package='shiftcrypto.bitbox02',
   syntax='proto3',
-  serialized_pb=_b('\n\x0emnemonic.proto\"\x15\n\x13ShowMnemonicRequest\"H\n\x1aRestoreFromMnemonicRequest\x12\x11\n\ttimestamp\x18\x01 \x01(\r\x12\x17\n\x0ftimezone_offset\x18\x02 \x01(\x05\"6\n#SetMnemonicPassphraseEnabledRequest\x12\x0f\n\x07\x65nabled\x18\x01 \x01(\x08\x62\x06proto3')
+  serialized_pb=_b('\n\x0emnemonic.proto\x12\x14shiftcrypto.bitbox02\"\x15\n\x13ShowMnemonicRequest\"H\n\x1aRestoreFromMnemonicRequest\x12\x11\n\ttimestamp\x18\x01 \x01(\r\x12\x17\n\x0ftimezone_offset\x18\x02 \x01(\x05\"6\n#SetMnemonicPassphraseEnabledRequest\x12\x0f\n\x07\x65nabled\x18\x01 \x01(\x08\x62\x06proto3')
 )
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
@@ -28,7 +28,7 @@ _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 _SHOWMNEMONICREQUEST = _descriptor.Descriptor(
   name='ShowMnemonicRequest',
-  full_name='ShowMnemonicRequest',
+  full_name='shiftcrypto.bitbox02.ShowMnemonicRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
@@ -45,27 +45,27 @@ _SHOWMNEMONICREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=18,
-  serialized_end=39,
+  serialized_start=40,
+  serialized_end=61,
 )
 
 
 _RESTOREFROMMNEMONICREQUEST = _descriptor.Descriptor(
   name='RestoreFromMnemonicRequest',
-  full_name='RestoreFromMnemonicRequest',
+  full_name='shiftcrypto.bitbox02.RestoreFromMnemonicRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='timestamp', full_name='RestoreFromMnemonicRequest.timestamp', index=0,
+      name='timestamp', full_name='shiftcrypto.bitbox02.RestoreFromMnemonicRequest.timestamp', index=0,
       number=1, type=13, cpp_type=3, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='timezone_offset', full_name='RestoreFromMnemonicRequest.timezone_offset', index=1,
+      name='timezone_offset', full_name='shiftcrypto.bitbox02.RestoreFromMnemonicRequest.timezone_offset', index=1,
       number=2, type=5, cpp_type=1, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
@@ -83,20 +83,20 @@ _RESTOREFROMMNEMONICREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=41,
-  serialized_end=113,
+  serialized_start=63,
+  serialized_end=135,
 )
 
 
 _SETMNEMONICPASSPHRASEENABLEDREQUEST = _descriptor.Descriptor(
   name='SetMnemonicPassphraseEnabledRequest',
-  full_name='SetMnemonicPassphraseEnabledRequest',
+  full_name='shiftcrypto.bitbox02.SetMnemonicPassphraseEnabledRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='enabled', full_name='SetMnemonicPassphraseEnabledRequest.enabled', index=0,
+      name='enabled', full_name='shiftcrypto.bitbox02.SetMnemonicPassphraseEnabledRequest.enabled', index=0,
       number=1, type=8, cpp_type=7, label=1,
       has_default_value=False, default_value=False,
       message_type=None, enum_type=None, containing_type=None,
@@ -114,8 +114,8 @@ _SETMNEMONICPASSPHRASEENABLEDREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=115,
-  serialized_end=169,
+  serialized_start=137,
+  serialized_end=191,
 )
 
 DESCRIPTOR.message_types_by_name['ShowMnemonicRequest'] = _SHOWMNEMONICREQUEST
@@ -125,21 +125,21 @@ DESCRIPTOR.message_types_by_name['SetMnemonicPassphraseEnabledRequest'] = _SETMN
 ShowMnemonicRequest = _reflection.GeneratedProtocolMessageType('ShowMnemonicRequest', (_message.Message,), dict(
   DESCRIPTOR = _SHOWMNEMONICREQUEST,
   __module__ = 'mnemonic_pb2'
-  # @@protoc_insertion_point(class_scope:ShowMnemonicRequest)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.ShowMnemonicRequest)
   ))
 _sym_db.RegisterMessage(ShowMnemonicRequest)
 
 RestoreFromMnemonicRequest = _reflection.GeneratedProtocolMessageType('RestoreFromMnemonicRequest', (_message.Message,), dict(
   DESCRIPTOR = _RESTOREFROMMNEMONICREQUEST,
   __module__ = 'mnemonic_pb2'
-  # @@protoc_insertion_point(class_scope:RestoreFromMnemonicRequest)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.RestoreFromMnemonicRequest)
   ))
 _sym_db.RegisterMessage(RestoreFromMnemonicRequest)
 
 SetMnemonicPassphraseEnabledRequest = _reflection.GeneratedProtocolMessageType('SetMnemonicPassphraseEnabledRequest', (_message.Message,), dict(
   DESCRIPTOR = _SETMNEMONICPASSPHRASEENABLEDREQUEST,
   __module__ = 'mnemonic_pb2'
-  # @@protoc_insertion_point(class_scope:SetMnemonicPassphraseEnabledRequest)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.SetMnemonicPassphraseEnabledRequest)
   ))
 _sym_db.RegisterMessage(SetMnemonicPassphraseEnabledRequest)
 

--- a/py/bitbox02/bitbox02/communication/generated/perform_attestation_pb2.py
+++ b/py/bitbox02/bitbox02/communication/generated/perform_attestation_pb2.py
@@ -17,9 +17,9 @@ _sym_db = _symbol_database.Default()
 
 DESCRIPTOR = _descriptor.FileDescriptor(
   name='perform_attestation.proto',
-  package='',
+  package='shiftcrypto.bitbox02',
   syntax='proto3',
-  serialized_pb=_b('\n\x19perform_attestation.proto\".\n\x19PerformAttestationRequest\x12\x11\n\tchallenge\x18\x01 \x01(\x0c\"\x9e\x01\n\x1aPerformAttestationResponse\x12\x17\n\x0f\x62ootloader_hash\x18\x01 \x01(\x0c\x12\x15\n\rdevice_pubkey\x18\x02 \x01(\x0c\x12\x13\n\x0b\x63\x65rtificate\x18\x03 \x01(\x0c\x12\x1e\n\x16root_pubkey_identifier\x18\x04 \x01(\x0c\x12\x1b\n\x13\x63hallenge_signature\x18\x05 \x01(\x0c\x62\x06proto3')
+  serialized_pb=_b('\n\x19perform_attestation.proto\x12\x14shiftcrypto.bitbox02\".\n\x19PerformAttestationRequest\x12\x11\n\tchallenge\x18\x01 \x01(\x0c\"\x9e\x01\n\x1aPerformAttestationResponse\x12\x17\n\x0f\x62ootloader_hash\x18\x01 \x01(\x0c\x12\x15\n\rdevice_pubkey\x18\x02 \x01(\x0c\x12\x13\n\x0b\x63\x65rtificate\x18\x03 \x01(\x0c\x12\x1e\n\x16root_pubkey_identifier\x18\x04 \x01(\x0c\x12\x1b\n\x13\x63hallenge_signature\x18\x05 \x01(\x0c\x62\x06proto3')
 )
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
@@ -28,13 +28,13 @@ _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 _PERFORMATTESTATIONREQUEST = _descriptor.Descriptor(
   name='PerformAttestationRequest',
-  full_name='PerformAttestationRequest',
+  full_name='shiftcrypto.bitbox02.PerformAttestationRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='challenge', full_name='PerformAttestationRequest.challenge', index=0,
+      name='challenge', full_name='shiftcrypto.bitbox02.PerformAttestationRequest.challenge', index=0,
       number=1, type=12, cpp_type=9, label=1,
       has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
@@ -52,48 +52,48 @@ _PERFORMATTESTATIONREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=29,
-  serialized_end=75,
+  serialized_start=51,
+  serialized_end=97,
 )
 
 
 _PERFORMATTESTATIONRESPONSE = _descriptor.Descriptor(
   name='PerformAttestationResponse',
-  full_name='PerformAttestationResponse',
+  full_name='shiftcrypto.bitbox02.PerformAttestationResponse',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='bootloader_hash', full_name='PerformAttestationResponse.bootloader_hash', index=0,
+      name='bootloader_hash', full_name='shiftcrypto.bitbox02.PerformAttestationResponse.bootloader_hash', index=0,
       number=1, type=12, cpp_type=9, label=1,
       has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='device_pubkey', full_name='PerformAttestationResponse.device_pubkey', index=1,
+      name='device_pubkey', full_name='shiftcrypto.bitbox02.PerformAttestationResponse.device_pubkey', index=1,
       number=2, type=12, cpp_type=9, label=1,
       has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='certificate', full_name='PerformAttestationResponse.certificate', index=2,
+      name='certificate', full_name='shiftcrypto.bitbox02.PerformAttestationResponse.certificate', index=2,
       number=3, type=12, cpp_type=9, label=1,
       has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='root_pubkey_identifier', full_name='PerformAttestationResponse.root_pubkey_identifier', index=3,
+      name='root_pubkey_identifier', full_name='shiftcrypto.bitbox02.PerformAttestationResponse.root_pubkey_identifier', index=3,
       number=4, type=12, cpp_type=9, label=1,
       has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='challenge_signature', full_name='PerformAttestationResponse.challenge_signature', index=4,
+      name='challenge_signature', full_name='shiftcrypto.bitbox02.PerformAttestationResponse.challenge_signature', index=4,
       number=5, type=12, cpp_type=9, label=1,
       has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
@@ -111,8 +111,8 @@ _PERFORMATTESTATIONRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=78,
-  serialized_end=236,
+  serialized_start=100,
+  serialized_end=258,
 )
 
 DESCRIPTOR.message_types_by_name['PerformAttestationRequest'] = _PERFORMATTESTATIONREQUEST
@@ -121,14 +121,14 @@ DESCRIPTOR.message_types_by_name['PerformAttestationResponse'] = _PERFORMATTESTA
 PerformAttestationRequest = _reflection.GeneratedProtocolMessageType('PerformAttestationRequest', (_message.Message,), dict(
   DESCRIPTOR = _PERFORMATTESTATIONREQUEST,
   __module__ = 'perform_attestation_pb2'
-  # @@protoc_insertion_point(class_scope:PerformAttestationRequest)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.PerformAttestationRequest)
   ))
 _sym_db.RegisterMessage(PerformAttestationRequest)
 
 PerformAttestationResponse = _reflection.GeneratedProtocolMessageType('PerformAttestationResponse', (_message.Message,), dict(
   DESCRIPTOR = _PERFORMATTESTATIONRESPONSE,
   __module__ = 'perform_attestation_pb2'
-  # @@protoc_insertion_point(class_scope:PerformAttestationResponse)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.PerformAttestationResponse)
   ))
 _sym_db.RegisterMessage(PerformAttestationResponse)
 

--- a/py/bitbox02/bitbox02/communication/generated/random_number_pb2.py
+++ b/py/bitbox02/bitbox02/communication/generated/random_number_pb2.py
@@ -17,9 +17,9 @@ _sym_db = _symbol_database.Default()
 
 DESCRIPTOR = _descriptor.FileDescriptor(
   name='random_number.proto',
-  package='',
+  package='shiftcrypto.bitbox02',
   syntax='proto3',
-  serialized_pb=_b('\n\x13random_number.proto\"&\n\x14RandomNumberResponse\x12\x0e\n\x06number\x18\x01 \x01(\x0c\"\x15\n\x13RandomNumberRequestb\x06proto3')
+  serialized_pb=_b('\n\x13random_number.proto\x12\x14shiftcrypto.bitbox02\"&\n\x14RandomNumberResponse\x12\x0e\n\x06number\x18\x01 \x01(\x0c\"\x15\n\x13RandomNumberRequestb\x06proto3')
 )
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
@@ -28,13 +28,13 @@ _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 _RANDOMNUMBERRESPONSE = _descriptor.Descriptor(
   name='RandomNumberResponse',
-  full_name='RandomNumberResponse',
+  full_name='shiftcrypto.bitbox02.RandomNumberResponse',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='number', full_name='RandomNumberResponse.number', index=0,
+      name='number', full_name='shiftcrypto.bitbox02.RandomNumberResponse.number', index=0,
       number=1, type=12, cpp_type=9, label=1,
       has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
@@ -52,14 +52,14 @@ _RANDOMNUMBERRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=23,
-  serialized_end=61,
+  serialized_start=45,
+  serialized_end=83,
 )
 
 
 _RANDOMNUMBERREQUEST = _descriptor.Descriptor(
   name='RandomNumberRequest',
-  full_name='RandomNumberRequest',
+  full_name='shiftcrypto.bitbox02.RandomNumberRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
@@ -76,8 +76,8 @@ _RANDOMNUMBERREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=63,
-  serialized_end=84,
+  serialized_start=85,
+  serialized_end=106,
 )
 
 DESCRIPTOR.message_types_by_name['RandomNumberResponse'] = _RANDOMNUMBERRESPONSE
@@ -86,14 +86,14 @@ DESCRIPTOR.message_types_by_name['RandomNumberRequest'] = _RANDOMNUMBERREQUEST
 RandomNumberResponse = _reflection.GeneratedProtocolMessageType('RandomNumberResponse', (_message.Message,), dict(
   DESCRIPTOR = _RANDOMNUMBERRESPONSE,
   __module__ = 'random_number_pb2'
-  # @@protoc_insertion_point(class_scope:RandomNumberResponse)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.RandomNumberResponse)
   ))
 _sym_db.RegisterMessage(RandomNumberResponse)
 
 RandomNumberRequest = _reflection.GeneratedProtocolMessageType('RandomNumberRequest', (_message.Message,), dict(
   DESCRIPTOR = _RANDOMNUMBERREQUEST,
   __module__ = 'random_number_pb2'
-  # @@protoc_insertion_point(class_scope:RandomNumberRequest)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.RandomNumberRequest)
   ))
 _sym_db.RegisterMessage(RandomNumberRequest)
 

--- a/py/bitbox02/bitbox02/communication/generated/system_pb2.py
+++ b/py/bitbox02/bitbox02/communication/generated/system_pb2.py
@@ -17,9 +17,9 @@ _sym_db = _symbol_database.Default()
 
 DESCRIPTOR = _descriptor.FileDescriptor(
   name='system.proto',
-  package='',
+  package='shiftcrypto.bitbox02',
   syntax='proto3',
-  serialized_pb=_b('\n\x0csystem.proto\"\x0f\n\rRebootRequestb\x06proto3')
+  serialized_pb=_b('\n\x0csystem.proto\x12\x14shiftcrypto.bitbox02\"\x0f\n\rRebootRequestb\x06proto3')
 )
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
@@ -28,7 +28,7 @@ _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 _REBOOTREQUEST = _descriptor.Descriptor(
   name='RebootRequest',
-  full_name='RebootRequest',
+  full_name='shiftcrypto.bitbox02.RebootRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
@@ -45,8 +45,8 @@ _REBOOTREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=16,
-  serialized_end=31,
+  serialized_start=38,
+  serialized_end=53,
 )
 
 DESCRIPTOR.message_types_by_name['RebootRequest'] = _REBOOTREQUEST
@@ -54,7 +54,7 @@ DESCRIPTOR.message_types_by_name['RebootRequest'] = _REBOOTREQUEST
 RebootRequest = _reflection.GeneratedProtocolMessageType('RebootRequest', (_message.Message,), dict(
   DESCRIPTOR = _REBOOTREQUEST,
   __module__ = 'system_pb2'
-  # @@protoc_insertion_point(class_scope:RebootRequest)
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.RebootRequest)
   ))
 _sym_db.RegisterMessage(RebootRequest)
 


### PR DESCRIPTION
Our protobuf definitions have no package specified.
This is intentional. The protos aren't used anywhere except
communications with the device and adding a package namespace makes
type names even longer for too little benefit.

However, the bitbox02 Python package is used elsewhere like the
electrum app where all its py protobufs combined may have name
collisions due to the empty package name.

The generated protos for Go, C and Rust bindings remain as is for now:
package name isn't used on the wire. This is not a breaking change.

Once this is submitted and a new bitbox02 py package is released, this should permanently resolve the issue in https://github.com/spesmilo/electrum/pull/5993#issuecomment-611080550.