### PR TITLE
rust/bitbox02: add stubs for testing

### DIFF
--- a/src/rust/bitbox02-rust-c/Cargo.toml
+++ b/src/rust/bitbox02-rust-c/Cargo.toml
@@ -57,6 +57,9 @@ platform-bitboxbase = []
 
 bootloader = []
 
+# Only to be enabled in unit tests.
+testing = ["bitbox02/testing"]
+
 app-ethereum = [
   "ethereum", # this is a dependency
 ]

--- a/src/rust/bitbox02/Cargo.toml
+++ b/src/rust/bitbox02/Cargo.toml
@@ -24,3 +24,7 @@ license = "Apache-2.0"
 bitbox02-sys = {path="../bitbox02-sys"}
 util = {path = "../util"}
 zeroize = "1.1.0"
+
+[features]
+# Only to be enabled in unit tests.
+testing = []

--- a/src/rust/bitbox02/src/lib.rs
+++ b/src/rust/bitbox02/src/lib.rs
@@ -22,6 +22,8 @@ extern crate std;
 
 pub mod commander;
 pub mod keystore;
+
+#[cfg_attr(feature = "testing", path = "memory_stub.rs")]
 pub mod memory;
 pub mod password;
 pub mod random;

--- a/src/rust/bitbox02/src/memory_stub.rs
+++ b/src/rust/bitbox02/src/memory_stub.rs
@@ -1,0 +1,51 @@
+// Copyright 2020 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Stubs for testing.
+
+pub fn set_device_name(_name: &str) -> Result<(), ()> {
+    panic!("not implemented")
+}
+
+pub fn is_initialized() -> bool {
+    panic!("not implemented")
+}
+
+pub fn is_mnemonic_passphrase_enabled() -> bool {
+    panic!("not implemented")
+}
+
+pub fn get_attestation_pubkey_and_certificate(
+    _device_pubkey: &mut [u8; 64],
+    _certificate: &mut [u8; 64],
+    _root_pubkey_identifier: &mut [u8; 32],
+) -> Result<(), ()> {
+    panic!("not implemented")
+}
+
+pub fn bootloader_hash(_out: &mut [u8; 32]) {
+    panic!("not implemented")
+}
+
+pub fn get_noise_static_private_key() -> Result<zeroize::Zeroizing<[u8; 32]>, ()> {
+    panic!("not implemented")
+}
+
+pub fn check_noise_remote_static_pubkey(_pubkey: &[u8; 32]) -> bool {
+    panic!("not implemented")
+}
+
+pub fn add_noise_remote_static_pubkey(_pubkey: &[u8; 32]) -> Result<(), ()> {
+    panic!("not implemented")
+}


### PR DESCRIPTION
The bitbox02 safely wraps C functions. In Rust tests, C is not linked,
and even if it was, properly mocking the functions would be difficult.

We do a workaround instead: by adding the 'testing' feature and
enabling it only in tests, we can supply stub/mock implementations
that can be used in unit tests, not referencing any C functions.

In future commits, we can add some light mocking infrastructure to be
able to check args and mock the return values.

Alternatives dismissed:
- Add a trait for memory, keystore, ui and mock those.
  This resulted in all the code littered with generic params and lots
  of boilerplate.
- Implement the C funtions in Rust using cdylib and use that:
  Too complicated compared to the testing feature.