### PR TITLE
font-size: tweak gesture confirm arrow position

### DIFF
--- a/src/ui/components/confirm_gesture.c
+++ b/src/ui/components/confirm_gesture.c
@@ -72,7 +72,7 @@ static void _render(component_t* component)
 
     // Draw the top arrow
     const uint16_t padding = 1;
-    x = SCREEN_WIDTH * 15 / 16 - (arrow_height * 2 + 1);
+    x = SCREEN_WIDTH * 15 / 16 - (arrow_height + arrow_height / 2);
     y0 = padding + data->active_count / SCALE;
     image_arrow(x, y0, arrow_height, ARROW_DOWN);
 


### PR DESCRIPTION
Slightly to the right to make more space for the body.

Straight from #416.