### PR TITLE
rust-bindgen: turn commander_error_t into a Rust enum

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -373,6 +373,7 @@ add_custom_target(rust-bindgen
     --whitelist-function random_32_bytes_mcu
     --whitelist-type component_t
     --whitelist-type commander_error_t
+    --rustified-enum commander_error_t
     --whitelist-function commander
     --whitelist-type BitBoxBaseRequest
     --whitelist-var ".*_tag"

--- a/src/rust/bitbox02/src/commander.rs
+++ b/src/rust/bitbox02/src/commander.rs
@@ -1,4 +1,5 @@
 // Copyright 2020 Shift Cryptosecurity AG
+// Copyright 2020 Shift Crypto AG
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,6 +12,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+pub type Error = bitbox02_sys::commander_error_t;
 
 extern crate alloc;
 use alloc::vec::Vec;

--- a/src/rust/bitbox02/src/lib.rs
+++ b/src/rust/bitbox02/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright 2019 Shift Cryptosecurity AG
+// Copyright 2020 Shift Crypto AG
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -57,14 +58,6 @@ pub const BitBoxBaseRequest_set_config_tag: u16 =
 // Use this for functions exported to "C"
 #[allow(non_camel_case_types)]
 pub type commander_error_t = bitbox02_sys::commander_error_t;
-pub type CommanderError = bitbox02_sys::commander_error_t;
-
-pub const COMMANDER_ERR_USER_ABORT: bitbox02_sys::commander_error_t =
-    bitbox02_sys::commander_error_t_COMMANDER_ERR_USER_ABORT;
-pub const COMMANDER_ERR_GENERIC: bitbox02_sys::commander_error_t =
-    bitbox02_sys::commander_error_t_COMMANDER_ERR_GENERIC;
-pub const COMMANDER_OK: bitbox02_sys::commander_error_t =
-    bitbox02_sys::commander_error_t_COMMANDER_OK;
 
 pub use bitbox02_sys::font_monogram_5X9;
 


### PR DESCRIPTION
Easier to pattern match in the future than a bunch of constants.