### PR TITLE
apps/btc/sign: move init validation to a new file

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -69,6 +69,7 @@ set(DBB-FIRMWARE-SOURCES
   ${CMAKE_SOURCE_DIR}/src/apps/btc/btc_common.c
   ${CMAKE_SOURCE_DIR}/src/apps/btc/btc_params.c
   ${CMAKE_SOURCE_DIR}/src/apps/btc/btc_sign.c
+  ${CMAKE_SOURCE_DIR}/src/apps/btc/btc_sign_validate.c
   ${CMAKE_SOURCE_DIR}/src/apps/btc/btc_bip143.c
   ${CMAKE_SOURCE_DIR}/src/apps/btc/confirm_locktime_rbf.c
   ${CMAKE_SOURCE_DIR}/src/apps/btc/confirm_multisig.c

--- a/src/apps/btc/btc_sign_validate.c
+++ b/src/apps/btc/btc_sign_validate.c
@@ -1,0 +1,61 @@
+// Copyright 2020 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "btc_sign_validate.h"
+#include "btc_common.h"
+#include "btc_params.h"
+#include "confirm_multisig.h"
+
+#include <memory/memory.h>
+
+app_btc_result_t app_btc_sign_validate_init_script_configs(
+    BTCCoin coin,
+    const BTCScriptConfig* script_config,
+    const uint32_t* keypath_account,
+    size_t keypath_account_count)
+{
+    const app_btc_coin_params_t* coin_params = app_btc_params_get(coin);
+    if (coin_params == NULL) {
+        return APP_BTC_ERR_INVALID_INPUT;
+    }
+    switch (script_config->which_config) {
+    case BTCScriptConfig_simple_type_tag:
+        break;
+    case BTCScriptConfig_multisig_tag: {
+        const BTCScriptConfig_Multisig* multisig = &script_config->config.multisig;
+        if (!btc_common_multisig_is_valid(
+                multisig, keypath_account, keypath_account_count, coin_params->bip44_coin)) {
+            return APP_BTC_ERR_INVALID_INPUT;
+        }
+        uint8_t multisig_hash[SHA256_LEN] = {0};
+        if (!btc_common_multisig_hash(
+                coin, multisig, keypath_account, keypath_account_count, multisig_hash)) {
+            return APP_BTC_ERR_INVALID_INPUT;
+        };
+        char multisig_registered_name[MEMORY_MULTISIG_NAME_MAX_LEN] = {0};
+        if (!memory_multisig_get_by_hash(multisig_hash, multisig_registered_name)) {
+            // Not previously registered -> fail.
+            return APP_BTC_ERR_INVALID_INPUT;
+        }
+        if (!apps_btc_confirm_multisig(
+                "Spend from", coin, multisig_registered_name, multisig, false)) {
+            return APP_BTC_ERR_USER_ABORT;
+        }
+        break;
+    }
+    default:
+        return APP_BTC_ERR_INVALID_INPUT;
+    }
+    return APP_BTC_OK;
+}

--- a/src/apps/btc/btc_sign_validate.h
+++ b/src/apps/btc/btc_sign_validate.h
@@ -1,0 +1,38 @@
+// Copyright 2020 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "btc.h"
+
+#include <compiler_util.h>
+#include <hww.pb.h>
+#include <stddef.h>
+
+/**
+ * When starting a signing workflow with the BTCSignInit request, this function is used to validate
+ * the script configs in the request.
+ *
+ * For multisig, this means confirming with the user that they are spending from the correct
+ * account.
+ *
+ * @param[in] coin we are spending
+ * @param[in] script_config the script config used for all inputs and changes.
+ * @param[in] keypath_account Account-level keypath.
+ * @param[in] keypath_account_count number of elements in keypath_account.
+ * @return See `app_btc_result_t`.
+ */
+USE_RESULT app_btc_result_t app_btc_sign_validate_init_script_configs(
+    BTCCoin coin,
+    const BTCScriptConfig* script_config,
+    const uint32_t* keypath_account,
+    size_t keypath_account_count);


### PR DESCRIPTION
btc_sign.c is growing too big.

With the next commits we will allow mixed inputs, so the init script
configs validation will be extended.

This commit does not change any semantics yet, just moving code.