### PR TITLE
Makefile/clean: delete build-semihosting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,4 +142,4 @@ prepare-tidy: | build build-build
 	make -C build generate-protobufs rust-cbindgen
 	make -C build-build generate-protobufs rust-cbindgen
 clean:
-	rm -rf build build-build
+	rm -rf build build-build build-semihosting


### PR DESCRIPTION
Created by e.g. `make firmware-semihosting'