### PR TITLE
unit-tests: print output on failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ device-tests: | build
 	${MAKE} -C build device-tests
 # Must compile C tests before running them
 run-unit-tests: | build-build
-	$(MAKE) -C build-build test
+	CTEST_OUTPUT_ON_FAILURE=1 $(MAKE) -C build-build test
 run-rust-unit-tests:
 	${MAKE} -C build-build rust-test
 run-rust-clippy:


### PR DESCRIPTION
Without this, "make run-unit-tests" just says "failed" without an explanation of what failed exactly.