### PR TITLE
backup: provide generator to backup_fill

### DIFF
--- a/src/backup/backup.c
+++ b/src/backup/backup.c
@@ -24,6 +24,7 @@
 #include <memory/memory.h>
 #include <sd.h>
 #include <util.h>
+#include <version.h>
 
 #include <pb_encode.h>
 #include <wally_crypto.h>
@@ -106,7 +107,12 @@ backup_error_t backup_create(uint32_t backup_create_timestamp, uint32_t seed_bir
     BackupData __attribute__((__cleanup__(backup_cleanup_backup_data))) backup_data;
     encode_data_t encode_data;
     backup_error_t res = backup_fill(
-        backup_create_timestamp, seed_birthdate_timestamp, &backup, &backup_data, &encode_data);
+        DIGITAL_BITBOX_VERSION_SHORT,
+        backup_create_timestamp,
+        seed_birthdate_timestamp,
+        &backup,
+        &backup_data,
+        &encode_data);
     if (res != BACKUP_OK) {
         return res;
     }
@@ -167,7 +173,7 @@ backup_error_t backup_check(char* id_out, char* name_out, uint32_t* birthdate_ou
     Backup __attribute__((__cleanup__(backup_cleanup_backup))) backup;
     BackupData __attribute__((__cleanup__(backup_cleanup_backup_data))) backup_data;
     encode_data_t encode_data;
-    backup_error_t backup_res = backup_fill(0, 0, &backup, &backup_data, &encode_data);
+    backup_error_t backup_res = backup_fill("", 0, 0, &backup, &backup_data, &encode_data);
     if (backup_res != BACKUP_OK) {
         return backup_res;
     }

--- a/src/backup/backup_common.c
+++ b/src/backup/backup_common.c
@@ -5,7 +5,6 @@
 #include <memory/memory.h>
 #include <sd.h>
 #include <util.h>
-#include <version.h>
 
 #include <pb_encode.h>
 #include <wally_crypto.h>
@@ -102,6 +101,7 @@ static bool _encode_backup_data(pb_ostream_t* ostream, const pb_field_t* field, 
 }
 
 backup_error_t backup_fill(
+    const char* generator,
     uint32_t backup_create_timestamp,
     uint32_t seed_birthdate_timestamp,
     Backup* backup,
@@ -120,8 +120,8 @@ backup_error_t backup_fill(
         util_zero(backup_metadata->name, sizeof(backup_metadata->name));
         memory_get_device_name(backup_metadata->name);
         memset(backup_data, 0, sizeof(BackupData));
-        const char* firmware_v = DIGITAL_BITBOX_VERSION_SHORT;
-        snprintf(backup_data->generator, sizeof(backup_data->generator), "%s", firmware_v);
+
+        snprintf(backup_data->generator, sizeof(backup_data->generator), "%s", generator);
 
         backup_data->birthdate = seed_birthdate_timestamp;
 

--- a/src/backup/backup_common.h
+++ b/src/backup/backup_common.h
@@ -56,6 +56,7 @@ void backup_calculate_checksum(BackupContent* content, BackupData* backup_data, 
 
 /**
  * Fills the backup structure with backup data.
+ * @param[in] generator a string identifying the creator of the backup, e.g. the firmware version.
  * @param[in] backup_create_timestamp The time at which the backup was created.
  * @param[in] seed_birtdate_timestamp The time at which the seed was created. It is not necessarily
  * the same as backup_create_timestamp, as a backup of the same seed can be re-created (e.g. on a
@@ -65,6 +66,7 @@ void backup_calculate_checksum(BackupContent* content, BackupData* backup_data, 
  * @param[out] encode_data Additional data required for encoding/decoding.
  */
 backup_error_t backup_fill(
+    const char* generator,
     uint32_t backup_create_timestamp,
     uint32_t seed_birthdate_timestamp,
     Backup* backup,

--- a/test/unit-test/test_backup.c
+++ b/test/unit-test/test_backup.c
@@ -190,7 +190,13 @@ static void test_backup_fixture(void** state)
     encode_data_t encode_data;
     _will_mock_backup_queries(_mock_seed_birthdate, _mock_seed);
     assert_int_equal(
-        backup_fill(_current_timestamp, _mock_seed_birthdate, &backup, &backup_data, &encode_data),
+        backup_fill(
+            "v9.0.0",
+            _current_timestamp,
+            _mock_seed_birthdate,
+            &backup,
+            &backup_data,
+            &encode_data),
         BACKUP_OK);
 
     uint8_t encoded[1000] = {0};

--- a/test/unit-test/test_restore.c
+++ b/test/unit-test/test_restore.c
@@ -96,7 +96,12 @@ static int test_setup(void** state)
 
     assert_int_equal(
         backup_fill(
-            _current_timestamp, _mock_seed_birthdate, &_backup, &_backup_data, &_encode_data),
+            "v9.0.0",
+            _current_timestamp,
+            _mock_seed_birthdate,
+            &_backup,
+            &_backup_data,
+            &_encode_data),
         BACKUP_OK);
 
     _will_mock_backup_queries(_mock_seed_birthdate, _mock_seed);


### PR DESCRIPTION
It is sort of an identifer for what created the backup. The way it is
now, the fixture test in test_backup.c will fail when we change the
firmware version. Proiding it explicitly means we can test with any
string in the test.