### PR TITLE
font-size: use hollow arrow (not filled), and bigger arrows

### DIFF
--- a/src/ui/components/confirm_gesture.c
+++ b/src/ui/components/confirm_gesture.c
@@ -50,7 +50,7 @@ bool confirm_gesture_is_active(component_t* component)
  */
 static void _render(component_t* component)
 {
-    uint8_t arrow_height = 5;
+    uint8_t arrow_height = 6;
     int16_t x, y0, y1;
     confirm_data_t* data = (confirm_data_t*)component->data;
 
@@ -71,13 +71,13 @@ static void _render(component_t* component)
     }
 
     // Draw the top arrow
-    x = SCREEN_WIDTH / 9 * 8;
-    y0 = data->active_count / SCALE;
-    UG_FillFrame(x - arrow_height, 0, x + arrow_height, y0, screen_back_color);
+    const uint16_t padding = 1;
+    x = SCREEN_WIDTH * 15 / 16 - (arrow_height * 2 + 1);
+    y0 = padding + data->active_count / SCALE;
     image_arrow(x, y0, arrow_height, ARROW_DOWN);
 
     // Draw the bottom arrow
-    y1 = SCREEN_HEIGHT - data->bottom_arrow_slidein / SCALE - data->active_count / SCALE;
+    y1 = SCREEN_HEIGHT - padding - data->bottom_arrow_slidein / SCALE - data->active_count / SCALE;
     if (data->bottom_arrow_slidein) {
         image_arrow(x, y1, arrow_height, ARROW_UP);
     }

--- a/src/ui/components/confirm_transaction.c
+++ b/src/ui/components/confirm_transaction.c
@@ -35,7 +35,11 @@ static void _render(component_t* component)
     data_t* data = (data_t*)component->data;
     ui_util_component_render_subcomponents(component);
     if (data->has_address) {
-        image_arrow(SCREEN_WIDTH / 2, 33, IMAGE_DEFAULT_ARROW_HEIGHT, ARROW_DOWN);
+        image_arrow(
+            SCREEN_WIDTH / 2 - IMAGE_DEFAULT_ARROW_HEIGHT,
+            34,
+            IMAGE_DEFAULT_ARROW_HEIGHT,
+            ARROW_DOWN);
     }
 }
 

--- a/src/ui/components/icon_button.c
+++ b/src/ui/components/icon_button.c
@@ -45,20 +45,37 @@ static void _render(component_t* component)
 {
     data_t* data = (data_t*)component->data;
     uint16_t y = 0;
-    uint16_t x = data->type == ICON_BUTTON_CROSS ? (SCREEN_WIDTH / 7) : (SCREEN_WIDTH / 7 * 6);
-    const uint16_t arrow_height = 4;
+    uint16_t x = 0;
+    const uint16_t arrow_height = 5;
+    const uint16_t check_width =
+        IMAGE_DEFAULT_CHECKMARK_HEIGHT + IMAGE_DEFAULT_CHECKMARK_HEIGHT / 2 - 1;
+    switch (data->type) {
+    case ICON_BUTTON_CHECK:
+        x = SCREEN_WIDTH * 15 / 16;
+        x -= check_width;
+        break;
+    case ICON_BUTTON_CROSS:
+        x = SCREEN_WIDTH / 16;
+        break;
+    case ICON_BUTTON_NEXT:
+        x = SCREEN_WIDTH * 15 / 16;
+        x -= arrow_height;
+        break;
+    default:
+        break;
+    }
     if (data->type == ICON_BUTTON_NEXT) {
         if (data->location == bottom_slider) {
-            y = SCREEN_HEIGHT - arrow_height * 2;
+            y = SCREEN_HEIGHT - arrow_height * 2 + 1;
         }
         // horizontal animation
         x += data->active_count / SCALE;
     } else {
         // vertical animation
         if (data->location == top_slider) {
-            y = data->active_count / SCALE;
+            y = data->active_count / SCALE + 1;
         } else {
-            y = SCREEN_HEIGHT - data->active_count / SCALE - IMAGE_DEFAULT_ARROW_HEIGHT - 1;
+            y = SCREEN_HEIGHT - data->active_count / SCALE - IMAGE_DEFAULT_ARROW_HEIGHT - 1 + 1;
         }
     }
 
@@ -75,7 +92,7 @@ static void _render(component_t* component)
         image_cross(x, y, IMAGE_DEFAULT_CROSS_HEIGHT);
         break;
     case ICON_BUTTON_NEXT:
-        image_arrow(x, y, arrow_height, ARROW_RIGHT);
+        image_arrow_hollow(x, y, arrow_height, ARROW_RIGHT);
         break;
     default:
         break;

--- a/src/ui/components/left_arrow.c
+++ b/src/ui/components/left_arrow.c
@@ -52,7 +52,7 @@ static void _render(component_t* component)
         active_count = MAX(scale - 1, active_count - scale);
     }
     j_start -= active_count / scale;
-    image_arrow(j_start, component->position.top, HEIGHT, ARROW_LEFT);
+    image_arrow_hollow(j_start, component->position.top, HEIGHT, ARROW_LEFT);
 }
 
 static void _on_event(const event_t* event, component_t* component)

--- a/src/ui/components/right_arrow.c
+++ b/src/ui/components/right_arrow.c
@@ -52,7 +52,7 @@ static void _render(component_t* component)
         active_count = MAX(scale - 1, active_count - scale);
     }
     j_start += active_count / scale;
-    image_arrow(j_start, component->position.top, HEIGHT, ARROW_RIGHT);
+    image_arrow_hollow(j_start, component->position.top, HEIGHT, ARROW_RIGHT);
 }
 
 static void _on_event(const event_t* event, component_t* component)

--- a/src/ui/components/ui_images.c
+++ b/src/ui/components/ui_images.c
@@ -20,32 +20,61 @@
 void image_arrow(int x, int y, int height, arrow_orientation_t orientation)
 {
     int width = height * 2 - 1;
-    for (int h = 0; h < height; h++) {
-        for (int w = (width + 1) / 2 - h; w < (width + 1) / 2 + h + 1; w++) {
-            switch (orientation) {
-            case ARROW_RIGHT:
-                UG_DrawPixel(x + height - h - 1, y + w, C_WHITE);
-                break;
-            case ARROW_LEFT:
-                UG_DrawPixel(x + h, y + w, C_WHITE);
-                break;
-            case ARROW_DOWN:
-                UG_DrawPixel(x + w, y + height - h - 1, C_WHITE);
-                break;
-            case ARROW_UP:
-                UG_DrawPixel(x + w, y + h, C_WHITE);
-                break;
-            default:
-                break;
-            }
+    switch (orientation) {
+    case ARROW_RIGHT:
+        for (int h = 0; h < height; ++h) {
+            UG_DrawLine(x + h, y + h, x + h, y + width - 1 - h, C_WHITE);
         }
+        break;
+    case ARROW_LEFT:
+        for (int h = 0; h < height; ++h) {
+            UG_DrawLine(x + h, y + height - 1 - h, x + h, y + height - 1 + h, C_WHITE);
+        }
+        break;
+    case ARROW_DOWN:
+        for (int h = 0; h < height; ++h) {
+            UG_DrawLine(x + h, y + h, x + width - 1 - h, y + h, C_WHITE);
+        }
+        break;
+    case ARROW_UP:
+        for (int h = 0; h < height; ++h) {
+            UG_DrawLine(x + height - 1 - h, y + h, x + height - 1 + h, y + h, C_WHITE);
+        }
+        break;
+    default:
+        break;
+    }
+}
+
+void image_arrow_hollow(int x, int y, int height, arrow_orientation_t orientation)
+{
+    int width = height * 2 - 1;
+    switch (orientation) {
+    case ARROW_RIGHT:
+        UG_DrawLine(x, y, x + height - 1, y + height - 1, C_WHITE);
+        UG_DrawLine(x + height - 1, y + height - 1, x, y + width - 1, C_WHITE);
+        break;
+    case ARROW_LEFT:
+        UG_DrawLine(x + height - 1, y, x, y + height - 1, C_WHITE);
+        UG_DrawLine(x, y + height - 1, x + height - 1, y + width - 1, C_WHITE);
+        break;
+    case ARROW_DOWN:
+        UG_DrawLine(x, y, x + height - 1, y + height - 1, C_WHITE);
+        UG_DrawLine(x + height - 1, y + height - 1, x + width - 1, y, C_WHITE);
+        break;
+    case ARROW_UP:
+        UG_DrawLine(x, y + height - 1, x + height - 1, y, C_WHITE);
+        UG_DrawLine(x + height - 1, y, x + width - 1, y + height - 1, C_WHITE);
+        break;
+    default:
+        break;
     }
 }
 
 void image_checkmark(int x, int y, int h)
 {
-    UG_DrawLine(x + h, y, x, y + h, C_WHITE);
-    UG_DrawLine(x - (h - h / 2 - 1), y + h / 2 + 1, x, y + h, C_WHITE);
+    UG_DrawLine(x, y + h - (h / 2 - 1) - 1, x + h / 2 - 1, y + h - 1, C_WHITE);
+    UG_DrawLine(x + h / 2 - 1, y + h - 1, x + h - 1 + h / 2 - 1, y, C_WHITE);
 }
 
 void image_cross(int x, int y, int h)

--- a/src/ui/components/ui_images.h
+++ b/src/ui/components/ui_images.h
@@ -102,8 +102,8 @@ static const uint8_t IMAGE_ROTATE_REVERSE[] = {
     0x02, 0x01, 0xc0, 0x08, 0x02, 0x00, 0x40, 0x00, 0x06, 0x00, 0x00, 0x60, 0x00};
 
 #define IMAGE_DEFAULT_ARROW_HEIGHT 6
-#define IMAGE_DEFAULT_CHECKMARK_HEIGHT 5
-#define IMAGE_DEFAULT_CROSS_HEIGHT 5
+#define IMAGE_DEFAULT_CHECKMARK_HEIGHT 7
+#define IMAGE_DEFAULT_CROSS_HEIGHT 6
 #define IMAGE_DEFAULT_LOCK_RADIUS 6
 
 typedef enum {
@@ -114,6 +114,7 @@ typedef enum {
 } arrow_orientation_t;
 
 void image_arrow(int x, int y, int height, arrow_orientation_t orientation);
+void image_arrow_hollow(int x, int y, int height, arrow_orientation_t orientation);
 void image_checkmark(int x, int y, int h);
 void image_cross(int x, int y, int h);
 void image_lock(int x, int y, int r);


### PR DESCRIPTION
Part of #416. The other PR did not hollow out the right arrow, used in scrolling through the words when showing the mnemonic.