### PR TITLE
ci: make github runner pick correct target branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: true
-      - name: vars
-        run: echo "---${{github.head_ref}}---"
       - name: Pull CI container image
         run: ./.ci/run-container-ci pull
       - name: Run CI in container
-        run: ./.ci/run-container-ci ${{github.workspace}} ${{github.head_ref}}
+        run: ./.ci/run-container-ci ${{github.workspace}} ${{github.base_ref}}


### PR DESCRIPTION
Initial commit 1184760 to set up github CI runners used incorrect
variable to identify the target branch of a pull request for various
style linters.

Here's an example of a failed run:
https://github.com/digitalbitbox/bitbox02-firmware/runs/765310884

This commit hopefully makes it work correctly.

See the following for docs:
https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#github-context