### PR TITLE
apps/btc/sign: replace 'See the BitBoxApp' flicker between outputs

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -126,6 +126,7 @@ set(DBB-FIRMWARE-UI-SOURCES
     ${CMAKE_SOURCE_DIR}/src/ui/components/status.c
     ${CMAKE_SOURCE_DIR}/src/ui/components/image.c
     ${CMAKE_SOURCE_DIR}/src/ui/components/button.c
+    ${CMAKE_SOURCE_DIR}/src/ui/components/empty.c
     ${CMAKE_SOURCE_DIR}/src/ui/components/insert_sd_card.c
     ${CMAKE_SOURCE_DIR}/src/ui/components/remove_sd_card.c
     ${CMAKE_SOURCE_DIR}/src/ui/components/confirm_mnemonic.c

--- a/src/ui/components/empty.c
+++ b/src/ui/components/empty.c
@@ -1,0 +1,37 @@
+// Copyright 2020 Shift Cryptosecurity AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "empty.h"
+#include <hardfault.h>
+#include <ui/ui_util.h>
+
+#include <string.h>
+
+static const component_functions_t _component_functions = {
+    .cleanup = ui_util_component_cleanup,
+    .render = ui_util_component_render_subcomponents,
+    .on_event = ui_util_on_event_noop,
+};
+
+/********************************** Create Instance **********************************/
+component_t* empty_create(void)
+{
+    component_t* component = malloc(sizeof(component_t));
+    if (!component) {
+        Abort("Error: malloc empty component");
+    }
+    memset(component, 0, sizeof(component_t));
+    component->f = &_component_functions;
+    return component;
+}

--- a/src/ui/components/empty.h
+++ b/src/ui/components/empty.h
@@ -1,0 +1,25 @@
+// Copyright 2020 Shift Cryptosecurity AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _EMPTY_H_
+#define _EMPTY_H_
+
+#include <ui/component.h>
+
+/**
+ * Creates an empty component: empty screen, no processing of any kind.
+ */
+component_t* empty_create(void);
+
+#endif

--- a/src/ui/screen_stack.c
+++ b/src/ui/screen_stack.c
@@ -55,6 +55,16 @@ void ui_screen_stack_pop(void)
     }
 }
 
+void ui_screen_stack_pop_and_clean(void)
+{
+    if (_screen_stack.size > 0) {
+        component_t* top = _screen_stack.screens[_screen_stack.size - 1];
+        _screen_stack.size--;
+
+        top->f->cleanup(top);
+    }
+}
+
 void ui_screen_stack_pop_all(void)
 {
     while (_screen_stack.size) {

--- a/src/ui/screen_stack.h
+++ b/src/ui/screen_stack.h
@@ -20,9 +20,13 @@
 
 component_t* ui_screen_stack_top(void);
 void ui_screen_stack_push(component_t* component);
+/* pop component and defer cleanup to `void ui_screen_stack_cleanup()` */
 void ui_screen_stack_pop(void);
+/* pop component and immediately perform cleanup on it */
+void ui_screen_stack_pop_and_clean(void);
 void ui_screen_stack_pop_all(void);
 void ui_screen_stack_switch(component_t* component);
+/* clean up all popped components. */
 void ui_screen_stack_cleanup(void);
 
 #endif


### PR DESCRIPTION
The device waits for the next api call from the client after
confirming an output. During this time, the 'See the BitBoxApp' is
shown as the default screen if there is nothing else on the screen
stack.

This can result in an ugly flicker if there are multiple outputs to
confirm.

This is an attempt to reduce the flicker by just rendering an empty
screen (black screen) instead the regular waiting screen in this case.