### PR TITLE
backup: fix call to _encode_backup_data, wrong tag

### DIFF
--- a/messages/backup.proto
+++ b/messages/backup.proto
@@ -40,6 +40,17 @@ message BackupData {
 message BackupContent {
     bytes checksum = 1;
     BackupMetaData metadata = 2;
+    // length is the length of the `data` field, serialized as
+    // protobuf, prefixed with the serialized field tag of the `data`
+    // field. Counting the prefix in the length is a historical
+    // accident, but it is part of the checksum, so it cannot be
+    // changed anymore, otherwise existing backups could not be loaded
+    // anymore.
+    //
+    // This field is also technically redundant, as protobuf already
+    // encodes the length when serializing the data field. We keep it
+    // for now, as fixing it and dealing with the prefix mismatch
+    // might be more confusing.
     uint32 length = 3;
     bytes data = 4;
 }

--- a/test/unit-test/test_backup.c
+++ b/test/unit-test/test_backup.c
@@ -63,11 +63,9 @@ bool __wrap_keystore_copy_seed(uint8_t* seed, uint32_t* length)
 
 static void _will_mock_backup_queries(const uint32_t seed_birthdate, const uint8_t* seed)
 {
-    for (int i = 0; i < 3; i++) {
-        will_return(__wrap_memory_get_device_name, DEVICE_NAME);
-        will_return(__wrap_keystore_copy_seed, _mock_seed_length);
-        will_return(__wrap_keystore_copy_seed, cast_ptr_to_largest_integral_type(seed));
-    }
+    will_return(__wrap_memory_get_device_name, DEVICE_NAME);
+    will_return(__wrap_keystore_copy_seed, _mock_seed_length);
+    will_return(__wrap_keystore_copy_seed, cast_ptr_to_largest_integral_type(seed));
 }
 
 static void _load_first_backup(Backup* backup, BackupData* backup_data)

--- a/test/unit-test/test_restore.c
+++ b/test/unit-test/test_restore.c
@@ -83,11 +83,9 @@ static size_t _num_backup_bytes;
 
 static void _will_mock_backup_queries(const uint32_t seed_birthdate, const uint8_t* seed)
 {
-    for (int i = 0; i < 3; i++) {
-        will_return(__wrap_memory_get_device_name, DEVICE_NAME);
-        will_return(__wrap_keystore_copy_seed, _mock_seed_length);
-        will_return(__wrap_keystore_copy_seed, cast_ptr_to_largest_integral_type(seed));
-    }
+    will_return(__wrap_memory_get_device_name, DEVICE_NAME);
+    will_return(__wrap_keystore_copy_seed, _mock_seed_length);
+    will_return(__wrap_keystore_copy_seed, cast_ptr_to_largest_integral_type(seed));
 }
 
 static int test_setup(void** state)


### PR DESCRIPTION
_encode_backup_data() is called manually to calculcate the length of
the serialization of the `data` field. Just passing
`BackupData_fields` is wrong though, as that points to the first field
in the BackupData message, not the `data` field.

Practically the length did not change as serializing the tag for the
first field or the data field resulted in the same length, but it was
very confusing to understand what was going on.

This will help when upgrading nanopb, which changes the fields
representation.