### PR TITLE
rust: bind memory_set_device_name

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -376,6 +376,7 @@ add_custom_target(rust-bindgen
     --whitelist-function commander
     --whitelist-type BitBoxBaseRequest
     --whitelist-var ".*_tag"
+    --whitelist-var MAX_LABEL_SIZE
     --whitelist-var font_font_a_9X9
     --whitelist-var font_font_a_11X10
     --whitelist-var font_monogram_5X9

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -344,6 +344,8 @@ add_custom_target(rust-bindgen
     --whitelist-function memory_get_noise_static_private_key
     --whitelist-function memory_check_noise_remote_static_pubkey
     --whitelist-function memory_add_noise_remote_static_pubkey
+    --whitelist-function memory_set_device_name
+    --whitelist-var MEMORY_DEVICE_NAME_MAX_LEN
     --whitelist-function securechip_attestation_sign
     --whitelist-function keystore_is_locked
     --whitelist-function keystore_unlock

--- a/src/rust/bitbox02/src/memory.rs
+++ b/src/rust/bitbox02/src/memory.rs
@@ -1,4 +1,5 @@
 // Copyright 2020 Shift Cryptosecurity AG
+// Copyright 2020 Shift Crypto AG
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,6 +12,22 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// deduct one for the null terminator.
+pub const DEVICE_NAME_MAX_LEN: usize = bitbox02_sys::MEMORY_DEVICE_NAME_MAX_LEN as usize - 1;
+
+/// `name.as_bytes()` must be smaller or equal to
+/// `DEVICE_NAME_MAX_LEN`, otherwise this function panics.
+pub fn set_device_name(name: &str) -> Result<(), ()> {
+    match unsafe {
+        bitbox02_sys::memory_set_device_name(
+            crate::str_to_cstr_force!(name, DEVICE_NAME_MAX_LEN).as_ptr(),
+        )
+    } {
+        true => Ok(()),
+        false => Err(()),
+    }
+}
 
 pub fn is_initialized() -> bool {
     unsafe { bitbox02_sys::memory_is_initialized() }

--- a/src/rust/bitbox02/src/ui.rs
+++ b/src/rust/bitbox02/src/ui.rs
@@ -19,6 +19,9 @@ extern crate alloc;
 use crate::password::Password;
 use alloc::boxed::Box;
 
+// Taking the constant straight from C, as it's excluding the null terminator.
+const MAX_LABEL_SIZE: usize = bitbox02_sys::MAX_LABEL_SIZE as _;
+
 /// Wraps the C component_t to be used in Rust.
 pub use core::marker::PhantomData;
 
@@ -82,7 +85,7 @@ where
 
     let component = unsafe {
         bitbox02_sys::trinary_input_string_create_password(
-            crate::str_to_cstr_force!(title, 640).as_ptr(), // same as label.c MAX_LABEL_SIZE
+            crate::str_to_cstr_force!(title, MAX_LABEL_SIZE).as_ptr(),
             special_chars,
             Some(c_confirm_callback::<F>),
             // passed to c_confirm_callback as `param`.
@@ -148,8 +151,8 @@ where
     F: FnMut(bool) + 'a,
 {
     let params = bitbox02_sys::confirm_params_t {
-        title: crate::str_to_cstr_force!(params.title, 640).as_ptr(), // same as label.c MAX_LABEL_SIZE
-        body: crate::str_to_cstr_force!(params.body, 640).as_ptr(), // same as label.c MAX_LABEL_SIZE
+        title: crate::str_to_cstr_force!(params.title, MAX_LABEL_SIZE).as_ptr(),
+        body: crate::str_to_cstr_force!(params.body, MAX_LABEL_SIZE).as_ptr(),
         font: params.font.as_ptr(),
         scrollable: params.scrollable,
         longtouch: params.longtouch,
@@ -206,7 +209,7 @@ where
 
     let component = unsafe {
         bitbox02_sys::status_create(
-            crate::str_to_cstr_force!(text, 640).as_ptr(), // same as label.c MAX_LABEL_SIZE
+            crate::str_to_cstr_force!(text, MAX_LABEL_SIZE).as_ptr(),
             status_success,
             Some(c_callback::<F>),
             Box::into_raw(Box::new(callback)) as *mut _, // passed to c_callback as `param`.

--- a/src/rust/bitbox02/src/util.rs
+++ b/src/rust/bitbox02/src/util.rs
@@ -54,7 +54,7 @@ pub fn str_from_null_terminated(input: &[u8]) -> Result<&str, core::str::Utf8Err
 /// ```
 #[macro_export]
 macro_rules! str_to_cstr {
-    ($input:expr, $len:literal) => {{
+    ($input:expr, $len:expr) => {{
         let mut buf = [0u8; $len + 1];
         if !$input.is_ascii() {
             Err(buf)
@@ -78,7 +78,7 @@ macro_rules! str_to_cstr {
 
 #[macro_export]
 macro_rules! str_to_cstr_force {
-    ($input:expr, $len:literal) => {
+    ($input:expr, $len:expr) => {
         match $crate::str_to_cstr!($input, $len) {
             Ok(buf) => buf,
             Err(_) => panic!("str did not fit"),

--- a/src/ui/components/label.c
+++ b/src/ui/components/label.c
@@ -24,10 +24,6 @@
 #include <ui/ui_util.h>
 #include <util.h>
 
-// Max size of text shown (excl. null terminator). The current size of 640 is chosen to be able to
-// show up to 320 bytes of Ethereum tx data in hex format.
-#define MAX_LABEL_SIZE 640
-
 typedef struct {
     // +3 for '...' if truncated, +1 for null terminator.
     char text[MAX_LABEL_SIZE + 3 + 1];

--- a/src/ui/components/label.h
+++ b/src/ui/components/label.h
@@ -19,6 +19,10 @@
 #include <ui/ugui/ugui.h>
 #include <ui/ui_util.h>
 
+// Max size of text shown (excl. null terminator). The current size of 640 is chosen to be able to
+// show up to 320 bytes of Ethereum tx data in hex format.
+#define MAX_LABEL_SIZE 640
+
 /**
  * Creates a label with the given font and positions it in the center.
  * @param[in] component The component to update.


### PR DESCRIPTION
Easiest/first api call to convert to Rust to make it async, so this is
a prerequisite.