### PR TITLE
ui/unlock: show next arrow instead of checkmark to go to visual conf

### DIFF
--- a/src/rust/bitbox02-rust/src/workflow/unlock.rs
+++ b/src/rust/bitbox02-rust/src/workflow/unlock.rs
@@ -30,6 +30,7 @@ async fn confirm_mnemonic_passphrase(passphrase: &str) -> bool {
         title: "",
         body: "You will be asked to\nvisually confirm your\npassphrase now.",
         accept_only: true,
+        accept_is_nextarrow: true,
         ..Default::default()
     };
 


### PR DESCRIPTION
"You will be asked to visually confirm your passphrase now." is better
confirmed with the next arrow than a checkmark.