### PR TITLE
rust/clippy: disable redundant_clone

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -425,6 +425,7 @@ if(NOT CMAKE_CROSSCOMPILING)
             -A clippy::new_without_default
             -A clippy::single_match
             -A clippy::iter_nth_zero
+            -A clippy::redundant_clone
 
     )
   add_dependencies(rust-clippy rust-bindgen)

--- a/src/rust/bitbox02-rust-c/src/bitboxbase.rs
+++ b/src/rust/bitbox02-rust-c/src/bitboxbase.rs
@@ -207,7 +207,7 @@ pub extern "C" fn bitboxbase_state_set_not_alive() {
 #[no_mangle]
 pub extern "C" fn bitboxbase_state_get() -> BitBoxBaseBackgroundState {
     let state = unsafe { &STATE };
-    state.state.clone()
+    state.state
 }
 
 /// # Safety

--- a/src/rust/bitbox02-rust-c/src/sha2.rs
+++ b/src/rust/bitbox02-rust-c/src/sha2.rs
@@ -32,6 +32,7 @@ pub extern "C" fn rust_sha256_new() -> *mut c_void {
 #[no_mangle]
 pub unsafe extern "C" fn rust_sha256_update(ctx: *mut c_void, data: *const c_void, len: usize) {
     let data = core::slice::from_raw_parts(data as *const u8, len);
+    #[allow(clippy::cast_ptr_alignment)] // ctx is properly aligned, see `Box::into_raw`.
     let ctx = ctx as *mut Sha256;
     (*ctx).input(data);
 }
@@ -42,6 +43,7 @@ pub unsafe extern "C" fn rust_sha256_update(ctx: *mut c_void, data: *const c_voi
 #[no_mangle]
 pub unsafe extern "C" fn rust_sha256_finish(ctx: *mut *mut c_void, out: *mut c_uchar) {
     let out = core::slice::from_raw_parts_mut(out, 32);
+    #[allow(clippy::cast_ptr_alignment)] // ctx is properly aligned, see `Box::into_raw`.
     let hasher = Box::from_raw(*ctx as *mut Sha256); // dropped at the end
     let hash = hasher.result();
     out.copy_from_slice(&hash[..]);
@@ -54,6 +56,7 @@ pub unsafe extern "C" fn rust_sha256_finish(ctx: *mut *mut c_void, out: *mut c_u
 #[no_mangle]
 pub unsafe extern "C" fn rust_sha256_free(ctx: *mut *mut c_void) {
     if !(*ctx).is_null() {
+        #[allow(clippy::cast_ptr_alignment)] // ctx is properly aligned, see `Box::into_raw`.
         Box::from_raw(*ctx as *mut Sha256);
         *ctx = core::ptr::null_mut();
     }

--- a/src/rust/bitbox02-rust-c/src/util.rs
+++ b/src/rust/bitbox02-rust-c/src/util.rs
@@ -70,10 +70,11 @@ impl AsRef<[u8]> for Bytes {
     /// Create a slice to a buffer. Only allowed for non-null pointers with length or null pointers
     /// with 0 length due to limitation in `core::slice`.
     fn as_ref(&self) -> &[u8] {
-        let mut buf = self.buf;
-        if self.len == 0 && self.buf.is_null() {
-            buf = core::ptr::NonNull::dangling().as_ptr();
-        }
+        let buf = if self.len == 0 && self.buf.is_null() {
+            core::ptr::NonNull::dangling().as_ptr()
+        } else {
+            self.buf
+        };
         assert!(!buf.is_null());
         unsafe { core::slice::from_raw_parts(buf, self.len) }
     }
@@ -83,10 +84,11 @@ impl AsRef<[u8]> for BytesMut {
     /// Create a slice to a buffer. Only allowed for non-null pointers with length or null pointers
     /// with 0 length due to limitation in `core::slice`.
     fn as_ref(&self) -> &[u8] {
-        let mut buf = self.buf;
-        if self.len == 0 && self.buf.is_null() {
-            buf = core::ptr::NonNull::dangling().as_ptr();
-        }
+        let buf = if self.len == 0 && self.buf.is_null() {
+            core::ptr::NonNull::dangling().as_ptr()
+        } else {
+            self.buf
+        };
         assert!(!buf.is_null());
         unsafe { core::slice::from_raw_parts(buf, self.len) }
     }
@@ -96,10 +98,11 @@ impl AsMut<[u8]> for BytesMut {
     /// Create a slice to a buffer. Only allowed for non-null pointers with length or null pointers
     /// with 0 length due to limitation in `core::slice`.
     fn as_mut(&mut self) -> &mut [u8] {
-        let mut buf = self.buf;
-        if self.len == 0 && self.buf.is_null() {
-            buf = core::ptr::NonNull::dangling().as_ptr();
-        }
+        let buf = if self.len == 0 && self.buf.is_null() {
+            core::ptr::NonNull::dangling().as_ptr()
+        } else {
+            self.buf
+        };
         assert!(!buf.is_null());
         unsafe { core::slice::from_raw_parts_mut(buf, self.len) }
     }
@@ -116,19 +119,20 @@ impl CStr {
     /// Create a CStr from a null-terminated string or null pointer. Unsafe because it will read
     /// until it finds a null character.
     pub unsafe fn new(buf: *const c_char) -> Self {
-        let mut buf = buf;
-        let mut len = 0;
         if buf.is_null() {
-            buf = core::ptr::NonNull::dangling().as_ptr();
-            len = 0;
+            CStr {
+                buf: core::ptr::NonNull::dangling().as_ptr(),
+                len: 0,
+            }
         } else {
+            let mut len = 0;
             let mut b = buf;
             while b.read() != 0 {
                 len += 1;
                 b = b.offset(1);
             }
+            CStr { buf, len }
         }
-        CStr { buf, len }
     }
 }
 


### PR DESCRIPTION
Has false positives that can be very subtle, so best to play it
safe.

https://github.com/async-rs/async-task/issues/23