### PR TITLE
rust/password: use heap allocation

### DIFF
--- a/src/rust/bitbox02-rust-c/src/workflow.rs
+++ b/src/rust/bitbox02-rust-c/src/workflow.rs
@@ -20,7 +20,6 @@ extern crate alloc;
 
 use alloc::boxed::Box;
 use alloc::string::String;
-use bitbox02::password::Password;
 use bitbox02_rust::bb02_async::{block_on, spin, Task};
 use bitbox02_rust::workflow::{confirm, password, status, unlock, verify_message};
 use core::fmt::Write;
@@ -143,10 +142,13 @@ pub unsafe extern "C" fn rust_workflow_status_unlock_bip39_blocking() {
 pub unsafe extern "C" fn rust_workflow_password_enter_twice_blocking(
     mut password_out: crate::util::CStrMut,
 ) -> bool {
-    let mut password = Password::new();
-    let result = block_on(password::enter_twice(&mut password));
-    password_out.write_str(password.as_str()).unwrap();
-    result
+    match block_on(password::enter_twice()) {
+        Ok(password) => {
+            password_out.write_str(password.as_str()).unwrap();
+            true
+        }
+        Err(()) => false,
+    }
 }
 
 #[no_mangle]

--- a/src/rust/bitbox02-rust/src/hww/api/set_password.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/set_password.rs
@@ -16,7 +16,6 @@ use super::pb;
 use super::Error;
 
 use crate::workflow::password;
-use bitbox02::password::Password;
 use core::convert::TryInto;
 use pb::response::Response;
 
@@ -32,10 +31,7 @@ pub async fn process(
         Err(_) => return Err(Error::InvalidInput),
         Ok(e) => e,
     };
-    let mut password = Password::new();
-    if !password::enter_twice(&mut password).await {
-        return Err(Error::Generic);
-    }
+    let password = password::enter_twice().await?;
     if !bitbox02::keystore::create_and_store_seed(&password, &entropy32) {
         return Err(Error::Generic);
     }

--- a/src/rust/bitbox02-rust/src/workflow/password.rs
+++ b/src/rust/bitbox02-rust/src/workflow/password.rs
@@ -23,7 +23,7 @@ use core::cell::RefCell;
 /// enter("Enter password", true, &mut pw).await;
 /// // use pw.
 /// ```
-pub async fn enter(title: &str, special_chars: bool, password_out: &mut Password) {
+pub async fn enter(title: &str, special_chars: bool) -> Password {
     let result = RefCell::new(None);
     let mut component =
         bitbox02::ui::trinary_input_string_create_password(title, special_chars, |pw| {
@@ -31,29 +31,25 @@ pub async fn enter(title: &str, special_chars: bool, password_out: &mut Password
         });
     component.screen_stack_push();
     option(&result).await;
-    let result: &Option<Password> = &result.borrow();
-    let result: Option<&Password> = result.as_ref();
-    let result: &Password = result.unwrap();
-    password_out.copy_from(&result);
+    drop(component);
+    let result: Option<Password> = result.into_inner();
+    result.unwrap()
 }
 
 /// Prompt the user to enter a password twice. A warning is displayed
-/// if the password has fewer than 4 chars. Returns false if the two
+/// if the password has fewer than 4 chars. Returns `Err` if the two
 /// passwords do not match, or if the user aborts at the warning.
 ///
 /// Example:
 /// ```no_run
-/// let mut pw = Password::new();
-/// enter_twice(&mut pw).await;
+/// let pw = enter_twice().await.unwrap();
 /// // use pw.
-pub async fn enter_twice(password_out: &mut Password) -> bool {
-    let mut password = Password::new();
-    let mut password_repeat = Password::new();
-    enter("Set password", false, &mut password).await;
-    enter("Repeat password", false, &mut password_repeat).await;
+pub async fn enter_twice() -> Result<Password, ()> {
+    let password = enter("Set password", false).await;
+    let password_repeat = enter("Repeat password", false).await;
     if password.as_str() != password_repeat.as_str() {
         status::status("Passwords\ndo not match", false).await;
-        return false;
+        return Err(());
     }
     if password.as_str().len() < 4 {
         let params = confirm::Params {
@@ -64,10 +60,9 @@ pub async fn enter_twice(password_out: &mut Password) -> bool {
         };
 
         if !confirm::confirm(&params).await {
-            return false;
+            return Err(());
         }
     }
     status::status("Success", true).await;
-    password_out.copy_from(&password);
-    true
+    Ok(password)
 }

--- a/src/rust/bitbox02-rust/src/workflow/unlock.rs
+++ b/src/rust/bitbox02-rust/src/workflow/unlock.rs
@@ -59,8 +59,7 @@ async fn confirm_mnemonic_passphrase(passphrase: &str) -> bool {
 /// If they keystore is already unlocked, this function does not
 /// change the state and just checks the password.
 pub async fn unlock_keystore(title: &str) -> Result<(), ()> {
-    let mut password = Password::new();
-    password::enter(title, false, &mut password).await;
+    let password = password::enter(title, false).await;
 
     match keystore::unlock(&password) {
         Ok(()) => Ok(()),
@@ -86,7 +85,7 @@ pub async fn unlock_bip39() {
     if bitbox02::memory::is_mnemonic_passphrase_enabled() {
         // Loop until the user confirms.
         loop {
-            password::enter("Optional passphrase", true, &mut mnemonic_passphrase).await;
+            mnemonic_passphrase = password::enter("Optional passphrase", true).await;
 
             if confirm_mnemonic_passphrase(mnemonic_passphrase.as_str()).await {
                 break;

--- a/src/rust/bitbox02/src/password.rs
+++ b/src/rust/bitbox02/src/password.rs
@@ -12,16 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+extern crate alloc;
+use alloc::boxed::Box;
+
 /// C-style including null terminator, as it is used in C only so far.
 /// 150 corresponds to SET_PASSWORD_MAX_PASSWORD_LENGTH.
 /// Does *not* implement Copy, so that we can have a Drop to zero the contents.
 // TODO: use a reusable zero-on-drop buffer type
-pub struct Password([u8; 150]);
+pub struct Password(Box<[u8; 150]>);
 
 impl Password {
     /// Makes a password buffer filled with 0.
     pub fn new() -> Password {
-        Password([0; 150])
+        Password(Box::new([0; 150]))
     }
 
     /// Copies the password bytes from `source` without additional allocations.
@@ -31,7 +34,7 @@ impl Password {
 
     /// Returns the underlying C string buffer (null terminated), to be used in C function calls.
     pub fn as_cstr(&self) -> *const util::c_types::c_char {
-        &self.0 as *const _
+        &*self.0 as *const _
     }
 
     /// Returns the buffer size (including null terminator).


### PR DESCRIPTION
Much better ergonomics and less copies.