### PR TITLE
components/trinary_input: render title on top, always visible

### DIFF
--- a/src/workflow/restore_from_mnemonic.c
+++ b/src/workflow/restore_from_mnemonic.c
@@ -86,13 +86,13 @@ static void _cleanup_wordlist(char*** wordlist)
 static void _set_title(uint8_t word_idx, char* title_out, size_t title_out_len)
 {
     if (word_idx == 0) {
-        snprintf(title_out, title_out_len, "Enter 1st word");
+        snprintf(title_out, title_out_len, "1st word");
     } else if (word_idx == 1) {
-        snprintf(title_out, title_out_len, "Enter 2nd word");
+        snprintf(title_out, title_out_len, "2nd word");
     } else if (word_idx == 2) {
-        snprintf(title_out, title_out_len, "Enter 3rd word");
+        snprintf(title_out, title_out_len, "3rd word");
     } else {
-        snprintf(title_out, title_out_len, "Enter %dth word", (int)(word_idx + 1));
+        snprintf(title_out, title_out_len, "%dth word", (int)(word_idx + 1));
     }
 }
 


### PR DESCRIPTION
When the input is used to enter words from a wordlist (bip39
mnemonic), the title should be rendered at the top instead of at the
center, to be always visible, even when during typing.

- The user usually copies the words from paper, and should never be
  disoriented at which word they are.

- This will help with a future change: the user will be able to go
  back one word, in which case the previous word will be shown and the
  user knows at which position they are.