### PR TITLE
apps/btc: do not verify rbf&locktime if locktime is 0

### DIFF
--- a/src/apps/btc/btc_common.h
+++ b/src/apps/btc/btc_common.h
@@ -62,8 +62,8 @@ USE_RESULT bool btc_common_is_valid_keypath_xpub(
 USE_RESULT bool btc_common_is_valid_keypath_account_simple(
     BTCScriptConfig_SimpleType script_type,
     const uint32_t* keypath,
-    const size_t keypath_len,
-    const uint32_t expected_coin);
+    size_t keypath_len,
+    uint32_t expected_coin);
 
 /**
  * Does limit checks the keypath, whitelisting bip44 purposes, accounts and

--- a/src/apps/btc/btc_sign.c
+++ b/src/apps/btc/btc_sign.c
@@ -801,17 +801,21 @@ app_btc_result_t app_btc_sign_output(
             }
         }
 
-        // This is not a security feature, a transaction that is not rbf
-        // and has a locktime of 0 will not be verified.
-        if (_locktime_applies || _rbf == CONFIRM_LOCKTIME_RBF_ON) {
-            // The RBF nsequence bytes are often set in conjunction with a locktime,
-            // so verify both simultaneously.
-            // There is no RBF in Litecoin, so make sure it is disabled.
-            if (!_coin_params->rbf_support) {
-                _rbf = CONFIRM_LOCKTIME_RBF_DISABLED;
-            }
-            if (!apps_btc_confirm_locktime_rbf(_init_request.locktime, _rbf)) {
-                return _error(APP_BTC_ERR_USER_ABORT);
+        // A locktime of 0 will also not be verified, as it's certainly in the past and can't do any
+        // harm.
+        if (_init_request.locktime > 0) {
+            // This is not a security feature, a transaction that is not rbf or has a locktime of 0
+            // will not be verified.
+            if (_locktime_applies || _rbf == CONFIRM_LOCKTIME_RBF_ON) {
+                // The RBF nsequence bytes are often set in conjunction with a locktime,
+                // so verify both simultaneously.
+                // There is no RBF in Litecoin, so make sure it is disabled.
+                if (!_coin_params->rbf_support) {
+                    _rbf = CONFIRM_LOCKTIME_RBF_DISABLED;
+                }
+                if (!apps_btc_confirm_locktime_rbf(_init_request.locktime, _rbf)) {
+                    return _error(APP_BTC_ERR_USER_ABORT);
+                }
             }
         }
 

--- a/src/apps/btc/btc_sign.c
+++ b/src/apps/btc/btc_sign.c
@@ -804,8 +804,8 @@ app_btc_result_t app_btc_sign_output(
         // A locktime of 0 will also not be verified, as it's certainly in the past and can't do any
         // harm.
         if (_init_request.locktime > 0) {
-            // This is not a security feature, a transaction that is not rbf or has a locktime of 0
-            // will not be verified.
+            // This is not a security feature, the extra locktime/RBF user confirmation is skipped
+            // if the tx is not rbf or has a locktime of 0.
             if (_locktime_applies || _rbf == CONFIRM_LOCKTIME_RBF_ON) {
                 // The RBF nsequence bytes are often set in conjunction with a locktime,
                 // so verify both simultaneously.


### PR DESCRIPTION
RBF verification is not a security feature (as described in the
comment), but merely a sanity check, meant for advanced wallets like
Electrum.

Locktime on the other hand might be security relevant, when the
referenced block is in the future.

Until now, we verified the locktime if it is enabled anyway, also 0,
as it technically is considered. Practically however, a locktime of 0
has no effect, as the current block is always > 0.

We want to be able to opt-in to RBF with transactions made in the
BitBoxApp. Currently if doing so, the user would be prompted to verify

"Transaction is RBF. Locktime on block: XYZ"

Which is gibberisch to an average user. Especially the latter, a user
can not really verify.

We do a workaround and skip verification of RBF and locktime if the
locktime is zero, with the effect that the BitBoxApp can make RBF
transcations without disturbing the user with a complicated screen on
the device. This should have no security downside, and UX is better.