### PR TITLE
util: add util_format_datetime

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -17,6 +17,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 #include "rust/rust.h"
 #include "util.h"
@@ -76,4 +77,16 @@ bool safe_uint64_add(uint64_t* a, uint64_t b)
     }
     *a += b;
     return true;
+}
+
+void util_format_datetime(
+    uint32_t timestamp,
+    int32_t timezone_offset,
+    bool date_only,
+    char* out,
+    size_t out_size)
+{
+    time_t local_timestamp = timestamp + timezone_offset;
+    struct tm* local_time = localtime(&local_timestamp);
+    strftime(out, out_size, date_only ? "%a %Y-%m-%d" : "%a %Y-%m-%d\n%H:%M:%S", local_time);
 }

--- a/src/util.h
+++ b/src/util.h
@@ -162,4 +162,18 @@ typedef struct {
  */
 typedef enum { ASYNC_OP_TRUE, ASYNC_OP_FALSE, ASYNC_OP_NOT_READY } async_op_result_t;
 
+/**
+ * Formats the timestamp in the local timezone.
+ * @param[in] timestamp unix timestamp in seconds.
+ * @param[in] timezone_offset is added to the timestamp, timezone part.
+ * @param[in] date_only if true, only the date is formatted. If false, both date and time are
+ * formatted.
+ */
+void util_format_datetime(
+    uint32_t timestamp,
+    int32_t timezone_offset,
+    bool date_only,
+    char* out,
+    size_t out_size);
+
 #endif

--- a/src/workflow/confirm_time.c
+++ b/src/workflow/confirm_time.c
@@ -22,20 +22,12 @@ bool workflow_confirm_time(uint32_t timestamp, int32_t timezone_offset, bool dat
         return false;
     }
     // Local time for confirming on screen
-    time_t local_timestamp = timestamp + timezone_offset;
-    struct tm* local_time = localtime(&local_timestamp);
     static char local_timestring[100] = {0};
-    const char* title;
-    if (date_only) {
-        title = "Is today?";
-        strftime(local_timestring, sizeof(local_timestring), "%a %Y-%m-%d", local_time);
-    } else {
-        title = "Is now?";
-        strftime(local_timestring, sizeof(local_timestring), "%a %Y-%m-%d\n%H:%M:%S", local_time);
-    }
+    util_format_datetime(
+        timestamp, timezone_offset, date_only, local_timestring, sizeof(local_timestring));
 
     const confirm_params_t params = {
-        .title = title,
+        .title = date_only ? "Is today?" : "Is now?",
         .body = local_timestring,
     };
     return workflow_confirm_blocking(&params);

--- a/test/unit-test/test_util.c
+++ b/test/unit-test/test_util.c
@@ -50,10 +50,27 @@ static void test_minmax(void** state)
     assert_int_not_equal(res, 5);
 }
 
+static void test_util_format_datetime(void** state)
+{
+    char out[100];
+    util_format_datetime(1601281809, 0, true, out, sizeof(out));
+    assert_string_equal(out, "Mon 2020-09-28");
+
+    util_format_datetime(1601281809, 0, false, out, sizeof(out));
+    assert_string_equal(out, "Mon 2020-09-28\n08:30:09");
+
+    util_format_datetime(1601281809, 18000, false, out, sizeof(out));
+    assert_string_equal(out, "Mon 2020-09-28\n13:30:09");
+
+    util_format_datetime(1601281809, -32400, false, out, sizeof(out));
+    assert_string_equal(out, "Sun 2020-09-27\n23:30:09");
+}
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_minmax),
+        cmocka_unit_test(test_util_format_datetime),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }


### PR DESCRIPTION
Isolate C datetime formatting so it is easier to wrap from Rust.

Rust does not seem to have a good way to format datetimes without the
`chrono` crate, which is huge, also in terms of added binary size.