### PR TITLE
noise: pop screens on new handshake

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -360,6 +360,7 @@ add_custom_target(rust-bindgen
     --whitelist-function screen_print_debug
     --whitelist-function ui_screen_stack_push
     --whitelist-function ui_screen_stack_pop
+    --whitelist-function ui_screen_stack_pop_all
     --whitelist-function screen_process
     --whitelist-function label_create
     --whitelist-function confirm_create

--- a/src/rust/bitbox02-rust-c/src/noise.rs
+++ b/src/rust/bitbox02-rust-c/src/noise.rs
@@ -1,4 +1,5 @@
 // Copyright 2020 Shift Cryptosecurity AG
+// Copyright 2020 Shift Crypto AG
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/rust/bitbox02-rust/src/hww/noise.rs
+++ b/src/rust/bitbox02-rust/src/hww/noise.rs
@@ -70,6 +70,12 @@ pub(crate) async fn process(usb_in: Vec<u8>, usb_out: &mut Vec<u8>) -> Result<()
     let mut state = NOISE_STATE.0.borrow_mut();
     match usb_in.split_first() {
         Some((&OP_I_CAN_HAS_HANDSHAEK, b"")) => {
+            // The previous screen was "See the BitBoxApp".
+            // Since a handshake was requested, a client was connected, so we pop that screen.
+            // Pairing is the start of a session, so we clean the screen stack in case
+            // we started a new session in the middle of something.
+            bitbox02::ui::screen_stack_pop_all();
+
             state.init(bitbox02_noise::Sensitive::from(
                 memory::get_noise_static_private_key()?,
             ));

--- a/src/rust/bitbox02/src/ui.rs
+++ b/src/rust/bitbox02/src/ui.rs
@@ -1,4 +1,5 @@
 // Copyright 2020 Shift Cryptosecurity AG
+// Copyright 2020 Shift Crypto AG
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -222,4 +223,10 @@ pub fn with_lock_animation<F: Fn()>(f: F) {
     unsafe { bitbox02_sys::lock_animation_start() };
     f();
     unsafe { bitbox02_sys::lock_animation_stop() };
+}
+
+pub fn screen_stack_pop_all() {
+    unsafe {
+        bitbox02_sys::ui_screen_stack_pop_all();
+    }
 }


### PR DESCRIPTION
Not doing so is a regression from the rewrite of noise to Rust. This
removes the 'See the BitBoxApp' screen and goes to the default waiting
screen.

See
https://github.com/digitalbitbox/bitbox02-firmware/commit/d90d5e14207fcb1f79a69492c7cee78f71b2ea11#diff-ae8fe1d4fe4e70004f0f0ee3300406e8L189

In the future, we should consider showing the 'See the BitBoxApp'
screen again once the app is closed.

The screen stack pop was moved to the beginning of the handshake as
opposed to the end. This avoids a short flash of the 'See the
BitBoxApp' screen (as there are multiple api calls to finish the
pairing process), and we know the app (or a client) connected when a
handshake request comes in.