### PR TITLE
rust/util/ascii: give all_ascii a more suitable name

### DIFF
--- a/src/apps/eth/eth_sign_msg.c
+++ b/src/apps/eth/eth_sign_msg.c
@@ -64,7 +64,7 @@ app_eth_sign_error_t app_eth_sign_msg(
 
     // determine if the message is in ASCII
     bool all_ascii =
-        rust_util_all_ascii_bytes(rust_util_bytes(request->msg.bytes, request->msg.size));
+        rust_util_is_printable_ascii_bytes(rust_util_bytes(request->msg.bytes, request->msg.size));
 
     char body[sizeof(request->msg.bytes) * 2 + 1] = {0};
     confirm_params_t params = {

--- a/src/rust/bitbox02-rust-c/src/util.rs
+++ b/src/rust/bitbox02-rust-c/src/util.rs
@@ -26,14 +26,14 @@ pub extern "C" fn rust_util_zero(mut dst: BytesMut) {
 }
 
 #[no_mangle]
-pub extern "C" fn rust_util_all_ascii_bytes(bytes: Bytes) -> bool {
-    util::ascii::all_ascii(bytes)
+pub extern "C" fn rust_util_is_printable_ascii_bytes(bytes: Bytes) -> bool {
+    util::ascii::is_printable_ascii(bytes)
 }
 
 #[no_mangle]
-pub extern "C" fn rust_util_all_ascii(cstr: CStr) -> bool {
+pub extern "C" fn rust_util_is_printable_ascii(cstr: CStr) -> bool {
     let s: &str = cstr.as_ref();
-    util::ascii::all_ascii(s)
+    util::ascii::is_printable_ascii(s)
 }
 
 #[no_mangle]
@@ -384,9 +384,9 @@ mod tests {
     }
 
     #[test]
-    fn test_all_ascii_bytes() {
+    fn test_is_printable_ascii_bytes() {
         let buf = b"foo";
-        assert!(rust_util_all_ascii_bytes(rust_util_bytes(
+        assert!(rust_util_is_printable_ascii_bytes(rust_util_bytes(
             buf.as_ptr(),
             buf.len()
         )));

--- a/src/rust/util/src/ascii.rs
+++ b/src/rust/util/src/ascii.rs
@@ -12,12 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// Returns true if all bytes are in this set (including the space ' '):
+/// Returns true if all bytes are in this set, including the space ` `:
 ///
-/// `` !"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~``
+/// ```text
+/// !"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~
+/// ```
 ///
-/// Note that newline, tab, etc. are not part of this set.
-pub fn all_ascii<T: AsRef<[u8]>>(bytes: T) -> bool {
+/// Unlike std's is_ascii, control characters such as newline, tab, etc. are not part
+/// of the set.
+pub fn is_printable_ascii<T: AsRef<[u8]>>(bytes: T) -> bool {
     bytes.as_ref().iter().all(|&b| b >= 32 && b <= 126)
 }
 
@@ -29,16 +32,16 @@ mod tests {
     static ALL_ASCII: &[u8] = "! \"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~".as_bytes();
 
     #[test]
-    fn test_all_ascii() {
+    fn test_is_printable_ascii() {
         // All ascii chars.
-        assert!(all_ascii(ALL_ASCII));
+        assert!(is_printable_ascii(ALL_ASCII));
         // Edge cases: highest and lowest non ascii chars.
-        assert!(!all_ascii(b"\x7f"));
-        assert!(!all_ascii(b"\x19"));
-        assert!(!all_ascii(b"\n"));
-        assert!(!all_ascii(b"\t"));
+        assert!(!is_printable_ascii(b"\x7f"));
+        assert!(!is_printable_ascii(b"\x19"));
+        assert!(!is_printable_ascii(b"\n"));
+        assert!(!is_printable_ascii(b"\t"));
         // Works for any AsRef<[u8]>
         let trait_obj: &dyn AsRef<[u8]> = &"abc";
-        assert!(all_ascii(trait_obj));
+        assert!(is_printable_ascii(trait_obj));
     }
 }

--- a/src/rust/util/src/name.rs
+++ b/src/rust/util/src/name.rs
@@ -19,7 +19,7 @@ pub fn validate(name: &str, max_len: usize) -> bool {
     if name.is_empty() || name.len() > max_len {
         return false;
     }
-    if !super::ascii::all_ascii(name) {
+    if !super::ascii::is_printable_ascii(name) {
         return false;
     }
     // Safe because all_ascii passed.


### PR DESCRIPTION
Rust's stdlib has a similar method is_ascii but it's different in that
bb's all_ascii considers only printable characters. This commit makes
the distinction explicit.