### PR TITLE
py/bitbox02: bump version to 3.0.0

### DIFF
--- a/py/bitbox02/bitbox02/bitbox02/__init__.py
+++ b/py/bitbox02/bitbox02/bitbox02/__init__.py
@@ -16,7 +16,7 @@
 from __future__ import print_function
 import sys
 
-__version__ = "2.0.3"
+__version__ = "3.0.0"
 
 if sys.version_info.major != 3 or sys.version_info.minor < 6:
     print(


### PR DESCRIPTION
btc_sign() had a breaking change.