### PR TITLE
keystore: do not require caller of get_bip39_mnemonic to free()

### DIFF
--- a/src/keystore.c
+++ b/src/keystore.c
@@ -385,7 +385,7 @@ bool keystore_is_locked(void)
     return !unlocked;
 }
 
-bool keystore_get_bip39_mnemonic(char** mnemonic_out)
+bool keystore_get_bip39_mnemonic(char* mnemonic_out, size_t mnemonic_out_size)
 {
     if (keystore_is_locked()) {
         return false;
@@ -394,7 +394,14 @@ bool keystore_get_bip39_mnemonic(char** mnemonic_out)
     if (seed == NULL) {
         return false;
     }
-    return bip39_mnemonic_from_bytes(NULL, seed, _seed_length, mnemonic_out) == WALLY_OK;
+    char* mnemonic = NULL;
+    if (bip39_mnemonic_from_bytes(NULL, seed, _seed_length, &mnemonic) != WALLY_OK) {
+        return false;
+    }
+    int snprintf_result = snprintf(mnemonic_out, mnemonic_out_size, "%s", mnemonic);
+    util_cleanup_str(&mnemonic);
+    free(mnemonic);
+    return snprintf_result >= 0 && snprintf_result < (int)mnemonic_out_size;
 }
 
 bool keystore_bip39_mnemonic_to_seed(const char* mnemonic, uint8_t* seed_out, size_t* seed_len_out)

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -108,10 +108,13 @@ void keystore_lock(void);
 USE_RESULT bool keystore_is_locked(void);
 
 /**
- * @return returns false if the keystore is not unlocked. String returned
- * should be freed using `wally_free_string`.
+ * @param[out] mnemonic_out resulting mnemonic
+ * @param[in] mnemonic_out_size size of mnemonic_out. Should be at least 216 bytes (longest possible
+ *            24 word phrase plus null terminator).
+ * @return returns false if the keystore is not unlocked or the mnemonic does not fit.
+ * The resulting string should be safely zeroed after use.
  */
-USE_RESULT bool keystore_get_bip39_mnemonic(char** mnemonic_out);
+USE_RESULT bool keystore_get_bip39_mnemonic(char* mnemonic_out, size_t mnemonic_out_size);
 
 /**
  * Turn a bip39 mnemonic into a seed. Make sure to use UTIL_CLEANUP_32 to destroy it.

--- a/src/workflow/show_mnemonic.c
+++ b/src/workflow/show_mnemonic.c
@@ -132,16 +132,12 @@ static bool _show_words(const char** words, uint8_t words_count)
 }
 
 typedef struct {
-    char* mnemonic;
-    // Keep len as mnemonic is tokenized using strtok, so util_cleanup_str() does not work anymore
-    // to clean the string.
-    size_t len;
+    char mnemonic[300];
 } mnemonic_t;
 
 static void _cleanup_mnemonic(mnemonic_t* mnemonic)
 {
-    util_zero(mnemonic->mnemonic, mnemonic->len);
-    free(mnemonic->mnemonic);
+    util_zero(mnemonic->mnemonic, sizeof(mnemonic->mnemonic));
 }
 
 bool workflow_show_mnemonic_create(void)
@@ -151,12 +147,9 @@ bool workflow_show_mnemonic_create(void)
     }
 
     mnemonic_t __attribute__((__cleanup__(_cleanup_mnemonic))) mnemonic;
-    if (!keystore_get_bip39_mnemonic(&mnemonic.mnemonic)) {
+    if (!keystore_get_bip39_mnemonic(mnemonic.mnemonic, sizeof(mnemonic.mnemonic))) {
         Abort("mnemonic create not possible");
     }
-    // This field must be set before we tokenize the mnemonic, because we use the length when we
-    // zero the memory after confirmation.
-    mnemonic.len = strlens(mnemonic.mnemonic);
 
     // No malloc elements point into parts of the tokenized `mnemonic`.
     const char* words[BIP39_NUM_WORDS];

--- a/test/unit-test/test_keystore.c
+++ b/test/unit-test/test_keystore.c
@@ -415,6 +415,28 @@ static void _test_keystore_lock(void** state)
     assert_true(keystore_is_locked());
 }
 
+static void _test_keystore_get_bip39_mnemonic(void** state)
+{
+    char mnemonic[300];
+    mock_state(NULL, NULL);
+    assert_false(keystore_get_bip39_mnemonic(mnemonic, sizeof(mnemonic)));
+
+    mock_state(_mock_seed, NULL);
+    assert_false(keystore_get_bip39_mnemonic(mnemonic, sizeof(mnemonic)));
+
+    mock_state(_mock_seed, _mock_bip39_seed);
+    assert_true(keystore_get_bip39_mnemonic(mnemonic, sizeof(mnemonic)));
+    const char* expected_mnemonic =
+        "baby mass dust captain baby mass mass dust captain baby mass dutch creek office smoke "
+        "grid creek olive baby mass dust captain baby length";
+    assert_string_equal(mnemonic, expected_mnemonic);
+
+    // Output buffer too short.
+    assert_false(keystore_get_bip39_mnemonic(mnemonic, strlen(expected_mnemonic)));
+    // Just enough space to fit.
+    assert_true(keystore_get_bip39_mnemonic(mnemonic, strlen(expected_mnemonic) + 1));
+}
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
@@ -425,6 +447,7 @@ int main(void)
         cmocka_unit_test(_test_keystore_create_and_unlock_twice),
         cmocka_unit_test(_test_keystore_unlock),
         cmocka_unit_test(_test_keystore_lock),
+        cmocka_unit_test(_test_keystore_get_bip39_mnemonic),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/test/unit-test/test_keystore_functional.c
+++ b/test/unit-test/test_keystore_functional.c
@@ -98,15 +98,10 @@ static void _test_seeds(void** state)
     }
 }
 
-static void _free_string(char** s)
-{
-    wally_free_string(*s);
-}
-
 static void _check_mnemonic(const char* expected)
 {
-    char* __attribute__((__cleanup__(_free_string))) mnemonic;
-    assert_true(keystore_get_bip39_mnemonic(&mnemonic));
+    char mnemonic[300];
+    assert_true(keystore_get_bip39_mnemonic(mnemonic, sizeof(mnemonic)));
     assert_string_equal(mnemonic, expected);
 }
 


### PR DESCRIPTION
The wally function uses malloc/free. This commit makes this nuisance
internal, so the caller can just use a regular stack var.

This makes it easier to wrap this function in Rust.