### PR TITLE
py/bitbox02: avoid "multiple package definitions" proto error

### DIFF
--- a/py/bitbox02/Makefile
+++ b/py/bitbox02/Makefile
@@ -43,13 +43,12 @@ ${TMP_TARGETS}: ${PY_PROTO}
 	sed -i 's/^from \([^.]*_pb2\)/from .\1/g'  ${OUT_DIR}/*.pyi
 	sed -i 's/^import \([^.]*_pb2\) as \([^.]*__pb2\)/from . import \1 as \2/g' ${OUT_DIR}/*.py
 
-# Grab proto files and insert a package name in each one.
+# Insert a package name in each protobuf file.
 # There can be only one "syntax = ..." directive in a proto file.
 # So, that's our anchor and a good place to put the package name at.
-${PY_PROTO}: $(addprefix ../../messages/,${PROTO_FILES})
-	mkdir -p ${PY_PROTO_DIR}
-	cp $^ ${PY_PROTO_DIR}
-	sed -i 's/^syntax =.*/&\npackage shiftcrypto.bitbox02;/' ${PY_PROTO_DIR}/*.proto
+${PY_PROTO_DIR}/%: ../../messages/%
+	@mkdir -p $(@D)
+	sed 's/^syntax =.*/&\npackage shiftcrypto.bitbox02;/' $< > $@
 
 release-test: all
 	rm -rf dist/*


### PR DESCRIPTION
Somehow, Python's protobuf gen fails with:

    hww.proto:17:1: Multiple package definitions.
    hww.proto:18:1: Multiple package definitions.
    hww.proto:19:1: Multiple package definitions.
    ...

The only place where this could happen seems to be during the copy
where the cp command doesn't actually replace an existing destination.
It could happen if the host OS has some default cp flags set, like -u.

Instead of copying and then sed-updating in-place, do the package
insert in memory and output the result directly to the dest location
This should make it idempotent.