### PR TITLE
rust/util: improve errors in str_to_cstr

### DIFF
--- a/src/rust/bitbox02/src/lib.rs
+++ b/src/rust/bitbox02/src/lib.rs
@@ -90,11 +90,13 @@ pub use bitbox02_sys::buffer_t;
 #[macro_use]
 pub mod util;
 
+// ug_put_string displays a debug message on the screen for 3 sec.
 pub fn ug_put_string(x: i16, y: i16, input: &str, inverted: bool) {
-    if let Ok(buf) = str_to_cstr!(input, 128) {
-        unsafe { bitbox02_sys::UG_PutString(x, y, buf.as_ptr() as *const _, inverted) }
-    } else {
-        screen_print_debug("string didn't fit", 3000);
+    match str_to_cstr!(input, 128) {
+       Ok(buf) => unsafe {
+           bitbox02_sys::UG_PutString(x, y, buf.as_ptr() as *const _, inverted);
+       },
+       Err(msg) => screen_print_debug(msg, 3000),
     }
 }
 
@@ -140,8 +142,11 @@ pub fn screen_print_debug(msg: &str, duration: i32) {
         Ok(cstr) => unsafe {
             bitbox02_sys::screen_print_debug(cstr.as_ptr() as *const _, duration)
         },
-        Err(cstr) => unsafe {
-            bitbox02_sys::screen_print_debug(cstr.as_ptr() as *const _, duration)
+        Err(errmsg) => unsafe {
+            bitbox02_sys::screen_print_debug(
+                str_to_cstr_force!(errmsg, 200).as_ptr() as *const _,
+                duration,
+            )
         },
     }
 }

--- a/src/rust/bitbox02/src/util.rs
+++ b/src/rust/bitbox02/src/util.rs
@@ -49,7 +49,7 @@ pub fn str_from_null_terminated(input: &[u8]) -> Result<&str, core::str::Utf8Err
 /// let name = "sample_string";
 /// let buf = match str_to_cstr!(name, 50) {
 ///     Ok(buf) => buf,
-///     Err(_) => panic!("to short"),
+///     Err(msg) => panic!(msg),
 /// };
 /// ```
 #[macro_export]
@@ -57,7 +57,7 @@ macro_rules! str_to_cstr {
     ($input:expr, $len:expr) => {{
         let mut buf = [0u8; $len + 1];
         if !$input.is_ascii() {
-            Err(buf)
+            Err("non-ascii input")
         } else {
             let len = core::cmp::min($len, $input.len());
             {
@@ -68,7 +68,7 @@ macro_rules! str_to_cstr {
                 buf.copy_from_slice(input);
             }
             if $input.len() > len {
-                Err(buf)
+                Err("str is too long")
             } else {
                 Ok(buf)
             }
@@ -81,7 +81,7 @@ macro_rules! str_to_cstr_force {
     ($input:expr, $len:expr) => {
         match $crate::str_to_cstr!($input, $len) {
             Ok(buf) => buf,
-            Err(_) => panic!("str did not fit"),
+            Err(msg) => panic!(msg),
         }
     };
 }


### PR DESCRIPTION
There are more than one case where making a C str out of Rust may fail.
For example, when Rust str contains non-ASCII characters.

This commit distinguishes between string length and non-ASCII errors
when panicking.