### PR TITLE
protobuf: add package name to .proto files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ NOTES.md
 bitbox02.egg-info
 /py/bitbox02/build
 /py/bitbox02/dist
-/py/bitbox02/.proto
 
 # Git backup files created on merge conflicts
 *_BACKUP_*

--- a/messages/backup.options
+++ b/messages/backup.options
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+* mangle_names:M_STRIP_PACKAGE
+
 // skip `bool has_*` fields for submessages
 // https://github.com/nanopb/nanopb/blob/1fdc916e984b27cc0a3824427f70a15def567a2e/docs/migration.rst#submessages-now-have-has-field-in-proto3-mode
 * proto3_singular_msgs:true

--- a/messages/backup.proto
+++ b/messages/backup.proto
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 syntax = "proto3";
+package shiftcrypto.bitbox02;
 
 enum BackupMode {
     PLAINTEXT = 0;

--- a/messages/backup_commands.options
+++ b/messages/backup_commands.options
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+* mangle_names:M_STRIP_PACKAGE
+
 CheckBackupResponse.id fixed_length:true max_size:65
 ListBackupsResponse.info max_count:50
 // One backup per seed -> 100 seeds may be backed up per SD card. Adapt this number if it is too small.

--- a/messages/backup_commands.proto
+++ b/messages/backup_commands.proto
@@ -15,6 +15,7 @@
 // This file is named backup_commands to avoid conflicting header files with top-most backup.proto
 
 syntax = "proto3";
+package shiftcrypto.bitbox02;
 
 message CheckBackupRequest {
     bool silent = 1;

--- a/messages/bitbox02_system.options
+++ b/messages/bitbox02_system.options
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+* mangle_names:M_STRIP_PACKAGE
+
 DeviceInfoResponse.name max_size:64
 DeviceInfoResponse.version max_size:10
 SetDeviceLanguageRequest.language fixed_length:true max_size:5

--- a/messages/bitbox02_system.proto
+++ b/messages/bitbox02_system.proto
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 syntax = "proto3";
+package shiftcrypto.bitbox02;
 
 message CheckSDCardRequest {
 }

--- a/messages/bitboxbase.options
+++ b/messages/bitboxbase.options
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+* mangle_names:M_STRIP_PACKAGE
+
 BitBoxBaseConfirmPairingRequest.msg fixed_length:true max_size:32
 BitBoxBaseSetConfigRequest.hostname fixed_length:true max_size:64
 BitBoxBaseSetConfigRequest.ip fixed_length:true max_size:4

--- a/messages/bitboxbase.proto
+++ b/messages/bitboxbase.proto
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 syntax = "proto3";
+package shiftcrypto.bitbox02;
 
 // Should be sent every X seconds (TBD) unless the firmware already is busy with a command.
 message BitBoxBaseHeartbeatRequest {

--- a/messages/btc.options
+++ b/messages/btc.options
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+* mangle_names:M_STRIP_PACKAGE
+
 // skip `bool has_*` fields for submessages
 // https://github.com/nanopb/nanopb/blob/1fdc916e984b27cc0a3824427f70a15def567a2e/docs/migration.rst#submessages-now-have-has-field-in-proto3-mode
 * proto3_singular_msgs:true

--- a/messages/btc.proto
+++ b/messages/btc.proto
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 syntax = "proto3";
+package shiftcrypto.bitbox02;
 
 import "common.proto";
 

--- a/messages/common.options
+++ b/messages/common.options
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+* mangle_names:M_STRIP_PACKAGE
+
 PubResponse.pub max_size:500
 RootFingerprintResponse.fingerprint fixed_length:true max_size:4
 

--- a/messages/common.proto
+++ b/messages/common.proto
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 syntax = "proto3";
+package shiftcrypto.bitbox02;
 
 message PubResponse {
   string pub = 1;

--- a/messages/eth.options
+++ b/messages/eth.options
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+* mangle_names:M_STRIP_PACKAGE
+
 ETHPubRequest.keypath max_count:10
 ETHPubRequest.contract_address fixed_length:true max_size:20
 ETHSignRequest.keypath max_count:10

--- a/messages/eth.proto
+++ b/messages/eth.proto
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 syntax = "proto3";
+package shiftcrypto.bitbox02;
 
 import "common.proto";
 

--- a/messages/hww.options
+++ b/messages/hww.options
@@ -12,4 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+* mangle_names:M_STRIP_PACKAGE
+
 Error.message max_size:255

--- a/messages/hww.proto
+++ b/messages/hww.proto
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 syntax = "proto3";
+package shiftcrypto.bitbox02;
 
 import "common.proto";
 

--- a/messages/keystore.proto
+++ b/messages/keystore.proto
@@ -2,6 +2,7 @@
 // The keypath argument has to be m/4541509'/1112098098'
 
 syntax = "proto3";
+package shiftcrypto.bitbox02;
 
 message ElectrumEncryptionKeyRequest {
   repeated uint32 keypath = 1;

--- a/messages/mnemonic.options
+++ b/messages/mnemonic.options
@@ -1,4 +1,4 @@
-// Copyright 2020 Shift Cryptosecurity AG
+// Copyright 2020 Shift Crypto AG
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,6 +13,3 @@
 // limitations under the License.
 
 * mangle_names:M_STRIP_PACKAGE
-
-ElectrumEncryptionKeyRequest.keypath max_count:2
-ElectrumEncryptionKeyResponse.key max_size:500

--- a/messages/mnemonic.proto
+++ b/messages/mnemonic.proto
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 syntax = "proto3";
+package shiftcrypto.bitbox02;
 
 message ShowMnemonicRequest {
 }

--- a/messages/perform_attestation.options
+++ b/messages/perform_attestation.options
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+* mangle_names:M_STRIP_PACKAGE
+
 PerformAttestationRequest.challenge fixed_length:true max_size:32
 PerformAttestationResponse.bootloader_hash fixed_length:true max_size:32
 PerformAttestationResponse.device_pubkey fixed_length:true max_size:64

--- a/messages/perform_attestation.proto
+++ b/messages/perform_attestation.proto
@@ -1,5 +1,6 @@
 
 syntax = "proto3";
+package shiftcrypto.bitbox02;
 
 // Deprecated, last used in v1.0.0
 message PerformAttestationRequest {

--- a/messages/random_number.options
+++ b/messages/random_number.options
@@ -12,4 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+* mangle_names:M_STRIP_PACKAGE
+
 RandomNumberResponse.number fixed_length:true max_size:32

--- a/messages/random_number.proto
+++ b/messages/random_number.proto
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 syntax = "proto3";
+package shiftcrypto.bitbox02;
 
 message RandomNumberResponse {
     bytes number = 1;
@@ -20,4 +21,3 @@ message RandomNumberResponse {
 
 message RandomNumberRequest {
 }
-

--- a/messages/system.options
+++ b/messages/system.options
@@ -13,6 +13,3 @@
 // limitations under the License.
 
 * mangle_names:M_STRIP_PACKAGE
-
-ElectrumEncryptionKeyRequest.keypath max_count:2
-ElectrumEncryptionKeyResponse.key max_size:500

--- a/messages/system.proto
+++ b/messages/system.proto
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 syntax = "proto3";
+package shiftcrypto.bitbox02;
 
 message RebootRequest {
 

--- a/py/bitbox02/Makefile
+++ b/py/bitbox02/Makefile
@@ -21,11 +21,7 @@ TARGETS=$(addprefix ${OUT_DIR}/, $(PROTO_FILES:.proto=_pb2.py))
 
 all: ${TARGETS}
 
-# To avoid protobuf name collisions with other packages used elsewhere like the
-# electrum app, the pb files for Python are generated from a copy
-# of ../../messages where all protos specify a non-empty package directive.
-# The proto files need not be committed to the repo. They are created at build time.
-PY_PROTO_DIR=.proto
+PY_PROTO_DIR=../../messages
 PY_PROTO=$(addprefix ${PY_PROTO_DIR}/,${PROTO_FILES})
 
 # Explicit rules cannot have multiple outputs (it will be interpreted as multiple rules and
@@ -43,13 +39,6 @@ ${TMP_TARGETS}: ${PY_PROTO}
 	sed -i 's/^from \([^.]*_pb2\)/from .\1/g'  ${OUT_DIR}/*.pyi
 	sed -i 's/^import \([^.]*_pb2\) as \([^.]*__pb2\)/from . import \1 as \2/g' ${OUT_DIR}/*.py
 
-# Insert a package name in each protobuf file.
-# There can be only one "syntax = ..." directive in a proto file.
-# So, that's our anchor and a good place to put the package name at.
-${PY_PROTO_DIR}/%: ../../messages/%
-	@mkdir -p $(@D)
-	sed 's/^syntax =.*/&\npackage shiftcrypto.bitbox02;/' $< > $@
-
 release-test: all
 	rm -rf dist/*
 	python3 setup.py sdist bdist_wheel
@@ -62,4 +51,3 @@ release-live: all
 
 clean:
 	rm -f ${TARGETS}
-	rm -rf ${PY_PROTO_DIR}


### PR DESCRIPTION
- Adds proper namespaces when the proto files are used in other
libraries
- Python hack to insert the package name with `sed` removed
- C names kept the same as before by using
mangle_names:M_STRIP_PACKAGE - avoid super long C struct/enum/define
names.