### PR TITLE
Verify signmsg

### DIFF
--- a/py/send_message.py
+++ b/py/send_message.py
@@ -636,11 +636,11 @@ class SendMessage:
             eprint("Aborted by user")
 
     def _sign_eth_message(self) -> None:
-        msg = input("Message to sign: ")
+        msg = input(r"Message to sign (\n = newline): ")
         if msg.startswith("0x"):
             msg_bytes = binascii.unhexlify(msg[2:])
         else:
-            msg_bytes = msg.encode("utf-8")
+            msg_bytes = msg.replace(r"\n", "\n").encode("utf-8")
         msg_hex = binascii.hexlify(msg_bytes).decode("utf-8")
         print(f"signing\nbytes: {msg_bytes}\nhex: 0x{msg_hex}")
         sig = self._device.eth_sign_msg(

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -56,7 +56,9 @@ dependencies = [
  "binascii 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitbox02 0.1.0",
  "bitbox02-noise 0.1.0",
+ "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.6.1 (git+https://github.com/danburkert/prost.git?rev=6113789f70b69709820becba4242824b4fb3ffec)",
+ "util 0.1.0",
 ]
 
 [[package]]

--- a/src/rust/bitbox02-rust-c/src/lib.rs
+++ b/src/rust/bitbox02-rust-c/src/lib.rs
@@ -21,6 +21,8 @@ extern crate std;
 
 // Since util_c defines an "alloc_error_handler" we get conflicts with std when testing
 #[cfg(not(test))]
+// for `format!`
+#[macro_use]
 mod alloc;
 
 mod async_usb;

--- a/src/rust/bitbox02-rust-c/src/util.rs
+++ b/src/rust/bitbox02-rust-c/src/util.rs
@@ -26,17 +26,6 @@ pub extern "C" fn rust_util_zero(mut dst: BytesMut) {
 }
 
 #[no_mangle]
-pub extern "C" fn rust_util_is_printable_ascii_bytes(bytes: Bytes) -> bool {
-    util::ascii::is_printable_ascii(bytes, false)
-}
-
-#[no_mangle]
-pub extern "C" fn rust_util_is_printable_ascii(cstr: CStr) -> bool {
-    let s: &str = cstr.as_ref();
-    util::ascii::is_printable_ascii(s, false)
-}
-
-#[no_mangle]
 pub extern "C" fn rust_util_validate_name(cstr: CStr, max_len: size_t) -> bool {
     let s: &str = cstr.as_ref();
     util::name::validate(s, max_len)
@@ -381,15 +370,6 @@ mod tests {
         let mut cstr_mut = unsafe { CStrMut::new(buf.as_mut_ptr(), buf.len()) };
         use std::fmt::Write;
         let _ = write!(&mut cstr_mut, "test foo ");
-    }
-
-    #[test]
-    fn test_is_printable_ascii_bytes() {
-        let buf = b"foo";
-        assert!(rust_util_is_printable_ascii_bytes(rust_util_bytes(
-            buf.as_ptr(),
-            buf.len()
-        )));
     }
 
     #[test]

--- a/src/rust/bitbox02-rust-c/src/util.rs
+++ b/src/rust/bitbox02-rust-c/src/util.rs
@@ -27,13 +27,13 @@ pub extern "C" fn rust_util_zero(mut dst: BytesMut) {
 
 #[no_mangle]
 pub extern "C" fn rust_util_is_printable_ascii_bytes(bytes: Bytes) -> bool {
-    util::ascii::is_printable_ascii(bytes)
+    util::ascii::is_printable_ascii(bytes, false)
 }
 
 #[no_mangle]
 pub extern "C" fn rust_util_is_printable_ascii(cstr: CStr) -> bool {
     let s: &str = cstr.as_ref();
-    util::ascii::is_printable_ascii(s)
+    util::ascii::is_printable_ascii(s, false)
 }
 
 #[no_mangle]

--- a/src/rust/bitbox02-rust-c/src/workflow.rs
+++ b/src/rust/bitbox02-rust-c/src/workflow.rs
@@ -22,7 +22,7 @@ use alloc::boxed::Box;
 use alloc::string::String;
 use bitbox02::password::Password;
 use bitbox02_rust::bb02_async::{block_on, spin, Task};
-use bitbox02_rust::workflow::{confirm, password, status, unlock};
+use bitbox02_rust::workflow::{confirm, password, status, unlock, verify_message};
 use core::fmt::Write;
 use core::task::Poll;
 
@@ -174,4 +174,9 @@ pub unsafe extern "C" fn rust_workflow_confirm_blocking(
 #[no_mangle]
 pub unsafe extern "C" fn rust_workflow_unlock_check_blocking() -> bool {
     block_on(unlock::unlock_keystore("Unlock device"))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rust_workflow_verify_message(msg: crate::util::Bytes) -> bool {
+    block_on(verify_message::verify(msg.as_ref())).is_ok()
 }

--- a/src/rust/bitbox02-rust/Cargo.toml
+++ b/src/rust/bitbox02-rust/Cargo.toml
@@ -27,8 +27,10 @@ doctest = false
 
 [dependencies]
 bitbox02 = {path = "../bitbox02"}
+util = {path = "../util"}
 binascii = { version = "0.1.4", default-features = false, features = ["encode"] }
 bitbox02-noise = {path = "../bitbox02-noise"}
+hex = { version = "0.4", default-features = false }
 
 # For stack allocated strings
 [dependencies.arrayvec]

--- a/src/rust/bitbox02-rust/src/workflow.rs
+++ b/src/rust/bitbox02-rust/src/workflow.rs
@@ -18,3 +18,4 @@ pub mod password;
 pub mod sdcard;
 pub mod status;
 pub mod unlock;
+pub mod verify_message;

--- a/src/rust/bitbox02-rust/src/workflow/verify_message.rs
+++ b/src/rust/bitbox02-rust/src/workflow/verify_message.rs
@@ -17,6 +17,8 @@ use alloc::vec::Vec;
 
 use super::confirm;
 
+use util::ascii;
+
 /// Verify a message to be signed.
 ///
 /// If the bytes are all printable ascii chars, the message is
@@ -24,7 +26,7 @@ use super::confirm;
 ///
 /// Otherwise, it is displayed as hex.
 pub async fn verify(msg: &[u8]) -> Result<(), ()> {
-    if util::ascii::is_printable_ascii(&msg, true) {
+    if ascii::is_printable_ascii(&msg, ascii::Charset::AllNewline) {
         // The message is all ascii and printable.
         let msg = core::str::from_utf8(msg).unwrap();
 

--- a/src/rust/bitbox02-rust/src/workflow/verify_message.rs
+++ b/src/rust/bitbox02-rust/src/workflow/verify_message.rs
@@ -1,0 +1,70 @@
+// Copyright 2020 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate alloc;
+use alloc::vec::Vec;
+
+use super::confirm;
+
+/// Verify a message to be signed.
+///
+/// If the bytes are all printable ascii chars, the message is
+/// confirmed one line at a time (the str is split into lines).
+///
+/// Otherwise, it is displayed as hex.
+pub async fn verify(msg: &[u8]) -> Result<(), ()> {
+    if util::ascii::is_printable_ascii(&msg, true) {
+        // The message is all ascii and printable.
+        let msg = core::str::from_utf8(msg).unwrap();
+
+        let pages: Vec<&str> = msg.split('\n').filter(|line| !line.is_empty()).collect();
+        if pages.is_empty() {
+            return Err(());
+        }
+        for (i, &page) in pages.iter().enumerate() {
+            let is_last = i == pages.len() - 1;
+            let title = if pages.len() == 1 {
+                "Sign message".into()
+            } else {
+                format!("Sign {}/{}", i + 1, pages.len())
+            };
+            let params = confirm::Params {
+                title: &title,
+                body: page,
+                scrollable: true,
+                accept_is_nextarrow: !is_last,
+                longtouch: is_last,
+                ..Default::default()
+            };
+            if !confirm::confirm(&params).await {
+                return Err(());
+            }
+        }
+        Ok(())
+    } else {
+        let params = confirm::Params {
+            title: "Sign message\ndata (hex)",
+            body: &hex::encode(msg),
+            scrollable: true,
+            display_size: msg.len(),
+            longtouch: true,
+            ..Default::default()
+        };
+        if confirm::confirm(&params).await {
+            Ok(())
+        } else {
+            Err(())
+        }
+    }
+}

--- a/src/rust/util/src/ascii.rs
+++ b/src/rust/util/src/ascii.rs
@@ -18,10 +18,13 @@
 /// !"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~
 /// ```
 ///
-/// Unlike std's is_ascii, control characters such as newline, tab, etc. are not part
-/// of the set.
-pub fn is_printable_ascii<T: AsRef<[u8]>>(bytes: T) -> bool {
-    bytes.as_ref().iter().all(|&b| b >= 32 && b <= 126)
+/// Note that newline, tab, etc. are not part of this set.
+/// If `allow_newline` is true, '\n' is also accepted.
+pub fn is_printable_ascii<T: AsRef<[u8]>>(bytes: T, allow_newline: bool) -> bool {
+    bytes
+        .as_ref()
+        .iter()
+        .all(|&b| (b >= 32 && b <= 126) || (allow_newline && b == b'\n'))
 }
 
 #[cfg(test)]
@@ -34,14 +37,17 @@ mod tests {
     #[test]
     fn test_is_printable_ascii() {
         // All ascii chars.
-        assert!(is_printable_ascii(ALL_ASCII));
+        assert!(is_printable_ascii(ALL_ASCII, false));
         // Edge cases: highest and lowest non ascii chars.
-        assert!(!is_printable_ascii(b"\x7f"));
-        assert!(!is_printable_ascii(b"\x19"));
-        assert!(!is_printable_ascii(b"\n"));
-        assert!(!is_printable_ascii(b"\t"));
+        assert!(!is_printable_ascii(b"\x7f", false));
+        assert!(!is_printable_ascii(b"\x19", false));
+        assert!(!is_printable_ascii(b"\n", false));
+        assert!(!is_printable_ascii(b"\t", false));
         // Works for any AsRef<[u8]>
         let trait_obj: &dyn AsRef<[u8]> = &"abc";
-        assert!(is_printable_ascii(trait_obj));
+        assert!(is_printable_ascii(trait_obj, false));
+
+        // Newline allowed
+        assert!(is_printable_ascii("test\nnewline", true));
     }
 }

--- a/src/rust/util/src/name.rs
+++ b/src/rust/util/src/name.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::ascii;
+
 /// Validate a user given name. The name must be smaller or equal to `max_len` and larger than 0 in
 /// size, consist of printable ASCII characters only (and space), not
 /// start or end with whitespace, and contain no whitespace other than space.
@@ -19,7 +21,7 @@ pub fn validate(name: &str, max_len: usize) -> bool {
     if name.is_empty() || name.len() > max_len {
         return false;
     }
-    if !super::ascii::is_printable_ascii(name, false) {
+    if !ascii::is_printable_ascii(name, ascii::Charset::All) {
         return false;
     }
     // Safe because all_ascii passed.

--- a/src/rust/util/src/name.rs
+++ b/src/rust/util/src/name.rs
@@ -19,7 +19,7 @@ pub fn validate(name: &str, max_len: usize) -> bool {
     if name.is_empty() || name.len() > max_len {
         return false;
     }
-    if !super::ascii::is_printable_ascii(name) {
+    if !super::ascii::is_printable_ascii(name, false) {
         return false;
     }
     // Safe because all_ascii passed.

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -213,7 +213,7 @@ set(TEST_LIST
    app_eth_sign
    "-Wl,--wrap=app_eth_verify_standard_transaction,--wrap=app_eth_verify_erc20_transaction,--wrap=keystore_secp256k1_sign,--wrap=rust_ethereum_keypath_is_valid_address"
    app_eth_sign_msg
-   "-Wl,--wrap=keystore_secp256k1_sign,--wrap=keystore_secp256k1_pubkey,--wrap=rust_ethereum_keypath_is_valid_address,--wrap=workflow_confirm_blocking"
+   "-Wl,--wrap=keystore_secp256k1_sign,--wrap=keystore_secp256k1_pubkey,--wrap=rust_ethereum_keypath_is_valid_address,--wrap=workflow_confirm_blocking,--wrap=rust_workflow_verify_message"
    app_eth_verify
    "-Wl,--wrap=workflow_verify_recipient,--wrap=workflow_verify_total,--wrap=app_eth_erc20_params_get"
    usart

--- a/test/unit-test/test_app_eth_sign_msg.c
+++ b/test/unit-test/test_app_eth_sign_msg.c
@@ -20,6 +20,7 @@
 #include <apps/eth/eth_common.h>
 #include <apps/eth/eth_sign_msg.h>
 #include <keystore.h>
+#include <rust/rust.h>
 #include <ui/components/confirm.h>
 
 #include <wally_bip32.h>
@@ -33,6 +34,11 @@ static uint8_t _sig[65] =
     "\x55\x55\x55\x55\x55\x55\x55\x55\x55\x55\x55\x55\x55\x55\x55\x55\x55\x55\x03";
 
 bool __wrap_workflow_confirm_blocking(const confirm_params_t* params)
+{
+    return true;
+}
+
+bool __wrap_rust_workflow_verify_message(Bytes msg)
 {
     return true;
 }


### PR DESCRIPTION
Motivation: I saw that Bity makes you sign this kind of message when buying:

```
This message is part of the process of placing an exchange order on bity.com. To proceed, Bity is required to verify that you own the destination crypto address. By signing this message with your wallet, you are confirming 1) that you are the sole owner of the crypto address below and 2) that you will be sending your own funds to Bity. If you did not initiate this process yourself, do not sign this message.

Your order id: 69b87653-.....
Your IBAN: CH1.........
Your crypto address: 36..........
Your crypto address type: BTC
```

The newlines make this show as a hex string. After this PR a message like this can be easily verified.

To test, enter this in send_message for 21) (sign eth msg):

```
This message is part of the process of placing an exchange order on bity.com. To proceed, Bity is required to verify that you own the destination crypto address. By signing this message with your wallet, you are confirming 1) that you are the sole owner of the crypto address below and 2) that you will be sending your own funds to Bity. If you did not initiate this process yourself, do not sign this message.\n\nYour order id: 69b876.......d9f\nYour IBAN: CH17...0\nYour crypto address: 3659........T\nYour crypto address type: BTC
```