### PR TITLE
py/bitbox02: remote typing dependency and bump version

### DIFF
--- a/py/bitbox02/bitbox02/bitbox02/__init__.py
+++ b/py/bitbox02/bitbox02/bitbox02/__init__.py
@@ -16,7 +16,7 @@
 from __future__ import print_function
 import sys
 
-__version__ = "2.0.2"
+__version__ = "2.0.3"
 
 if sys.version_info.major != 3 or sys.version_info.minor < 6:
     print(

--- a/py/bitbox02/setup.py
+++ b/py/bitbox02/setup.py
@@ -57,7 +57,6 @@ setup(
         "ecdsa>=0.13",
         "semver>=2.8.1",
         # Needed as long as we support python < 3.7
-        "typing>=3.7.4",
         "typing_extensions>=3.7.4",
         "base58>=2.0.0",
     ],


### PR DESCRIPTION
See
https://github.com/spesmilo/electrum/pull/5993#issuecomment-611719275:

https://pypi.org/project/typing/

    NOTE: in Python 3.5 and later, the typing module lives in the stdlib, and installing this package has NO EFFECT.