### PR TITLE
commander: split protobuf encoding/decoding into new file

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,6 +19,7 @@ set(DBB-FIRMWARE-SOURCES
   ${CMAKE_SOURCE_DIR}/src/commander/commander.c
   ${CMAKE_SOURCE_DIR}/src/commander/commander_btc.c
   ${CMAKE_SOURCE_DIR}/src/commander/commander_states.c
+  ${CMAKE_SOURCE_DIR}/src/commander/protobuf.c
   ${CMAKE_SOURCE_DIR}/src/keystore.c
   ${CMAKE_SOURCE_DIR}/src/random.c
   ${CMAKE_SOURCE_DIR}/src/hardfault.c

--- a/src/backup.c
+++ b/src/backup.c
@@ -20,7 +20,6 @@
 #include <hardfault.h>
 #include <keystore.h>
 #include <memory/memory.h>
-#include <pb_decode.h>
 #include <pb_encode.h>
 #include <restore.h>
 #include <sd.h>

--- a/src/commander/protobuf.c
+++ b/src/commander/protobuf.c
@@ -1,0 +1,35 @@
+// Copyright 2020 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "protobuf.h"
+
+#include <hardfault.h>
+
+#include <pb_decode.h>
+#include <pb_encode.h>
+
+bool protobuf_decode(const in_buffer_t* buf, Request* request_out)
+{
+    pb_istream_t in_stream = pb_istream_from_buffer(buf->data, buf->len);
+    return pb_decode(&in_stream, Request_fields, request_out);
+}
+
+void protobuf_encode(buffer_t* buf_out, const Response* response)
+{
+    pb_ostream_t out_stream = pb_ostream_from_buffer(buf_out->data, buf_out->max_len);
+    if (!pb_encode(&out_stream, Response_fields, response)) {
+        Abort("Abort: pb_encode");
+    }
+    buf_out->len = out_stream.bytes_written;
+}

--- a/src/commander/protobuf.h
+++ b/src/commander/protobuf.h
@@ -1,0 +1,35 @@
+// Copyright 2020 Shift Cryptos AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _COMMANDER_PROTOBUF_H_
+#define _COMMANDER_PROTOBUF_H_
+
+#include <compiler_util.h>
+#include <util.h>
+
+#include <hww.pb.h>
+
+#include <stdbool.h>
+
+/**
+ * Parses an api protobuf request.
+ */
+USE_RESULT bool protobuf_decode(const in_buffer_t* in_buf, Request* request_out);
+
+/**
+ * Serializes an api protobuf response. Aborts() on error (e.g. if the output buffer is too short).
+ */
+void protobuf_encode(buffer_t* buf_out, const Response* response);
+
+#endif

--- a/src/restore.c
+++ b/src/restore.c
@@ -23,7 +23,6 @@
 #include <util.h>
 
 #include <pb_decode.h>
-#include <pb_encode.h>
 #include <string.h>
 
 /**


### PR DESCRIPTION
Easier to call from Rust. (work paused again, but putting in this commit so I don't have to look for it again later).