### PR TITLE
u2f: change label 'U2F authenticate' -> 'U2F auth'

### DIFF
--- a/src/u2f/u2f_app.c
+++ b/src/u2f/u2f_app.c
@@ -167,7 +167,7 @@ void u2f_app_confirm_start(enum u2f_app_confirm_t type, const uint8_t* app_id)
         }
         break;
     case U2F_APP_AUTHENTICATE:
-        title = "U2F authenticate";
+        title = "U2F auth";
         _app_string(app_id, app_string, sizeof(app_string));
         break;
     default:


### PR DESCRIPTION
'U2f authenticate' is a bit too long, touching the control buttons on
the top.