### PR TITLE
apps/btc/sign_msg: stricter input validation

### DIFF
--- a/src/apps/btc/btc_sign_msg.c
+++ b/src/apps/btc/btc_sign_msg.c
@@ -41,18 +41,18 @@ USE_RESULT app_btc_result_t app_btc_sign_msg(
     if (script_config->which_config != BTCScriptConfig_simple_type_tag) {
         return APP_BTC_ERR_INVALID_INPUT;
     }
+    BTCScriptConfig_SimpleType simple_type = script_config->config.simple_type;
+    if (simple_type != BTCScriptConfig_SimpleType_P2WPKH_P2SH &&
+        simple_type != BTCScriptConfig_SimpleType_P2WPKH) {
+        return APP_BTC_ERR_INVALID_INPUT;
+    }
     if (msg_size > MAX_MESSAGE_SIZE) {
         return APP_BTC_ERR_INVALID_INPUT;
     }
     // Keypath and script_config are validated in app_btc_address_simple().
     char address[500] = {0};
     if (!app_btc_address_simple(
-            coin,
-            script_config->config.simple_type,
-            keypath,
-            keypath_len,
-            address,
-            sizeof(address))) {
+            coin, simple_type, keypath, keypath_len, address, sizeof(address))) {
         return APP_BTC_ERR_INVALID_INPUT;
     }
 


### PR DESCRIPTION
Future script types should not be automatically accepted.

If a future script type had a different signing algorithm, without
this check, and old firmware would just accept the api call and do the
wrong algorithm.