### PR TITLE
git: ignore C/C++ LSP caches and local configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,13 @@
 /releases/temp/
 NOTES.md
 .vagrant/
+# LSP caches and local configs
+.clangd
+.cquery
+.ccls
+.ccls-cache
+compile_commands.json
+compile_flags.txt
 
 # gnu global
 /src/GPATH

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 /build/
 /build-*/
 /releases/temp/
-NOTES.md
 .vagrant/
 # LSP caches and local configs
 .clangd


### PR DESCRIPTION
This adds some well-known file and dir names which are not typically checked into the repo.