### PR TITLE
protobuf: remove unused fixed_length in backup_commands

### DIFF
--- a/messages/backup_commands.options
+++ b/messages/backup_commands.options
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 CheckBackupResponse.id fixed_length:true max_size:256
-ListBackupsResponse.info fixed_length:true max_count:100
+ListBackupsResponse.info max_count:100
 // One backup per seed -> 100 seeds may be backed up per SD card. Adapt this number if it is too small.
 BackupInfo.id fixed_length:true max_size:256
 BackupInfo.name fixed_length:true max_size:64


### PR DESCRIPTION
The fixed_length is used for bytes fields and requires max_size to be
defined as well. BackupListResponse.info doesn't have bytes fields
need not fixed_length. I suspect it might have been a copy&paste typo.

See nanopb docs:
https://jpa.kapsi.fi/nanopb/docs/reference.html#proto-file-options

No changes in the corresponding autogenerated backup pb.h or pb.c
files. Binary size is also the same. Verified backup operations still
work with send_message.py and the desktop app.