### PR TITLE
protobuf/backup: reduce sizes

### DIFF
--- a/messages/backup_commands.options
+++ b/messages/backup_commands.options
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-CheckBackupResponse.id fixed_length:true max_size:256
-ListBackupsResponse.info max_count:100
+CheckBackupResponse.id fixed_length:true max_size:65
+ListBackupsResponse.info max_count:50
 // One backup per seed -> 100 seeds may be backed up per SD card. Adapt this number if it is too small.
-BackupInfo.id fixed_length:true max_size:256
+BackupInfo.id fixed_length:true max_size:65
 BackupInfo.name fixed_length:true max_size:64
-RestoreBackupRequest.id fixed_length:true max_size:256
+RestoreBackupRequest.id fixed_length:true max_size:65


### PR DESCRIPTION
The list backup response size. serialized, was up to 33404 bytes if
all fields were maxed out. This is an accident, as we can't even
transmit more than ~7.6k protobuf packets.

In practice, the size was smaller and could not reach those numbers,
because the id field in reality is 64 bytes (format of a 32 byte hash), not up to 256 bytes as specified.

In addition, we reduce the number of max backups in the list of 100 to
50. 50 is still far more than reasonable, but puts the maximum number
of bytes of the response at 7103 bytes.