### PR TITLE
ci: add github workflow

### DIFF
--- a/.ci/run-container-ci
+++ b/.ci/run-container-ci
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Copyright 2019 Shift Cryptosecurity AG
 # Copyright 2020 Shift Crypto AG
 #
@@ -13,7 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#!/bin/bash
+# The script runs all CI builds and checks in a Docker container.
+# It accepts two positional arguments:
+# 1. A workspace dir, the root of the git repo clone, or "pull" literal.
+#    In the latter case, CI container image is pulled from a registry.
+# 2. An optional target branch for code style diffs. Defaults to "master" for
+#    push commits and overwritten with TRAVIS_BRANCH env var for pull requests
+#    when run on Travis CI.
 
 set -e
 set -x
@@ -25,8 +32,14 @@ if [ "$1" == "pull" ] ; then
 	exit 0
 fi
 
-TARGET_BRANCH=master
-if [ "${TRAVIS_PULL_REQUEST}" != "false" ] ; then
+WORKSPACE_DIR="$1"
+if [ -z "${WORKSPACE_DIR}" ]; then
+  echo "Workspace dir path is empty."
+  exit 1
+fi
+
+TARGET_BRANCH="${2:-master}"
+if [ "${TRAVIS}" == "true" ] && [ "${TRAVIS_PULL_REQUEST}" != "false" ] ; then
 	TARGET_BRANCH=${TRAVIS_BRANCH}
 fi
 
@@ -38,7 +51,7 @@ TARGET_BRANCH=origin/${TARGET_BRANCH}
 
 docker run -e TARGET_BRANCH="${TARGET_BRANCH}" \
 	--cap-add SYS_PTRACE \
-	--volume ${TRAVIS_BUILD_DIR}:/bitbox02-firmware/ \
+	--volume ${WORKSPACE_DIR}:/bitbox02-firmware/ \
 	--workdir /bitbox02-firmware \
 	${CONTAINER} \
 	bash -c "./.ci/ci"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+# See reference docs at
+# https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions
+name: ci
+on: [push, pull_request]
+
+jobs:
+  linux-docker:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Clone the repo
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: vars
+        run: echo "---${{github.head_ref}}---"
+      - name: Pull CI container image
+        run: ./.ci/run-container-ci pull
+      - name: Run CI in container
+        run: ./.ci/run-container-ci ${{github.workspace}} ${{github.head_ref}}

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ os:
 
 script:
 # Pull the docker image as a separate step to measure the time it takes
-- ./.ci/travis-ci pull
-- ./.ci/travis-ci
+- ./.ci/run-container-ci pull
+- ./.ci/run-container-ci "${TRAVIS_BUILD_DIR}"
 
 # Caching breaks the build right now because there is no dependency between the compiled external
 # library and the placement in the `bin` directory.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <img src="./doc/BB02_logo_github.svg" width="345px"/>
 
 [![Build Status](https://travis-ci.org/digitalbitbox/bitbox02-firmware.svg?branch=master)](https://travis-ci.org/digitalbitbox/bitbox02-firmware)
+![CI](https://github.com/digitalbitbox/bitbox02-firmware/workflows/ci/badge.svg?branch=master)
 
 The BitBox02 is a hardware wallet that simplifies secure handling of crypto coins through storing
 private keys and signing transactions. The content of this repository is the bootloader and


### PR DESCRIPTION
This is an alternative to Travis CI.
It runs the same scripts in docker on Ubuntu 18.04.