### PR TITLE
components/confirm: improved centering

### DIFF
--- a/src/ui/components/confirm.c
+++ b/src/ui/components/confirm.c
@@ -15,6 +15,7 @@
 #include "confirm.h"
 #include "../event.h"
 #include "confirm_gesture.h"
+#include "empty.h"
 #include "icon_button.h"
 #include "label.h"
 
@@ -71,12 +72,6 @@ static const component_functions_t _component_functions = {
     .on_event = _on_event,
 };
 
-static const component_functions_t _body_container_functions = {
-    .cleanup = ui_util_component_cleanup,
-    .render = ui_util_component_render_subcomponents,
-    .on_event = ui_util_on_event_noop,
-};
-
 /********************************** Create Instance **********************************/
 
 component_t* confirm_create(
@@ -116,21 +111,15 @@ component_t* confirm_create(
     slider_location_t slider_position = top_slider;
     // Create labels. We nest them in a body component that covers the screen minus the title bar,
     // so that the CENTER positioning starts below the title bar.
-    component_t* body_container = malloc(sizeof(component_t));
-    if (!body_container) {
-        Abort("Error: malloc confirm");
-    }
-    memset(body_container, 0, sizeof(component_t));
-
     component_t* title_component = label_create(params->title, NULL, CENTER_TOP, confirm);
     ui_util_add_sub_component(confirm, title_component);
 
+    component_t* body_container = empty_create();
     body_container->position.left = 0;
     // title bar height plus small padding
     body_container->position.top = title_component->dimension.height + 1;
     body_container->dimension.width = SCREEN_WIDTH;
     body_container->dimension.height = SCREEN_HEIGHT - body_container->position.top;
-    body_container->f = &_body_container_functions;
     ui_util_add_sub_component(confirm, body_container);
 
     if (params->scrollable) {

--- a/src/ui/components/confirm.c
+++ b/src/ui/components/confirm.c
@@ -71,6 +71,12 @@ static const component_functions_t _component_functions = {
     .on_event = _on_event,
 };
 
+static const component_functions_t _body_container_functions = {
+    .cleanup = ui_util_component_cleanup,
+    .render = ui_util_component_render_subcomponents,
+    .on_event = ui_util_on_event_noop,
+};
+
 /********************************** Create Instance **********************************/
 
 component_t* confirm_create(
@@ -108,15 +114,34 @@ component_t* confirm_create(
     }
 
     slider_location_t slider_position = top_slider;
-    // Create labels
+    // Create labels. We nest them in a body component that covers the screen minus the title bar,
+    // so that the CENTER positioning starts below the title bar.
+    component_t* body_container = malloc(sizeof(component_t));
+    if (!body_container) {
+        Abort("Error: malloc confirm");
+    }
+    memset(body_container, 0, sizeof(component_t));
+
+    component_t* title_component = label_create(params->title, NULL, CENTER_TOP, confirm);
+    ui_util_add_sub_component(confirm, title_component);
+
+    body_container->position.left = 0;
+    // title bar height plus small padding
+    body_container->position.top = title_component->dimension.height + 1;
+    body_container->dimension.width = SCREEN_WIDTH;
+    body_container->dimension.height = SCREEN_HEIGHT - body_container->position.top;
+    body_container->f = &_body_container_functions;
+    ui_util_add_sub_component(confirm, body_container);
+
     if (params->scrollable) {
         ui_util_add_sub_component(
-            confirm, label_create_scrollable(params->body, params->font, CENTER, confirm));
+            body_container,
+            label_create_scrollable(params->body, params->font, CENTER, body_container));
     } else {
         ui_util_add_sub_component(
-            confirm, label_create(params->body, params->font, CENTER, confirm));
+            body_container, label_create(params->body, params->font, CENTER, body_container));
     }
-    ui_util_add_sub_component(confirm, label_create(params->title, NULL, CENTER_TOP, confirm));
+
     // Create buttons
     if (!params->accept_only) {
         ui_util_add_sub_component(


### PR DESCRIPTION
Fix centering algorithm - before it would center the text in the whole
screen. Now it is centering it in the body part, which is the full
screen without the title bar. This leads to more natural looking
positioning.