### PR TITLE
restore from mnemonic: allow editing previous word

### DIFF
--- a/src/ui/components/trinary_input_string.c
+++ b/src/ui/components/trinary_input_string.c
@@ -94,6 +94,10 @@ typedef struct {
     // typing.
     bool title_on_top;
 
+    // If false, the cancel button is a cross. If true, the cancel button is rendered as a back
+    // button.
+    bool cancel_is_backbutton;
+
     component_t* title_component;
     component_t* trinary_char_component;
     component_t* confirm_component;
@@ -222,7 +226,7 @@ static void _render(component_t* component)
         data->cancel_component->disabled = true;
     }
     if (!confirm_gesture_active) {
-        if (data->string_index != 0 ||
+        if (data->cancel_is_backbutton || data->string_index != 0 ||
             trinary_input_char_in_progress(data->trinary_char_component)) {
             data->left_arrow_component->disabled = false;
             data->left_arrow_component->f->render(data->left_arrow_component);
@@ -354,6 +358,13 @@ static void _on_event(const event_t* event, component_t* component)
         if (trinary_input_char_in_progress(data->trinary_char_component)) {
             _set_alphabet(component);
             break;
+        }
+        if (data->string_index == 0) {
+            // Back button is cancel.
+            if (data->cancel_cb != NULL) {
+                data->cancel_cb(data->cancel_callback_param);
+            }
+            return;
         }
         // Move cursor backward and display preceeding character
         if (data->string_index > 0) {
@@ -500,12 +511,13 @@ component_t* trinary_input_string_create_wordlist(
     void (*confirm_cb)(const char* input, void* param),
     void* confirm_callback_param,
     void (*cancel_cb)(void* param),
-    void* cancel_callback_param)
+    void* cancel_callback_param,
+    bool cancel_is_backbutton)
 {
     if (wordlist == NULL) {
         Abort("trinary_input_string_\ncreate_wordlist");
     }
-    return _create(
+    component_t* component = _create(
         title,
         wordlist,
         wordlist_size,
@@ -516,6 +528,9 @@ component_t* trinary_input_string_create_wordlist(
         confirm_callback_param,
         cancel_cb,
         cancel_callback_param);
+    data_t* data = (data_t*)component->data;
+    data->cancel_is_backbutton = cancel_is_backbutton;
+    return component;
 }
 
 component_t* trinary_input_string_create_password(

--- a/src/ui/components/trinary_input_string.c
+++ b/src/ui/components/trinary_input_string.c
@@ -538,3 +538,20 @@ component_t* trinary_input_string_create_password(
         cancel_cb,
         cancel_callback_param);
 }
+
+void trinary_input_string_set_input(component_t* trinary_input_string, const char* word)
+{
+    data_t* data = (data_t*)trinary_input_string->data;
+    if (data->wordlist == NULL) {
+        return;
+    }
+    for (size_t i = 0; i < data->wordlist_size; i++) {
+        if (STREQ(data->wordlist[i], word)) {
+            data->string_index = snprintf(data->string, sizeof(data->string), "%s", word);
+            _set_alphabet(trinary_input_string);
+            _set_can_confirm(trinary_input_string);
+            return;
+        }
+    }
+    Abort("trinary_input_string_set_input");
+}

--- a/src/ui/components/trinary_input_string.h
+++ b/src/ui/components/trinary_input_string.h
@@ -54,4 +54,12 @@ component_t* trinary_input_string_create_password(
     void (*cancel_cb)(void* param),
     void* cancel_callback_param);
 
+/**
+ * Only applicable in wordlist-mode.
+ * Sets the current word. The user can then accept it or delete characters.
+ * The word must be in the wordlist as passed to `trinary_input_string_create_wordlist()`, otherwise
+ * this function aborts.
+ */
+void trinary_input_string_set_input(component_t* trinary_input_string, const char* word);
+
 #endif

--- a/src/ui/components/trinary_input_string.h
+++ b/src/ui/components/trinary_input_string.h
@@ -36,6 +36,8 @@
  * @param[in] confirm_cb The callback that is called when the user entered the string. Will be
  * called at most once.
  * @param[in] cancel_cb Called when the user cancels by hitting the back button.
+ * @param[in] cancel_is_backbutton whether the cancel button should be rendered as a back button
+ *            instead of as a cross.
  */
 component_t* trinary_input_string_create_wordlist(
     const char* title,
@@ -44,7 +46,8 @@ component_t* trinary_input_string_create_wordlist(
     void (*confirm_cb)(const char* input, void* param),
     void* confirm_callback_param,
     void (*cancel_cb)(void* param),
-    void* cancel_callback_param);
+    void* cancel_callback_param,
+    bool cancel_is_backbutton);
 
 component_t* trinary_input_string_create_password(
     const char* title,

--- a/src/workflow/cancel.c
+++ b/src/workflow/cancel.c
@@ -7,6 +7,7 @@
 #include <ui/screen_stack.h>
 
 static bool _cancel_pressed = false;
+static bool _force = false;
 
 void workflow_cancel(void)
 {
@@ -16,22 +17,36 @@ void workflow_cancel(void)
     }
 }
 
+void workflow_cancel_force(void)
+{
+    if (!_cancel_pressed) {
+        _cancel_pressed = true;
+        _force = true;
+        workflow_blocking_unblock();
+    }
+}
+
 bool workflow_cancel_run(const char* title, component_t* component)
 {
     ui_screen_stack_push(component);
     while (true) {
         _cancel_pressed = false;
+        _force = false;
         workflow_blocking_block();
         if (_cancel_pressed) {
-            const confirm_params_t params = {
-                .title = title,
-                .body = "Do you really\nwant to cancel?",
-            };
-            if (!workflow_confirm_blocking(&params)) {
-                continue;
+            if (!_force) {
+                const confirm_params_t params = {
+                    .title = title,
+                    .body = "Do you really\nwant to cancel?",
+                };
+                if (!workflow_confirm_blocking(&params)) {
+                    continue;
+                }
             }
             ui_screen_stack_pop();
-            workflow_status_blocking("Cancelled", false);
+            if (!_force) {
+                workflow_status_blocking("Cancelled", false);
+            }
             return false;
         }
         ui_screen_stack_pop();

--- a/src/workflow/cancel.h
+++ b/src/workflow/cancel.h
@@ -20,11 +20,20 @@
 
 #include <stdbool.h>
 
+/**
+ * Ask the user if they really want to cancel, then cancel or do nothing.
+ */
 void workflow_cancel(void);
+
+/**
+ * Cancel without asking the user.
+ */
+void workflow_cancel_force(void);
 
 /**
  * Blocks on showing/running a component until `workflow_cancel` or `workflow_blocking_unblock` is
  * called. In the former, a prompt with the given title to confirm cancellation is shown.
+ * `workflow_cancel_force` can be used to cancel without user confirmation.
  * @param[in] title title to show in the cancel confirm prompt.
  * @param[in] component to process.
  */

--- a/src/workflow/restore_from_mnemonic.c
+++ b/src/workflow/restore_from_mnemonic.c
@@ -127,6 +127,7 @@ static bool _get_mnemonic(char* mnemonic_out)
         char title[50] = {0};
         _set_title(word_idx, title, sizeof(title));
         workflow_trinary_input_result_t result = workflow_trinary_input_wordlist(
+            word_idx,
             title,
             (const char* const*)wordlist,
             BIP39_WORDLIST_LEN,

--- a/src/workflow/restore_from_mnemonic.c
+++ b/src/workflow/restore_from_mnemonic.c
@@ -119,8 +119,9 @@ static bool _get_mnemonic(char* mnemonic_out)
     for (uint8_t word_idx = 0; word_idx < num_words; word_idx++) {
         char title[50] = {0};
         _set_title(word_idx, title, sizeof(title));
-        if (!workflow_trinary_input_wordlist(
-                title, (const char* const*)wordlist, BIP39_WORDLIST_LEN, words[word_idx])) {
+        workflow_trinary_input_result_t result = workflow_trinary_input_wordlist(
+            title, (const char* const*)wordlist, BIP39_WORDLIST_LEN, words[word_idx]);
+        if (result != WORKFLOW_TRINARY_INPUT_RESULT_OK) {
             return false;
         }
     }

--- a/src/workflow/restore_from_mnemonic.c
+++ b/src/workflow/restore_from_mnemonic.c
@@ -83,19 +83,6 @@ static void _cleanup_wordlist(char*** wordlist)
     }
 }
 
-static void _set_title(uint8_t word_idx, char* title_out, size_t title_out_len)
-{
-    if (word_idx == 0) {
-        snprintf(title_out, title_out_len, "1st word");
-    } else if (word_idx == 1) {
-        snprintf(title_out, title_out_len, "2nd word");
-    } else if (word_idx == 2) {
-        snprintf(title_out, title_out_len, "3rd word");
-    } else {
-        snprintf(title_out, title_out_len, "%dth word", (int)(word_idx + 1));
-    }
-}
-
 static bool _get_mnemonic(char* mnemonic_out)
 {
     char* wordlist[BIP39_WORDLIST_LEN] = {0};
@@ -124,11 +111,8 @@ static bool _get_mnemonic(char* mnemonic_out)
         // (delete one, the previous word is already preset).
         char* word = words[word_idx];
 
-        char title[50] = {0};
-        _set_title(word_idx, title, sizeof(title));
         workflow_trinary_input_result_t result = workflow_trinary_input_wordlist(
             word_idx,
-            title,
             (const char* const*)wordlist,
             BIP39_WORDLIST_LEN,
             strlen(word) ? word : NULL,

--- a/src/workflow/restore_from_mnemonic.c
+++ b/src/workflow/restore_from_mnemonic.c
@@ -113,18 +113,22 @@ static bool _get_mnemonic(char* mnemonic_out)
     snprintf(num_words_success_msg, sizeof(num_words_success_msg), "Enter %d words", num_words);
     workflow_status_blocking(num_words_success_msg, true);
 
+    char words[WORKFLOW_RESTORE_FROM_MNEMONIC_MAX_WORDS]
+              [WORKFLOW_TRINARY_INPUT_MAX_WORD_LENGTH + 1] = {0};
+
     for (uint8_t word_idx = 0; word_idx < num_words; word_idx++) {
-        char word[WORKFLOW_TRINARY_INPUT_MAX_WORD_LENGTH + 1] = {0};
         char title[50] = {0};
         _set_title(word_idx, title, sizeof(title));
         if (!workflow_trinary_input_wordlist(
-                title, (const char* const*)wordlist, BIP39_WORDLIST_LEN, word)) {
+                title, (const char* const*)wordlist, BIP39_WORDLIST_LEN, words[word_idx])) {
             return false;
         }
+    }
+    for (uint8_t word_idx = 0; word_idx < num_words; word_idx++) {
         if (word_idx != 0) {
             strcat(mnemonic_out, " "); // NOLINT (gcc and clang cannot agree on best practice here)
         }
-        strncat(mnemonic_out, word, WORKFLOW_TRINARY_INPUT_MAX_WORD_LENGTH);
+        strncat(mnemonic_out, words[word_idx], WORKFLOW_TRINARY_INPUT_MAX_WORD_LENGTH);
     }
     return true;
 }

--- a/src/workflow/trinary_input.c
+++ b/src/workflow/trinary_input.c
@@ -77,12 +77,22 @@ static void _cancel(void* param)
 
 workflow_trinary_input_result_t workflow_trinary_input_wordlist(
     size_t word_idx,
-    const char* title,
     const char* const* wordlist,
     size_t wordlist_size,
     const char* preset,
     char* word_out)
 {
+    char title[50] = {0};
+    if (word_idx == 0) {
+        snprintf(title, sizeof(title), "1st word");
+    } else if (word_idx == 1) {
+        snprintf(title, sizeof(title), "2nd word");
+    } else if (word_idx == 2) {
+        snprintf(title, sizeof(title), "3rd word");
+    } else {
+        snprintf(title, sizeof(title), "%dth word", (int)(word_idx + 1));
+    }
+
     component_t* component = trinary_input_string_create_wordlist(
         title, wordlist, wordlist_size, _confirm, NULL, _cancel, &word_idx, word_idx > 0);
     if (preset != NULL) {

--- a/src/workflow/trinary_input.c
+++ b/src/workflow/trinary_input.c
@@ -28,6 +28,13 @@
 static char _word[WORKFLOW_TRINARY_INPUT_MAX_WORD_LENGTH + 1];
 static workflow_trinary_input_result_t _cancel_reason;
 
+static const char* _cancel_choices[] = {
+    "Edit previous word",
+    "Cancel restore",
+};
+#define CHOICE_DELETE 0
+#define CHOICE_CANCEL 1
+
 static void _confirm(const char* word, void* param)
 {
     (void)param;
@@ -38,17 +45,18 @@ static void _confirm(const char* word, void* param)
     workflow_blocking_unblock();
 }
 
-static void _select(uint8_t idx)
+static void _select(uint8_t choice_idx)
 {
     ui_screen_stack_pop();
-    if (idx == 0) {
+    if (choice_idx == CHOICE_DELETE) {
         _cancel_reason = WORKFLOW_TRINARY_INPUT_RESULT_DELETE;
         workflow_cancel_force();
-    } else if (idx == 1) {
+    } else if (choice_idx == CHOICE_CANCEL) {
         _cancel_reason = WORKFLOW_TRINARY_INPUT_RESULT_CANCEL;
         workflow_cancel();
     }
 }
+
 static void _cancel(void* param)
 {
     size_t word_idx = *(size_t*)param;
@@ -57,11 +65,14 @@ static void _cancel(void* param)
         workflow_cancel();
         return;
     }
-    const char* words[] = {
-        "Edit previous word",
-        "Cancel restore",
-    };
-    ui_screen_stack_push(menu_create(words, _select, 2, "Choose", NULL, ui_screen_stack_pop, NULL));
+    ui_screen_stack_push(menu_create(
+        _cancel_choices,
+        _select,
+        sizeof(_cancel_choices) / sizeof(_cancel_choices[0]),
+        "Choose",
+        NULL,
+        ui_screen_stack_pop,
+        NULL));
 }
 
 workflow_trinary_input_result_t workflow_trinary_input_wordlist(

--- a/src/workflow/trinary_input.c
+++ b/src/workflow/trinary_input.c
@@ -63,12 +63,15 @@ workflow_trinary_input_result_t workflow_trinary_input_wordlist(
     const char* title,
     const char* const* wordlist,
     size_t wordlist_size,
+    const char* preset,
     char* word_out)
 {
-    if (!workflow_cancel_run(
-            "Restore",
-            trinary_input_string_create_wordlist(
-                title, wordlist, wordlist_size, _confirm, NULL, _cancel, NULL))) {
+    component_t* component = trinary_input_string_create_wordlist(
+        title, wordlist, wordlist_size, _confirm, NULL, _cancel, NULL);
+    if (preset != NULL) {
+        trinary_input_string_set_input(component, preset);
+    }
+    if (!workflow_cancel_run("Restore", component)) {
         return _cancel_reason;
     }
     snprintf(word_out, WORKFLOW_TRINARY_INPUT_MAX_WORD_LENGTH + 1, "%s", _word);

--- a/src/workflow/trinary_input.c
+++ b/src/workflow/trinary_input.c
@@ -51,7 +51,12 @@ static void _select(uint8_t idx)
 }
 static void _cancel(void* param)
 {
-    (void)param;
+    size_t word_idx = *(size_t*)param;
+    if (word_idx == 0) {
+        _cancel_reason = WORKFLOW_TRINARY_INPUT_RESULT_CANCEL;
+        workflow_cancel();
+        return;
+    }
     const char* words[] = {
         "Edit previous word",
         "Cancel restore",
@@ -60,6 +65,7 @@ static void _cancel(void* param)
 }
 
 workflow_trinary_input_result_t workflow_trinary_input_wordlist(
+    size_t word_idx,
     const char* title,
     const char* const* wordlist,
     size_t wordlist_size,
@@ -67,7 +73,7 @@ workflow_trinary_input_result_t workflow_trinary_input_wordlist(
     char* word_out)
 {
     component_t* component = trinary_input_string_create_wordlist(
-        title, wordlist, wordlist_size, _confirm, NULL, _cancel, NULL);
+        title, wordlist, wordlist_size, _confirm, NULL, _cancel, &word_idx, word_idx > 0);
     if (preset != NULL) {
         trinary_input_string_set_input(component, preset);
     }

--- a/src/workflow/trinary_input.h
+++ b/src/workflow/trinary_input.h
@@ -23,11 +23,19 @@
 // Excluding null terminator. 8 is the longest bip39 word.
 #define WORKFLOW_TRINARY_INPUT_MAX_WORD_LENGTH (8U)
 
+typedef enum {
+    // The user entered the word.
+    WORKFLOW_TRINARY_INPUT_RESULT_OK,
+    // The user cancelled the operation.
+    WORKFLOW_TRINARY_INPUT_RESULT_CANCEL,
+    // The user wants to go back to edit the previous word.
+    WORKFLOW_TRINARY_INPUT_RESULT_DELETE,
+} workflow_trinary_input_result_t;
+
 /**
  * The length of word_out must be WORKFLOW_TRINARY_INPUT_MAX_WORD_LENGTH + 1
  */
-
-USE_RESULT bool workflow_trinary_input_wordlist(
+USE_RESULT workflow_trinary_input_result_t workflow_trinary_input_wordlist(
     const char* title,
     const char* const* wordlist,
     size_t wordlist_size,

--- a/src/workflow/trinary_input.h
+++ b/src/workflow/trinary_input.h
@@ -37,6 +37,7 @@ typedef enum {
  * @param[in] preset if not NULL, this word will already be filled in
  */
 USE_RESULT workflow_trinary_input_result_t workflow_trinary_input_wordlist(
+    size_t word_idx,
     const char* title,
     const char* const* wordlist,
     size_t wordlist_size,

--- a/src/workflow/trinary_input.h
+++ b/src/workflow/trinary_input.h
@@ -38,7 +38,6 @@ typedef enum {
  */
 USE_RESULT workflow_trinary_input_result_t workflow_trinary_input_wordlist(
     size_t word_idx,
-    const char* title,
     const char* const* wordlist,
     size_t wordlist_size,
     const char* preset,

--- a/src/workflow/trinary_input.h
+++ b/src/workflow/trinary_input.h
@@ -34,11 +34,13 @@ typedef enum {
 
 /**
  * The length of word_out must be WORKFLOW_TRINARY_INPUT_MAX_WORD_LENGTH + 1
+ * @param[in] preset if not NULL, this word will already be filled in
  */
 USE_RESULT workflow_trinary_input_result_t workflow_trinary_input_wordlist(
     const char* title,
     const char* const* wordlist,
     size_t wordlist_size,
+    const char* preset,
     char* word_out);
 
 #endif


### PR DESCRIPTION
It is infuriating to have to restart the whole process and enter again all words in case of mistake. This allows the user to go back and edit the previous word, repeatedly if necessary.

This PR is best looked at commit by commit. 