### PR TITLE
apps/btc/sign: allow multiple script configs in a tx

### DIFF
--- a/messages/btc.options
+++ b/messages/btc.options
@@ -1,4 +1,5 @@
 // Copyright 2019 Shift Cryptosecurity AG
+// Copyright 2020 Shift Crypto AG
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,12 +15,13 @@
 
 BTCScriptConfig.Multisig.xpubs max_count:15
 BTCPubRequest.keypath max_count:10
-BTCSignInitRequest.keypath_account max_count:10
+BTCSignInitRequest.script_configs max_count:3
 BTCSignInputRequest.prevOutHash fixed_length:true max_size:32
 BTCSignInputRequest.keypath max_count:10
 BTCSignOutputRequest.hash max_size:32
 BTCSignOutputRequest.keypath max_count:10
 BTCSignNextResponse.signature fixed_length:true max_size:64
+BTCScriptConfigWithKeypath.keypath max_count:10
 BTCScriptConfigRegistration.keypath max_count:10
 BTCRegisterScriptConfigRequest.name max_size:31
 BTCPrevTxInputRequest.prev_out_hash fixed_length:true max_size:32

--- a/messages/btc.proto
+++ b/messages/btc.proto
@@ -1,4 +1,5 @@
 // Copyright 2019 Shift Cryptosecurity AG
+// Copyright 2020 Shift Crypto AG
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -70,11 +71,15 @@ message BTCPubRequest {
   bool display = 5;
 }
 
+message BTCScriptConfigWithKeypath {
+  BTCScriptConfig script_config = 2;
+  repeated uint32 keypath = 3;
+}
 
 message BTCSignInitRequest {
   BTCCoin coin = 1;
-  BTCScriptConfig script_config = 2; // script config for inputs and changes
-  repeated uint32 keypath_account = 3; // prefix to all input and change keypaths.
+  // used script configs in inputs and changes
+  repeated BTCScriptConfigWithKeypath script_configs = 2;
   uint32 version = 4; // must be 1 or 2
   uint32 num_inputs = 5;
   uint32 num_outputs = 6;
@@ -107,6 +112,8 @@ message BTCSignInputRequest {
   uint64 prevOutValue = 3;
   uint32 sequence = 4; // must be 0xffffffff-2, 0xffffffff-1 or 0xffffffff
   repeated uint32 keypath = 6; // all inputs must be ours.
+  // References a script config from BTCSignInitRequest
+  uint32 script_config_index = 7;
 }
 
 enum BTCOutputType {
@@ -124,6 +131,8 @@ message BTCSignOutputRequest {
   uint64 value = 3;
   bytes hash = 4; // if ours is false
   repeated uint32 keypath = 5; // if ours is true
+  // If ours is true. References a script config from BTCSignInitRequest
+  uint32 script_config_index = 6;
 }
 
 message BTCScriptConfigRegistration {

--- a/py/bitbox02/bitbox02/communication/generated/btc_pb2.py
+++ b/py/bitbox02/bitbox02/communication/generated/btc_pb2.py
@@ -21,7 +21,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='btc.proto',
   package='shiftcrypto.bitbox02',
   syntax='proto3',
-  serialized_pb=_b('\n\tbtc.proto\x12\x14shiftcrypto.bitbox02\x1a\x0c\x63ommon.proto\"\xb5\x02\n\x0f\x42TCScriptConfig\x12G\n\x0bsimple_type\x18\x01 \x01(\x0e\x32\x30.shiftcrypto.bitbox02.BTCScriptConfig.SimpleTypeH\x00\x12\x42\n\x08multisig\x18\x02 \x01(\x0b\x32..shiftcrypto.bitbox02.BTCScriptConfig.MultisigH\x00\x1a`\n\x08Multisig\x12\x11\n\tthreshold\x18\x01 \x01(\r\x12)\n\x05xpubs\x18\x02 \x03(\x0b\x32\x1a.shiftcrypto.bitbox02.XPub\x12\x16\n\x0eour_xpub_index\x18\x03 \x01(\r\")\n\nSimpleType\x12\x0f\n\x0bP2WPKH_P2SH\x10\x00\x12\n\n\x06P2WPKH\x10\x01\x42\x08\n\x06\x63onfig\"\xd7\x02\n\rBTCPubRequest\x12+\n\x04\x63oin\x18\x01 \x01(\x0e\x32\x1d.shiftcrypto.bitbox02.BTCCoin\x12\x0f\n\x07keypath\x18\x02 \x03(\r\x12\x41\n\txpub_type\x18\x03 \x01(\x0e\x32,.shiftcrypto.bitbox02.BTCPubRequest.XPubTypeH\x00\x12>\n\rscript_config\x18\x04 \x01(\x0b\x32%.shiftcrypto.bitbox02.BTCScriptConfigH\x00\x12\x0f\n\x07\x64isplay\x18\x05 \x01(\x08\"j\n\x08XPubType\x12\x08\n\x04TPUB\x10\x00\x12\x08\n\x04XPUB\x10\x01\x12\x08\n\x04YPUB\x10\x02\x12\x08\n\x04ZPUB\x10\x03\x12\x08\n\x04VPUB\x10\x04\x12\x08\n\x04UPUB\x10\x05\x12\x10\n\x0c\x43\x41PITAL_VPUB\x10\x06\x12\x10\n\x0c\x43\x41PITAL_ZPUB\x10\x07\x42\x08\n\x06output\"\xe4\x01\n\x12\x42TCSignInitRequest\x12+\n\x04\x63oin\x18\x01 \x01(\x0e\x32\x1d.shiftcrypto.bitbox02.BTCCoin\x12<\n\rscript_config\x18\x02 \x01(\x0b\x32%.shiftcrypto.bitbox02.BTCScriptConfig\x12\x17\n\x0fkeypath_account\x18\x03 \x03(\r\x12\x0f\n\x07version\x18\x04 \x01(\r\x12\x12\n\nnum_inputs\x18\x05 \x01(\r\x12\x13\n\x0bnum_outputs\x18\x06 \x01(\r\x12\x10\n\x08locktime\x18\x07 \x01(\r\"\xff\x01\n\x13\x42TCSignNextResponse\x12<\n\x04type\x18\x01 \x01(\x0e\x32..shiftcrypto.bitbox02.BTCSignNextResponse.Type\x12\r\n\x05index\x18\x02 \x01(\r\x12\x15\n\rhas_signature\x18\x03 \x01(\x08\x12\x11\n\tsignature\x18\x04 \x01(\x0c\x12\x12\n\nprev_index\x18\x05 \x01(\r\"]\n\x04Type\x12\t\n\x05INPUT\x10\x00\x12\n\n\x06OUTPUT\x10\x01\x12\x08\n\x04\x44ONE\x10\x02\x12\x0f\n\x0bPREVTX_INIT\x10\x03\x12\x10\n\x0cPREVTX_INPUT\x10\x04\x12\x11\n\rPREVTX_OUTPUT\x10\x05\"y\n\x13\x42TCSignInputRequest\x12\x13\n\x0bprevOutHash\x18\x01 \x01(\x0c\x12\x14\n\x0cprevOutIndex\x18\x02 \x01(\r\x12\x14\n\x0cprevOutValue\x18\x03 \x01(\x04\x12\x10\n\x08sequence\x18\x04 \x01(\r\x12\x0f\n\x07keypath\x18\x06 \x03(\r\"\x85\x01\n\x14\x42TCSignOutputRequest\x12\x0c\n\x04ours\x18\x01 \x01(\x08\x12\x31\n\x04type\x18\x02 \x01(\x0e\x32#.shiftcrypto.bitbox02.BTCOutputType\x12\r\n\x05value\x18\x03 \x01(\x04\x12\x0c\n\x04hash\x18\x04 \x01(\x0c\x12\x0f\n\x07keypath\x18\x05 \x03(\r\"\x99\x01\n\x1b\x42TCScriptConfigRegistration\x12+\n\x04\x63oin\x18\x01 \x01(\x0e\x32\x1d.shiftcrypto.bitbox02.BTCCoin\x12<\n\rscript_config\x18\x02 \x01(\x0b\x32%.shiftcrypto.bitbox02.BTCScriptConfig\x12\x0f\n\x07keypath\x18\x03 \x03(\r\"\x0c\n\nBTCSuccess\"m\n\"BTCIsScriptConfigRegisteredRequest\x12G\n\x0cregistration\x18\x01 \x01(\x0b\x32\x31.shiftcrypto.bitbox02.BTCScriptConfigRegistration\"<\n#BTCIsScriptConfigRegisteredResponse\x12\x15\n\ris_registered\x18\x01 \x01(\x08\"w\n\x1e\x42TCRegisterScriptConfigRequest\x12G\n\x0cregistration\x18\x01 \x01(\x0b\x32\x31.shiftcrypto.bitbox02.BTCScriptConfigRegistration\x12\x0c\n\x04name\x18\x02 \x01(\t\"b\n\x14\x42TCPrevTxInitRequest\x12\x0f\n\x07version\x18\x01 \x01(\r\x12\x12\n\nnum_inputs\x18\x02 \x01(\r\x12\x13\n\x0bnum_outputs\x18\x03 \x01(\r\x12\x10\n\x08locktime\x18\x04 \x01(\r\"r\n\x15\x42TCPrevTxInputRequest\x12\x15\n\rprev_out_hash\x18\x01 \x01(\x0c\x12\x16\n\x0eprev_out_index\x18\x02 \x01(\r\x12\x18\n\x10signature_script\x18\x03 \x01(\x0c\x12\x10\n\x08sequence\x18\x04 \x01(\r\">\n\x16\x42TCPrevTxOutputRequest\x12\r\n\x05value\x18\x01 \x01(\x04\x12\x15\n\rpubkey_script\x18\x02 \x01(\x0c\"\x9f\x03\n\nBTCRequest\x12_\n\x1bis_script_config_registered\x18\x01 \x01(\x0b\x32\x38.shiftcrypto.bitbox02.BTCIsScriptConfigRegisteredRequestH\x00\x12V\n\x16register_script_config\x18\x02 \x01(\x0b\x32\x34.shiftcrypto.bitbox02.BTCRegisterScriptConfigRequestH\x00\x12\x41\n\x0bprevtx_init\x18\x03 \x01(\x0b\x32*.shiftcrypto.bitbox02.BTCPrevTxInitRequestH\x00\x12\x43\n\x0cprevtx_input\x18\x04 \x01(\x0b\x32+.shiftcrypto.bitbox02.BTCPrevTxInputRequestH\x00\x12\x45\n\rprevtx_output\x18\x05 \x01(\x0b\x32,.shiftcrypto.bitbox02.BTCPrevTxOutputRequestH\x00\x42\t\n\x07request\"\xf0\x01\n\x0b\x42TCResponse\x12\x33\n\x07success\x18\x01 \x01(\x0b\x32 .shiftcrypto.bitbox02.BTCSuccessH\x00\x12`\n\x1bis_script_config_registered\x18\x02 \x01(\x0b\x32\x39.shiftcrypto.bitbox02.BTCIsScriptConfigRegisteredResponseH\x00\x12>\n\tsign_next\x18\x03 \x01(\x0b\x32).shiftcrypto.bitbox02.BTCSignNextResponseH\x00\x42\n\n\x08response*/\n\x07\x42TCCoin\x12\x07\n\x03\x42TC\x10\x00\x12\x08\n\x04TBTC\x10\x01\x12\x07\n\x03LTC\x10\x02\x12\x08\n\x04TLTC\x10\x03*H\n\rBTCOutputType\x12\x0b\n\x07UNKNOWN\x10\x00\x12\t\n\x05P2PKH\x10\x01\x12\x08\n\x04P2SH\x10\x02\x12\n\n\x06P2WPKH\x10\x03\x12\t\n\x05P2WSH\x10\x04\x62\x06proto3')
+  serialized_pb=_b('\n\tbtc.proto\x12\x14shiftcrypto.bitbox02\x1a\x0c\x63ommon.proto\"\xb5\x02\n\x0f\x42TCScriptConfig\x12G\n\x0bsimple_type\x18\x01 \x01(\x0e\x32\x30.shiftcrypto.bitbox02.BTCScriptConfig.SimpleTypeH\x00\x12\x42\n\x08multisig\x18\x02 \x01(\x0b\x32..shiftcrypto.bitbox02.BTCScriptConfig.MultisigH\x00\x1a`\n\x08Multisig\x12\x11\n\tthreshold\x18\x01 \x01(\r\x12)\n\x05xpubs\x18\x02 \x03(\x0b\x32\x1a.shiftcrypto.bitbox02.XPub\x12\x16\n\x0eour_xpub_index\x18\x03 \x01(\r\")\n\nSimpleType\x12\x0f\n\x0bP2WPKH_P2SH\x10\x00\x12\n\n\x06P2WPKH\x10\x01\x42\x08\n\x06\x63onfig\"\xd7\x02\n\rBTCPubRequest\x12+\n\x04\x63oin\x18\x01 \x01(\x0e\x32\x1d.shiftcrypto.bitbox02.BTCCoin\x12\x0f\n\x07keypath\x18\x02 \x03(\r\x12\x41\n\txpub_type\x18\x03 \x01(\x0e\x32,.shiftcrypto.bitbox02.BTCPubRequest.XPubTypeH\x00\x12>\n\rscript_config\x18\x04 \x01(\x0b\x32%.shiftcrypto.bitbox02.BTCScriptConfigH\x00\x12\x0f\n\x07\x64isplay\x18\x05 \x01(\x08\"j\n\x08XPubType\x12\x08\n\x04TPUB\x10\x00\x12\x08\n\x04XPUB\x10\x01\x12\x08\n\x04YPUB\x10\x02\x12\x08\n\x04ZPUB\x10\x03\x12\x08\n\x04VPUB\x10\x04\x12\x08\n\x04UPUB\x10\x05\x12\x10\n\x0c\x43\x41PITAL_VPUB\x10\x06\x12\x10\n\x0c\x43\x41PITAL_ZPUB\x10\x07\x42\x08\n\x06output\"k\n\x1a\x42TCScriptConfigWithKeypath\x12<\n\rscript_config\x18\x02 \x01(\x0b\x32%.shiftcrypto.bitbox02.BTCScriptConfig\x12\x0f\n\x07keypath\x18\x03 \x03(\r\"\xd7\x01\n\x12\x42TCSignInitRequest\x12+\n\x04\x63oin\x18\x01 \x01(\x0e\x32\x1d.shiftcrypto.bitbox02.BTCCoin\x12H\n\x0escript_configs\x18\x02 \x03(\x0b\x32\x30.shiftcrypto.bitbox02.BTCScriptConfigWithKeypath\x12\x0f\n\x07version\x18\x04 \x01(\r\x12\x12\n\nnum_inputs\x18\x05 \x01(\r\x12\x13\n\x0bnum_outputs\x18\x06 \x01(\r\x12\x10\n\x08locktime\x18\x07 \x01(\r\"\xff\x01\n\x13\x42TCSignNextResponse\x12<\n\x04type\x18\x01 \x01(\x0e\x32..shiftcrypto.bitbox02.BTCSignNextResponse.Type\x12\r\n\x05index\x18\x02 \x01(\r\x12\x15\n\rhas_signature\x18\x03 \x01(\x08\x12\x11\n\tsignature\x18\x04 \x01(\x0c\x12\x12\n\nprev_index\x18\x05 \x01(\r\"]\n\x04Type\x12\t\n\x05INPUT\x10\x00\x12\n\n\x06OUTPUT\x10\x01\x12\x08\n\x04\x44ONE\x10\x02\x12\x0f\n\x0bPREVTX_INIT\x10\x03\x12\x10\n\x0cPREVTX_INPUT\x10\x04\x12\x11\n\rPREVTX_OUTPUT\x10\x05\"\x96\x01\n\x13\x42TCSignInputRequest\x12\x13\n\x0bprevOutHash\x18\x01 \x01(\x0c\x12\x14\n\x0cprevOutIndex\x18\x02 \x01(\r\x12\x14\n\x0cprevOutValue\x18\x03 \x01(\x04\x12\x10\n\x08sequence\x18\x04 \x01(\r\x12\x0f\n\x07keypath\x18\x06 \x03(\r\x12\x1b\n\x13script_config_index\x18\x07 \x01(\r\"\xa2\x01\n\x14\x42TCSignOutputRequest\x12\x0c\n\x04ours\x18\x01 \x01(\x08\x12\x31\n\x04type\x18\x02 \x01(\x0e\x32#.shiftcrypto.bitbox02.BTCOutputType\x12\r\n\x05value\x18\x03 \x01(\x04\x12\x0c\n\x04hash\x18\x04 \x01(\x0c\x12\x0f\n\x07keypath\x18\x05 \x03(\r\x12\x1b\n\x13script_config_index\x18\x06 \x01(\r\"\x99\x01\n\x1b\x42TCScriptConfigRegistration\x12+\n\x04\x63oin\x18\x01 \x01(\x0e\x32\x1d.shiftcrypto.bitbox02.BTCCoin\x12<\n\rscript_config\x18\x02 \x01(\x0b\x32%.shiftcrypto.bitbox02.BTCScriptConfig\x12\x0f\n\x07keypath\x18\x03 \x03(\r\"\x0c\n\nBTCSuccess\"m\n\"BTCIsScriptConfigRegisteredRequest\x12G\n\x0cregistration\x18\x01 \x01(\x0b\x32\x31.shiftcrypto.bitbox02.BTCScriptConfigRegistration\"<\n#BTCIsScriptConfigRegisteredResponse\x12\x15\n\ris_registered\x18\x01 \x01(\x08\"w\n\x1e\x42TCRegisterScriptConfigRequest\x12G\n\x0cregistration\x18\x01 \x01(\x0b\x32\x31.shiftcrypto.bitbox02.BTCScriptConfigRegistration\x12\x0c\n\x04name\x18\x02 \x01(\t\"b\n\x14\x42TCPrevTxInitRequest\x12\x0f\n\x07version\x18\x01 \x01(\r\x12\x12\n\nnum_inputs\x18\x02 \x01(\r\x12\x13\n\x0bnum_outputs\x18\x03 \x01(\r\x12\x10\n\x08locktime\x18\x04 \x01(\r\"r\n\x15\x42TCPrevTxInputRequest\x12\x15\n\rprev_out_hash\x18\x01 \x01(\x0c\x12\x16\n\x0eprev_out_index\x18\x02 \x01(\r\x12\x18\n\x10signature_script\x18\x03 \x01(\x0c\x12\x10\n\x08sequence\x18\x04 \x01(\r\">\n\x16\x42TCPrevTxOutputRequest\x12\r\n\x05value\x18\x01 \x01(\x04\x12\x15\n\rpubkey_script\x18\x02 \x01(\x0c\"\x9f\x03\n\nBTCRequest\x12_\n\x1bis_script_config_registered\x18\x01 \x01(\x0b\x32\x38.shiftcrypto.bitbox02.BTCIsScriptConfigRegisteredRequestH\x00\x12V\n\x16register_script_config\x18\x02 \x01(\x0b\x32\x34.shiftcrypto.bitbox02.BTCRegisterScriptConfigRequestH\x00\x12\x41\n\x0bprevtx_init\x18\x03 \x01(\x0b\x32*.shiftcrypto.bitbox02.BTCPrevTxInitRequestH\x00\x12\x43\n\x0cprevtx_input\x18\x04 \x01(\x0b\x32+.shiftcrypto.bitbox02.BTCPrevTxInputRequestH\x00\x12\x45\n\rprevtx_output\x18\x05 \x01(\x0b\x32,.shiftcrypto.bitbox02.BTCPrevTxOutputRequestH\x00\x42\t\n\x07request\"\xf0\x01\n\x0b\x42TCResponse\x12\x33\n\x07success\x18\x01 \x01(\x0b\x32 .shiftcrypto.bitbox02.BTCSuccessH\x00\x12`\n\x1bis_script_config_registered\x18\x02 \x01(\x0b\x32\x39.shiftcrypto.bitbox02.BTCIsScriptConfigRegisteredResponseH\x00\x12>\n\tsign_next\x18\x03 \x01(\x0b\x32).shiftcrypto.bitbox02.BTCSignNextResponseH\x00\x42\n\n\x08response*/\n\x07\x42TCCoin\x12\x07\n\x03\x42TC\x10\x00\x12\x08\n\x04TBTC\x10\x01\x12\x07\n\x03LTC\x10\x02\x12\x08\n\x04TLTC\x10\x03*H\n\rBTCOutputType\x12\x0b\n\x07UNKNOWN\x10\x00\x12\t\n\x05P2PKH\x10\x01\x12\x08\n\x04P2SH\x10\x02\x12\n\n\x06P2WPKH\x10\x03\x12\t\n\x05P2WSH\x10\x04\x62\x06proto3')
   ,
   dependencies=[common__pb2.DESCRIPTOR,])
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
@@ -51,8 +51,8 @@ _BTCCOIN = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=2860,
-  serialized_end=2907,
+  serialized_start=3015,
+  serialized_end=3062,
 )
 _sym_db.RegisterEnumDescriptor(_BTCCOIN)
 
@@ -86,8 +86,8 @@ _BTCOUTPUTTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=2909,
-  serialized_end=2981,
+  serialized_start=3064,
+  serialized_end=3136,
 )
 _sym_db.RegisterEnumDescriptor(_BTCOUTPUTTYPE)
 
@@ -204,8 +204,8 @@ _BTCSIGNNEXTRESPONSE_TYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=1101,
-  serialized_end=1194,
+  serialized_start=1197,
+  serialized_end=1290,
 )
 _sym_db.RegisterEnumDescriptor(_BTCSIGNNEXTRESPONSE_TYPE)
 
@@ -359,6 +359,44 @@ _BTCPUBREQUEST = _descriptor.Descriptor(
 )
 
 
+_BTCSCRIPTCONFIGWITHKEYPATH = _descriptor.Descriptor(
+  name='BTCScriptConfigWithKeypath',
+  full_name='shiftcrypto.bitbox02.BTCScriptConfigWithKeypath',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='script_config', full_name='shiftcrypto.bitbox02.BTCScriptConfigWithKeypath.script_config', index=0,
+      number=2, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='keypath', full_name='shiftcrypto.bitbox02.BTCScriptConfigWithKeypath.keypath', index=1,
+      number=3, type=13, cpp_type=3, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=707,
+  serialized_end=814,
+)
+
+
 _BTCSIGNINITREQUEST = _descriptor.Descriptor(
   name='BTCSignInitRequest',
   full_name='shiftcrypto.bitbox02.BTCSignInitRequest',
@@ -374,42 +412,35 @@ _BTCSIGNINITREQUEST = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='script_config', full_name='shiftcrypto.bitbox02.BTCSignInitRequest.script_config', index=1,
-      number=2, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='keypath_account', full_name='shiftcrypto.bitbox02.BTCSignInitRequest.keypath_account', index=2,
-      number=3, type=13, cpp_type=3, label=3,
+      name='script_configs', full_name='shiftcrypto.bitbox02.BTCSignInitRequest.script_configs', index=1,
+      number=2, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='version', full_name='shiftcrypto.bitbox02.BTCSignInitRequest.version', index=3,
+      name='version', full_name='shiftcrypto.bitbox02.BTCSignInitRequest.version', index=2,
       number=4, type=13, cpp_type=3, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='num_inputs', full_name='shiftcrypto.bitbox02.BTCSignInitRequest.num_inputs', index=4,
+      name='num_inputs', full_name='shiftcrypto.bitbox02.BTCSignInitRequest.num_inputs', index=3,
       number=5, type=13, cpp_type=3, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='num_outputs', full_name='shiftcrypto.bitbox02.BTCSignInitRequest.num_outputs', index=5,
+      name='num_outputs', full_name='shiftcrypto.bitbox02.BTCSignInitRequest.num_outputs', index=4,
       number=6, type=13, cpp_type=3, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='locktime', full_name='shiftcrypto.bitbox02.BTCSignInitRequest.locktime', index=6,
+      name='locktime', full_name='shiftcrypto.bitbox02.BTCSignInitRequest.locktime', index=5,
       number=7, type=13, cpp_type=3, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
@@ -427,8 +458,8 @@ _BTCSIGNINITREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=708,
-  serialized_end=936,
+  serialized_start=817,
+  serialized_end=1032,
 )
 
 
@@ -487,8 +518,8 @@ _BTCSIGNNEXTRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=939,
-  serialized_end=1194,
+  serialized_start=1035,
+  serialized_end=1290,
 )
 
 
@@ -534,6 +565,13 @@ _BTCSIGNINPUTREQUEST = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
+    _descriptor.FieldDescriptor(
+      name='script_config_index', full_name='shiftcrypto.bitbox02.BTCSignInputRequest.script_config_index', index=5,
+      number=7, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
   ],
   extensions=[
   ],
@@ -546,8 +584,8 @@ _BTCSIGNINPUTREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1196,
-  serialized_end=1317,
+  serialized_start=1293,
+  serialized_end=1443,
 )
 
 
@@ -593,6 +631,13 @@ _BTCSIGNOUTPUTREQUEST = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
+    _descriptor.FieldDescriptor(
+      name='script_config_index', full_name='shiftcrypto.bitbox02.BTCSignOutputRequest.script_config_index', index=5,
+      number=6, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
   ],
   extensions=[
   ],
@@ -605,8 +650,8 @@ _BTCSIGNOUTPUTREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1320,
-  serialized_end=1453,
+  serialized_start=1446,
+  serialized_end=1608,
 )
 
 
@@ -650,8 +695,8 @@ _BTCSCRIPTCONFIGREGISTRATION = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1456,
-  serialized_end=1609,
+  serialized_start=1611,
+  serialized_end=1764,
 )
 
 
@@ -674,8 +719,8 @@ _BTCSUCCESS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1611,
-  serialized_end=1623,
+  serialized_start=1766,
+  serialized_end=1778,
 )
 
 
@@ -705,8 +750,8 @@ _BTCISSCRIPTCONFIGREGISTEREDREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1625,
-  serialized_end=1734,
+  serialized_start=1780,
+  serialized_end=1889,
 )
 
 
@@ -736,8 +781,8 @@ _BTCISSCRIPTCONFIGREGISTEREDRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1736,
-  serialized_end=1796,
+  serialized_start=1891,
+  serialized_end=1951,
 )
 
 
@@ -774,8 +819,8 @@ _BTCREGISTERSCRIPTCONFIGREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1798,
-  serialized_end=1917,
+  serialized_start=1953,
+  serialized_end=2072,
 )
 
 
@@ -826,8 +871,8 @@ _BTCPREVTXINITREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1919,
-  serialized_end=2017,
+  serialized_start=2074,
+  serialized_end=2172,
 )
 
 
@@ -878,8 +923,8 @@ _BTCPREVTXINPUTREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2019,
-  serialized_end=2133,
+  serialized_start=2174,
+  serialized_end=2288,
 )
 
 
@@ -916,8 +961,8 @@ _BTCPREVTXOUTPUTREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2135,
-  serialized_end=2197,
+  serialized_start=2290,
+  serialized_end=2352,
 )
 
 
@@ -978,8 +1023,8 @@ _BTCREQUEST = _descriptor.Descriptor(
       name='request', full_name='shiftcrypto.bitbox02.BTCRequest.request',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=2200,
-  serialized_end=2615,
+  serialized_start=2355,
+  serialized_end=2770,
 )
 
 
@@ -1026,8 +1071,8 @@ _BTCRESPONSE = _descriptor.Descriptor(
       name='response', full_name='shiftcrypto.bitbox02.BTCResponse.response',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=2618,
-  serialized_end=2858,
+  serialized_start=2773,
+  serialized_end=3013,
 )
 
 _BTCSCRIPTCONFIG_MULTISIG.fields_by_name['xpubs'].message_type = common__pb2._XPUB
@@ -1051,8 +1096,9 @@ _BTCPUBREQUEST.fields_by_name['xpub_type'].containing_oneof = _BTCPUBREQUEST.one
 _BTCPUBREQUEST.oneofs_by_name['output'].fields.append(
   _BTCPUBREQUEST.fields_by_name['script_config'])
 _BTCPUBREQUEST.fields_by_name['script_config'].containing_oneof = _BTCPUBREQUEST.oneofs_by_name['output']
+_BTCSCRIPTCONFIGWITHKEYPATH.fields_by_name['script_config'].message_type = _BTCSCRIPTCONFIG
 _BTCSIGNINITREQUEST.fields_by_name['coin'].enum_type = _BTCCOIN
-_BTCSIGNINITREQUEST.fields_by_name['script_config'].message_type = _BTCSCRIPTCONFIG
+_BTCSIGNINITREQUEST.fields_by_name['script_configs'].message_type = _BTCSCRIPTCONFIGWITHKEYPATH
 _BTCSIGNNEXTRESPONSE.fields_by_name['type'].enum_type = _BTCSIGNNEXTRESPONSE_TYPE
 _BTCSIGNNEXTRESPONSE_TYPE.containing_type = _BTCSIGNNEXTRESPONSE
 _BTCSIGNOUTPUTREQUEST.fields_by_name['type'].enum_type = _BTCOUTPUTTYPE
@@ -1094,6 +1140,7 @@ _BTCRESPONSE.oneofs_by_name['response'].fields.append(
 _BTCRESPONSE.fields_by_name['sign_next'].containing_oneof = _BTCRESPONSE.oneofs_by_name['response']
 DESCRIPTOR.message_types_by_name['BTCScriptConfig'] = _BTCSCRIPTCONFIG
 DESCRIPTOR.message_types_by_name['BTCPubRequest'] = _BTCPUBREQUEST
+DESCRIPTOR.message_types_by_name['BTCScriptConfigWithKeypath'] = _BTCSCRIPTCONFIGWITHKEYPATH
 DESCRIPTOR.message_types_by_name['BTCSignInitRequest'] = _BTCSIGNINITREQUEST
 DESCRIPTOR.message_types_by_name['BTCSignNextResponse'] = _BTCSIGNNEXTRESPONSE
 DESCRIPTOR.message_types_by_name['BTCSignInputRequest'] = _BTCSIGNINPUTREQUEST
@@ -1132,6 +1179,13 @@ BTCPubRequest = _reflection.GeneratedProtocolMessageType('BTCPubRequest', (_mess
   # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.BTCPubRequest)
   ))
 _sym_db.RegisterMessage(BTCPubRequest)
+
+BTCScriptConfigWithKeypath = _reflection.GeneratedProtocolMessageType('BTCScriptConfigWithKeypath', (_message.Message,), dict(
+  DESCRIPTOR = _BTCSCRIPTCONFIGWITHKEYPATH,
+  __module__ = 'btc_pb2'
+  # @@protoc_insertion_point(class_scope:shiftcrypto.bitbox02.BTCScriptConfigWithKeypath)
+  ))
+_sym_db.RegisterMessage(BTCScriptConfigWithKeypath)
 
 BTCSignInitRequest = _reflection.GeneratedProtocolMessageType('BTCSignInitRequest', (_message.Message,), dict(
   DESCRIPTOR = _BTCSIGNINITREQUEST,

--- a/py/bitbox02/bitbox02/communication/generated/btc_pb2.pyi
+++ b/py/bitbox02/bitbox02/communication/generated/btc_pb2.pyi
@@ -195,22 +195,42 @@ class BTCPubRequest(google___protobuf___message___Message):
         def ClearField(self, field_name: typing_extensions___Literal[u"coin",b"coin",u"display",b"display",u"keypath",b"keypath",u"output",b"output",u"script_config",b"script_config",u"xpub_type",b"xpub_type"]) -> None: ...
     def WhichOneof(self, oneof_group: typing_extensions___Literal[u"output",b"output"]) -> typing_extensions___Literal["xpub_type","script_config"]: ...
 
-class BTCSignInitRequest(google___protobuf___message___Message):
-    coin = ... # type: BTCCoin
-    keypath_account = ... # type: google___protobuf___internal___containers___RepeatedScalarFieldContainer[int]
-    version = ... # type: int
-    num_inputs = ... # type: int
-    num_outputs = ... # type: int
-    locktime = ... # type: int
+class BTCScriptConfigWithKeypath(google___protobuf___message___Message):
+    keypath = ... # type: google___protobuf___internal___containers___RepeatedScalarFieldContainer[int]
 
     @property
     def script_config(self) -> BTCScriptConfig: ...
 
     def __init__(self,
         *,
-        coin : typing___Optional[BTCCoin] = None,
         script_config : typing___Optional[BTCScriptConfig] = None,
-        keypath_account : typing___Optional[typing___Iterable[int]] = None,
+        keypath : typing___Optional[typing___Iterable[int]] = None,
+        ) -> None: ...
+    @classmethod
+    def FromString(cls, s: bytes) -> BTCScriptConfigWithKeypath: ...
+    def MergeFrom(self, other_msg: google___protobuf___message___Message) -> None: ...
+    def CopyFrom(self, other_msg: google___protobuf___message___Message) -> None: ...
+    if sys.version_info >= (3,):
+        def HasField(self, field_name: typing_extensions___Literal[u"script_config"]) -> bool: ...
+        def ClearField(self, field_name: typing_extensions___Literal[u"keypath",u"script_config"]) -> None: ...
+    else:
+        def HasField(self, field_name: typing_extensions___Literal[u"script_config",b"script_config"]) -> bool: ...
+        def ClearField(self, field_name: typing_extensions___Literal[u"keypath",b"keypath",u"script_config",b"script_config"]) -> None: ...
+
+class BTCSignInitRequest(google___protobuf___message___Message):
+    coin = ... # type: BTCCoin
+    version = ... # type: int
+    num_inputs = ... # type: int
+    num_outputs = ... # type: int
+    locktime = ... # type: int
+
+    @property
+    def script_configs(self) -> google___protobuf___internal___containers___RepeatedCompositeFieldContainer[BTCScriptConfigWithKeypath]: ...
+
+    def __init__(self,
+        *,
+        coin : typing___Optional[BTCCoin] = None,
+        script_configs : typing___Optional[typing___Iterable[BTCScriptConfigWithKeypath]] = None,
         version : typing___Optional[int] = None,
         num_inputs : typing___Optional[int] = None,
         num_outputs : typing___Optional[int] = None,
@@ -221,11 +241,9 @@ class BTCSignInitRequest(google___protobuf___message___Message):
     def MergeFrom(self, other_msg: google___protobuf___message___Message) -> None: ...
     def CopyFrom(self, other_msg: google___protobuf___message___Message) -> None: ...
     if sys.version_info >= (3,):
-        def HasField(self, field_name: typing_extensions___Literal[u"script_config"]) -> bool: ...
-        def ClearField(self, field_name: typing_extensions___Literal[u"coin",u"keypath_account",u"locktime",u"num_inputs",u"num_outputs",u"script_config",u"version"]) -> None: ...
+        def ClearField(self, field_name: typing_extensions___Literal[u"coin",u"locktime",u"num_inputs",u"num_outputs",u"script_configs",u"version"]) -> None: ...
     else:
-        def HasField(self, field_name: typing_extensions___Literal[u"script_config",b"script_config"]) -> bool: ...
-        def ClearField(self, field_name: typing_extensions___Literal[u"coin",b"coin",u"keypath_account",b"keypath_account",u"locktime",b"locktime",u"num_inputs",b"num_inputs",u"num_outputs",b"num_outputs",u"script_config",b"script_config",u"version",b"version"]) -> None: ...
+        def ClearField(self, field_name: typing_extensions___Literal[u"coin",b"coin",u"locktime",b"locktime",u"num_inputs",b"num_inputs",u"num_outputs",b"num_outputs",u"script_configs",b"script_configs",u"version",b"version"]) -> None: ...
 
 class BTCSignNextResponse(google___protobuf___message___Message):
     class Type(int):
@@ -282,6 +300,7 @@ class BTCSignInputRequest(google___protobuf___message___Message):
     prevOutValue = ... # type: int
     sequence = ... # type: int
     keypath = ... # type: google___protobuf___internal___containers___RepeatedScalarFieldContainer[int]
+    script_config_index = ... # type: int
 
     def __init__(self,
         *,
@@ -290,15 +309,16 @@ class BTCSignInputRequest(google___protobuf___message___Message):
         prevOutValue : typing___Optional[int] = None,
         sequence : typing___Optional[int] = None,
         keypath : typing___Optional[typing___Iterable[int]] = None,
+        script_config_index : typing___Optional[int] = None,
         ) -> None: ...
     @classmethod
     def FromString(cls, s: bytes) -> BTCSignInputRequest: ...
     def MergeFrom(self, other_msg: google___protobuf___message___Message) -> None: ...
     def CopyFrom(self, other_msg: google___protobuf___message___Message) -> None: ...
     if sys.version_info >= (3,):
-        def ClearField(self, field_name: typing_extensions___Literal[u"keypath",u"prevOutHash",u"prevOutIndex",u"prevOutValue",u"sequence"]) -> None: ...
+        def ClearField(self, field_name: typing_extensions___Literal[u"keypath",u"prevOutHash",u"prevOutIndex",u"prevOutValue",u"script_config_index",u"sequence"]) -> None: ...
     else:
-        def ClearField(self, field_name: typing_extensions___Literal[u"keypath",b"keypath",u"prevOutHash",b"prevOutHash",u"prevOutIndex",b"prevOutIndex",u"prevOutValue",b"prevOutValue",u"sequence",b"sequence"]) -> None: ...
+        def ClearField(self, field_name: typing_extensions___Literal[u"keypath",b"keypath",u"prevOutHash",b"prevOutHash",u"prevOutIndex",b"prevOutIndex",u"prevOutValue",b"prevOutValue",u"script_config_index",b"script_config_index",u"sequence",b"sequence"]) -> None: ...
 
 class BTCSignOutputRequest(google___protobuf___message___Message):
     ours = ... # type: bool
@@ -306,6 +326,7 @@ class BTCSignOutputRequest(google___protobuf___message___Message):
     value = ... # type: int
     hash = ... # type: bytes
     keypath = ... # type: google___protobuf___internal___containers___RepeatedScalarFieldContainer[int]
+    script_config_index = ... # type: int
 
     def __init__(self,
         *,
@@ -314,15 +335,16 @@ class BTCSignOutputRequest(google___protobuf___message___Message):
         value : typing___Optional[int] = None,
         hash : typing___Optional[bytes] = None,
         keypath : typing___Optional[typing___Iterable[int]] = None,
+        script_config_index : typing___Optional[int] = None,
         ) -> None: ...
     @classmethod
     def FromString(cls, s: bytes) -> BTCSignOutputRequest: ...
     def MergeFrom(self, other_msg: google___protobuf___message___Message) -> None: ...
     def CopyFrom(self, other_msg: google___protobuf___message___Message) -> None: ...
     if sys.version_info >= (3,):
-        def ClearField(self, field_name: typing_extensions___Literal[u"hash",u"keypath",u"ours",u"type",u"value"]) -> None: ...
+        def ClearField(self, field_name: typing_extensions___Literal[u"hash",u"keypath",u"ours",u"script_config_index",u"type",u"value"]) -> None: ...
     else:
-        def ClearField(self, field_name: typing_extensions___Literal[u"hash",b"hash",u"keypath",b"keypath",u"ours",b"ours",u"type",b"type",u"value",b"value"]) -> None: ...
+        def ClearField(self, field_name: typing_extensions___Literal[u"hash",b"hash",u"keypath",b"keypath",u"ours",b"ours",u"script_config_index",b"script_config_index",u"type",b"type",u"value",b"value"]) -> None: ...
 
 class BTCScriptConfigRegistration(google___protobuf___message___Message):
     coin = ... # type: BTCCoin

--- a/py/send_message.py
+++ b/py/send_message.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # Copyright 2019 Shift Cryptosecurity AG
+# Copyright 2020 Shift Crypto AG
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -90,6 +91,7 @@ def _btc_demo_inputs_outputs(
             "prev_out_value": int(1e8 * 0.60005),
             "sequence": 0xFFFFFFFF,
             "keypath": [84 + HARDENED, 0 + HARDENED, bip44_account, 0, 0],
+            "script_config_index": 0,
             "prev_tx": {
                 "version": 1,
                 "locktime": 0,
@@ -112,6 +114,7 @@ def _btc_demo_inputs_outputs(
             "prev_out_value": int(1e8 * 0.60005),
             "sequence": 0xFFFFFFFF,
             "keypath": [84 + HARDENED, 0 + HARDENED, bip44_account, 0, 1],
+            "script_config_index": 0,
             "prev_tx": {
                 "version": 1,
                 "locktime": 0,
@@ -129,7 +132,9 @@ def _btc_demo_inputs_outputs(
     ]
     outputs: List[bitbox02.BTCOutputType] = [
         bitbox02.BTCOutputInternal(
-            keypath=[84 + HARDENED, 0 + HARDENED, bip44_account, 1, 0], value=int(1e8 * 1)
+            keypath=[84 + HARDENED, 0 + HARDENED, bip44_account, 1, 0],
+            value=int(1e8 * 1),
+            script_config_index=0,
         ),
         bitbox02.BTCOutputExternal(
             output_type=bitbox02.btc.P2WSH,
@@ -346,8 +351,14 @@ class SendMessage:
         inputs, outputs = _btc_demo_inputs_outputs(bip44_account)
         sigs = self._device.btc_sign(
             bitbox02.btc.BTC,
-            bitbox02.btc.BTCScriptConfig(simple_type=bitbox02.btc.BTCScriptConfig.P2WPKH),
-            keypath_account=[84 + HARDENED, 0 + HARDENED, bip44_account],
+            [
+                bitbox02.btc.BTCScriptConfigWithKeypath(
+                    script_config=bitbox02.btc.BTCScriptConfig(
+                        simple_type=bitbox02.btc.BTCScriptConfig.P2WPKH
+                    ),
+                    keypath=[84 + HARDENED, 0 + HARDENED, bip44_account],
+                )
+            ],
             inputs=inputs,
             outputs=outputs,
         )
@@ -361,13 +372,21 @@ class SendMessage:
         # Add a change output.
         outputs.append(
             bitbox02.BTCOutputInternal(
-                keypath=[84 + HARDENED, 0 + HARDENED, bip44_account, 1, 0], value=int(1)
+                keypath=[84 + HARDENED, 0 + HARDENED, bip44_account, 1, 0],
+                value=int(1),
+                script_config_index=0,
             )
         )
         sigs = self._device.btc_sign(
             bitbox02.btc.BTC,
-            bitbox02.btc.BTCScriptConfig(simple_type=bitbox02.btc.BTCScriptConfig.P2WPKH),
-            keypath_account=[84 + HARDENED, 0 + HARDENED, bip44_account],
+            [
+                bitbox02.btc.BTCScriptConfigWithKeypath(
+                    script_config=bitbox02.btc.BTCScriptConfig(
+                        simple_type=bitbox02.btc.BTCScriptConfig.P2WPKH
+                    ),
+                    keypath=[84 + HARDENED, 0 + HARDENED, bip44_account],
+                )
+            ],
             inputs=inputs,
             outputs=outputs,
         )
@@ -426,6 +445,7 @@ class SendMessage:
                     "prev_out_value": inp["value"],
                     "sequence": inp["spending_sequence"],
                     "keypath": [84 + HARDENED, 1 + HARDENED, bip44_account, 0, 0],
+                    "script_config_index": 0,
                     "prev_tx": {
                         "version": prev_tx["transaction"]["version"],
                         "locktime": prev_tx["transaction"]["lock_time"],
@@ -448,8 +468,14 @@ class SendMessage:
         print("Start signing...")
         self._device.btc_sign(
             bitbox02.btc.TBTC,
-            bitbox02.btc.BTCScriptConfig(simple_type=bitbox02.btc.BTCScriptConfig.P2WPKH),
-            keypath_account=[84 + HARDENED, 1 + HARDENED, bip44_account],
+            [
+                bitbox02.btc.BTCScriptConfigWithKeypath(
+                    script_config=bitbox02.btc.BTCScriptConfig(
+                        simple_type=bitbox02.btc.BTCScriptConfig.P2WPKH
+                    ),
+                    keypath=[84 + HARDENED, 1 + HARDENED, bip44_account],
+                )
+            ],
             inputs=inputs,
             outputs=outputs,
         )

--- a/src/apps/btc/btc_sign_validate.h
+++ b/src/apps/btc/btc_sign_validate.h
@@ -26,13 +26,11 @@
  * account.
  *
  * @param[in] coin we are spending
- * @param[in] script_config the script config used for all inputs and changes.
- * @param[in] keypath_account Account-level keypath.
- * @param[in] keypath_account_count number of elements in keypath_account.
+ * @param[in] script_configs the script configs allowed for all inputs and changes.
+ * @param[in] script_configs_count number of elements in script_configs.
  * @return See `app_btc_result_t`.
  */
 USE_RESULT app_btc_result_t app_btc_sign_validate_init_script_configs(
     BTCCoin coin,
-    const BTCScriptConfig* script_config,
-    const uint32_t* keypath_account,
-    size_t keypath_account_count);
+    const BTCScriptConfigWithKeypath* script_configs,
+    size_t script_configs_count);

--- a/test/unit-test/test_app_btc_sign_multisig.c
+++ b/test/unit-test/test_app_btc_sign_multisig.c
@@ -1,4 +1,5 @@
 // Copyright 2019 Shift Cryptosecurity AG
+// Copyright 2020 Shift Crypto AG
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -179,25 +180,31 @@ static void _test_btc_sign_happy(void** state)
 {
     BTCSignInitRequest init_req = {
         .coin = BTCCoin_TBTC,
-        .script_config =
+        .script_configs_count = 1,
+        .script_configs =
             {
-                .which_config = BTCScriptConfig_multisig_tag,
-                .config =
-                    {
-                        .multisig =
-                            {
-                                .threshold = 1,
-                                .xpubs_count = 2,
-                            },
-                    },
-            },
-        .keypath_account_count = 4,
-        .keypath_account =
-            {
-                48 + BIP32_INITIAL_HARDENED_CHILD,
-                1 + BIP32_INITIAL_HARDENED_CHILD,
-                0 + BIP32_INITIAL_HARDENED_CHILD,
-                2 + BIP32_INITIAL_HARDENED_CHILD,
+                {
+                    .script_config =
+                        {
+                            .which_config = BTCScriptConfig_multisig_tag,
+                            .config =
+                                {
+                                    .multisig =
+                                        {
+                                            .threshold = 1,
+                                            .xpubs_count = 2,
+                                        },
+                                },
+                        },
+                    .keypath_count = 4,
+                    .keypath =
+                        {
+                            48 + BIP32_INITIAL_HARDENED_CHILD,
+                            1 + BIP32_INITIAL_HARDENED_CHILD,
+                            0 + BIP32_INITIAL_HARDENED_CHILD,
+                            2 + BIP32_INITIAL_HARDENED_CHILD,
+                        },
+                },
             },
         .version = 2,
         .num_inputs = 1,
@@ -207,11 +214,11 @@ static void _test_btc_sign_happy(void** state)
 
     // sudden tenant fault inject concert weather maid people chunk youth stumble grit /
     // 48'/1'/0'/2'
-    init_req.script_config.config.multisig.xpubs[0] = btc_util_parse_xpub(
+    init_req.script_configs[0].script_config.config.multisig.xpubs[0] = btc_util_parse_xpub(
         "xpub6EMfjyGVUvwhpc3WKN1zXhMFGKJGMaSBPqbja4tbGoYvRBSXeTBCaqrRDjcuGTcaY95JrrAnQvDG3pdQPdtnYU"
         "CugjeksHSbyZT7rq38VQF");
     // dumb rough room report huge dry sudden hamster wait foot crew obvious / 48'/1'/0'/2'
-    init_req.script_config.config.multisig.xpubs[1] = btc_util_parse_xpub(
+    init_req.script_configs[0].script_config.config.multisig.xpubs[1] = btc_util_parse_xpub(
         "xpub6ERxBysTYfQyY4USv6c6J1HNVv9hpZFN9LHVPu47Ac4rK8fLy6NnAeeAHyEsMvG4G66ay5aFZii2VM7wT3KxLK"
         "X8Q8keZPd67kRGmrD1WJj");
 
@@ -223,7 +230,7 @@ static void _test_btc_sign_happy(void** state)
     expect_memory(
         __wrap_apps_btc_confirm_multisig,
         multisig,
-        &init_req.script_config.config.multisig,
+        &init_req.script_configs[0].script_config.config.multisig,
         sizeof(BTCScriptConfig_Multisig));
     assert_int_equal(APP_BTC_OK, app_btc_sign_init(&init_req, &next));
     assert_int_equal(next.type, BTCSignNextResponse_Type_INPUT);
@@ -259,26 +266,32 @@ static void _test_btc_sign_large_happy(void** state)
 {
     BTCSignInitRequest init_req = {
         .coin = BTCCoin_TBTC,
-        .script_config =
+        .script_configs_count = 1,
+        .script_configs =
             {
-                .which_config = BTCScriptConfig_multisig_tag,
-                .config =
-                    {
-                        .multisig =
-                            {
-                                .threshold = 7,
-                                .xpubs_count = 15,
-                                .our_xpub_index = 14,
-                            },
-                    },
-            },
-        .keypath_account_count = 4,
-        .keypath_account =
-            {
-                48 + BIP32_INITIAL_HARDENED_CHILD,
-                1 + BIP32_INITIAL_HARDENED_CHILD,
-                0 + BIP32_INITIAL_HARDENED_CHILD,
-                2 + BIP32_INITIAL_HARDENED_CHILD,
+                {
+                    .script_config =
+                        {
+                            .which_config = BTCScriptConfig_multisig_tag,
+                            .config =
+                                {
+                                    .multisig =
+                                        {
+                                            .threshold = 7,
+                                            .xpubs_count = 15,
+                                            .our_xpub_index = 14,
+                                        },
+                                },
+                        },
+                    .keypath_count = 4,
+                    .keypath =
+                        {
+                            48 + BIP32_INITIAL_HARDENED_CHILD,
+                            1 + BIP32_INITIAL_HARDENED_CHILD,
+                            0 + BIP32_INITIAL_HARDENED_CHILD,
+                            2 + BIP32_INITIAL_HARDENED_CHILD,
+                        },
+                },
             },
         .version = 2,
         .num_inputs = 1,
@@ -290,7 +303,7 @@ static void _test_btc_sign_large_happy(void** state)
 
     // sudden tenant fault inject concert weather maid people chunk youth stumble grit /
     // 48'/1'/0'/2'
-    XPub* xpubs = init_req.script_config.config.multisig.xpubs;
+    XPub* xpubs = init_req.script_configs[0].script_config.config.multisig.xpubs;
     xpubs[0] = btc_util_parse_xpub("xpub6Eu7xJRyXRCi4eLYhJPnfZVjgAQtM7qFaEZwUhvgxGf4enEZMxevGzWvZTawCj9USP2MFTEhKQAwnqHwoaPHetTLqGuvq5r5uaLKyGx5QDZ");
     xpubs[1] = btc_util_parse_xpub("xpub6EQcxF2jFkYGn89AwoQJEEJkYMbRjED9AZgt7bkxQA5BLhZEoaQpUHcADbB5GxcMrTdDSGmjP7M3u462Q9otyE2PPam66P5KFLWitPVfYz9");
     xpubs[2] = btc_util_parse_xpub("xpub6EP4EycVS5dq1PN7ZqsxBtptkYhfLvLGokZjnB3fvPshMiAohh6E5TaJjAafZWoPRjo6uiZxhtDXLgCuk81ooQgwrsnEdfSWSfa4VUtX8nu");
@@ -316,7 +329,7 @@ static void _test_btc_sign_large_happy(void** state)
     expect_memory(
         __wrap_apps_btc_confirm_multisig,
         multisig,
-        &init_req.script_config.config.multisig,
+        &init_req.script_configs[0].script_config.config.multisig,
         sizeof(BTCScriptConfig_Multisig));
     assert_int_equal(APP_BTC_OK, app_btc_sign_init(&init_req, &next));
     assert_int_equal(next.type, BTCSignNextResponse_Type_INPUT);

--- a/test/unit-test/test_btc_sign.c
+++ b/test/unit-test/test_btc_sign.c
@@ -1,4 +1,5 @@
 // Copyright 2019 Shift Cryptosecurity AG
+// Copyright 2020 Shift Crypto AG
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -95,20 +96,26 @@ static void _test_btc_sign_init(void** state)
     // establish valid request to modify
     const BTCSignInitRequest init_req_valid = {
         .coin = BTCCoin_BTC,
-        .script_config =
+        .script_configs_count = 1,
+        .script_configs =
             {
-                .which_config = BTCScriptConfig_simple_type_tag,
-                .config =
-                    {
-                        .simple_type = BTCScriptConfig_SimpleType_P2WPKH,
-                    },
-            },
-        .keypath_account_count = 3,
-        .keypath_account =
-            {
-                84 + BIP32_INITIAL_HARDENED_CHILD,
-                0 + BIP32_INITIAL_HARDENED_CHILD,
-                0 + BIP32_INITIAL_HARDENED_CHILD,
+                {
+                    .script_config =
+                        {
+                            .which_config = BTCScriptConfig_simple_type_tag,
+                            .config =
+                                {
+                                    .simple_type = BTCScriptConfig_SimpleType_P2WPKH,
+                                },
+                        },
+                    .keypath_count = 3,
+                    .keypath =
+                        {
+                            84 + BIP32_INITIAL_HARDENED_CHILD,
+                            0 + BIP32_INITIAL_HARDENED_CHILD,
+                            0 + BIP32_INITIAL_HARDENED_CHILD,
+                        },
+                },
             },
         .version = 1,
         .num_inputs = 1,
@@ -322,20 +329,26 @@ static void _sign(const _modification_t* mod)
     }
     BTCSignInitRequest init_req = {
         .coin = BTCCoin_BTC,
-        .script_config =
+        .script_configs_count = 1,
+        .script_configs =
             {
-                .which_config = BTCScriptConfig_simple_type_tag,
-                .config =
-                    {
-                        .simple_type = mod->script_type,
-                    },
-            },
-        .keypath_account_count = 3,
-        .keypath_account =
-            {
-                purpose,
-                0 + BIP32_INITIAL_HARDENED_CHILD,
-                10 + BIP32_INITIAL_HARDENED_CHILD,
+                {
+                    .script_config =
+                        {
+                            .which_config = BTCScriptConfig_simple_type_tag,
+                            .config =
+                                {
+                                    .simple_type = mod->script_type,
+                                },
+                        },
+                    .keypath_count = 3,
+                    .keypath =
+                        {
+                            purpose,
+                            0 + BIP32_INITIAL_HARDENED_CHILD,
+                            10 + BIP32_INITIAL_HARDENED_CHILD,
+                        },
+                },
             },
         .version = 1,
         .num_inputs = 2,
@@ -356,9 +369,9 @@ static void _sign(const _modification_t* mod)
                     .keypath_count = 5,
                     .keypath =
                         {
-                            init_req.keypath_account[0],
-                            init_req.keypath_account[1],
-                            init_req.keypath_account[2],
+                            init_req.script_configs[0].keypath[0],
+                            init_req.script_configs[0].keypath[1],
+                            init_req.script_configs[0].keypath[2],
                             0,
                             5,
                         },
@@ -431,9 +444,9 @@ static void _sign(const _modification_t* mod)
                     .keypath_count = 5,
                     .keypath =
                         {
-                            init_req.keypath_account[0],
-                            init_req.keypath_account[1],
-                            init_req.keypath_account[2],
+                            init_req.script_configs[0].keypath[0],
+                            init_req.script_configs[0].keypath[1],
+                            init_req.script_configs[0].keypath[2],
                             0,
                             7,
                         },
@@ -569,9 +582,9 @@ static void _sign(const _modification_t* mod)
             .keypath_count = 5,
             .keypath =
                 {
-                    init_req.keypath_account[0],
-                    init_req.keypath_account[1],
-                    init_req.keypath_account[2],
+                    init_req.script_configs[0].keypath[0],
+                    init_req.script_configs[0].keypath[1],
+                    init_req.script_configs[0].keypath[2],
                     mod->bip44_change,
                     3,
                 },
@@ -583,9 +596,9 @@ static void _sign(const _modification_t* mod)
             .keypath_count = 5,
             .keypath =
                 {
-                    init_req.keypath_account[0],
-                    init_req.keypath_account[1],
-                    init_req.keypath_account[2],
+                    init_req.script_configs[0].keypath[0],
+                    init_req.script_configs[0].keypath[1],
+                    init_req.script_configs[0].keypath[2],
                     mod->bip44_change,
                     30,
                 },
@@ -612,7 +625,7 @@ static void _sign(const _modification_t* mod)
     if (mod->litecoin_rbf_disabled) {
         init_req.coin = BTCCoin_LTC;
         init_req.locktime = 1;
-        init_req.keypath_account[1] = 2 + BIP32_INITIAL_HARDENED_CHILD;
+        init_req.script_configs[0].keypath[1] = 2 + BIP32_INITIAL_HARDENED_CHILD;
         inputs[0].input.sequence = 0xffffffff - 2;
         inputs[0].input.keypath[1] = 2 + BIP32_INITIAL_HARDENED_CHILD;
         inputs[1].input.keypath[1] = 2 + BIP32_INITIAL_HARDENED_CHILD;
@@ -643,7 +656,7 @@ static void _sign(const _modification_t* mod)
         expect_value(
             __wrap_btc_common_is_valid_keypath_address_simple,
             script_type,
-            init_req.script_config.config.simple_type);
+            init_req.script_configs[0].script_config.config.simple_type);
         expect_memory(
             __wrap_btc_common_is_valid_keypath_address_simple,
             keypath,
@@ -674,7 +687,7 @@ static void _sign(const _modification_t* mod)
     expect_value(
         __wrap_btc_common_is_valid_keypath_address_simple,
         script_type,
-        init_req.script_config.config.simple_type);
+        init_req.script_configs[0].script_config.config.simple_type);
     expect_memory(
         __wrap_btc_common_is_valid_keypath_address_simple,
         keypath,
@@ -816,7 +829,7 @@ static void _sign(const _modification_t* mod)
     expect_value(
         __wrap_btc_common_is_valid_keypath_address_simple,
         script_type,
-        init_req.script_config.config.simple_type);
+        init_req.script_configs[0].script_config.config.simple_type);
     expect_memory(
         __wrap_btc_common_is_valid_keypath_address_simple,
         keypath,
@@ -839,7 +852,7 @@ static void _sign(const _modification_t* mod)
     expect_value(
         __wrap_btc_common_is_valid_keypath_address_simple,
         script_type,
-        init_req.script_config.config.simple_type);
+        init_req.script_configs[0].script_config.config.simple_type);
     expect_memory(
         __wrap_btc_common_is_valid_keypath_address_simple,
         keypath,
@@ -924,7 +937,7 @@ static void _sign(const _modification_t* mod)
     expect_value(
         __wrap_btc_common_is_valid_keypath_address_simple,
         script_type,
-        init_req.script_config.config.simple_type);
+        init_req.script_configs[0].script_config.config.simple_type);
     expect_memory(
         __wrap_btc_common_is_valid_keypath_address_simple,
         keypath,
@@ -967,7 +980,7 @@ static void _sign(const _modification_t* mod)
     expect_value(
         __wrap_btc_common_is_valid_keypath_address_simple,
         script_type,
-        init_req.script_config.config.simple_type);
+        init_req.script_configs[0].script_config.config.simple_type);
     expect_memory(
         __wrap_btc_common_is_valid_keypath_address_simple,
         keypath,


### PR DESCRIPTION
Before, one script config (address type) was allowed for all inputs
and changes.

This commit changes the API of the signing workflow to allow
specifying multiple script configurations that can be used in a tx,
instead of only one.

In each output and change, the `script_config_index` now references
which script config to use.

The current commit still only allows only one (see TODO), but
implements the change on the API level. The TODO will be handled in a
subsequent commit.