### PR TITLE
rust/api: validate user input in SetDeviceName

### DIFF
--- a/src/rust/bitbox02/src/memory_stub.rs
+++ b/src/rust/bitbox02/src/memory_stub.rs
@@ -14,6 +14,9 @@
 
 //! Stubs for testing.
 
+// Make the same consts accessible from stubs as well.
+pub const DEVICE_NAME_MAX_LEN: usize = bitbox02_sys::MEMORY_DEVICE_NAME_MAX_LEN as usize - 1;
+
 pub fn set_device_name(name: &str) -> Result<(), ()> {
     let data = crate::testing::DATA.0.borrow();
     data.memory_set_device_name.as_ref().unwrap()(name)


### PR DESCRIPTION
This avoids panic on too long strings and non-ascii characters.
The API now responds with ERR_INVALID_INPUT error, as opposed to
ERR_MEMORY in such cases and results in the bb app reporting back with
"Device name could not be set".