### PR TITLE
Cancelable password check

### DIFF
--- a/py/bitbox02/bitbox02/bitbox02/__init__.py
+++ b/py/bitbox02/bitbox02/bitbox02/__init__.py
@@ -16,7 +16,7 @@
 from __future__ import print_function
 import sys
 
-__version__ = "4.2.0"
+__version__ = "5.0.0"
 
 if sys.version_info.major != 3 or sys.version_info.minor < 6:
     print(

--- a/py/bitbox02/bitbox02/bitbox02/bitbox02.py
+++ b/py/bitbox02/bitbox02/bitbox02/bitbox02.py
@@ -227,21 +227,15 @@ class BitBox02(BitBoxCommonAPI):
             raise
         return response.check_backup.id
 
-    def show_mnemonic(self) -> bool:
+    def show_mnemonic(self) -> None:
         """
         Returns True if mnemonic was successfully shown and confirmed.
-        Returns False otherwise.
+        Raises a Bitbox02Exception on failure.
         """
         # pylint: disable=no-member
         request = hww.Request()
         request.show_mnemonic.CopyFrom(mnemonic.ShowMnemonicRequest())
-        try:
-            self._msg_query(request, expected_response="success")
-        except Bitbox02Exception as err:
-            if err.code == ERR_GENERIC:
-                return False
-            raise
-        return True
+        self._msg_query(request, expected_response="success")
 
     def _btc_msg_query(
         self, btc_request: btc.BTCRequest, expected_response: Optional[str] = None

--- a/py/send_message.py
+++ b/py/send_message.py
@@ -557,7 +557,11 @@ class SendMessage:
 
     def _show_mnemnoic_seed(self) -> None:
         print("Your BitBox02 will now show the mnemonic seed phrase")
-        print(self._device.show_mnemonic())
+        try:
+            self._device.show_mnemonic()
+            print("Success")
+        except UserAbortException:
+            print("Aborted by user")
 
     def _create_backup(self) -> None:
         if self._device.check_backup(silent=True) is not None:

--- a/src/rust/bitbox02-rust-c/src/workflow.rs
+++ b/src/rust/bitbox02-rust-c/src/workflow.rs
@@ -173,11 +173,6 @@ pub unsafe extern "C" fn rust_workflow_confirm_blocking(
     block_on(confirm::confirm(&params))
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn rust_workflow_unlock_check_blocking() -> bool {
-    block_on(unlock::unlock_keystore("Unlock device")).is_ok()
-}
-
 #[repr(C)]
 pub enum VerifyMessageResult {
     VerifyMessageResultOk,

--- a/src/rust/bitbox02-rust/src/hww/api/backup.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/backup.rs
@@ -99,7 +99,7 @@ pub async fn create(
     let is_initialized = bitbox02::memory::is_initialized();
 
     if is_initialized {
-        unlock::unlock_keystore("Unlock device").await?;
+        unlock::unlock_keystore("Unlock device", unlock::CanCancel::Yes).await?;
     }
 
     let seed_birthdate = if !is_initialized {

--- a/src/rust/bitbox02-rust/src/hww/api/error.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/error.rs
@@ -44,6 +44,15 @@ impl core::convert::From<crate::workflow::cancel::Error> for Error {
     }
 }
 
+impl core::convert::From<crate::workflow::unlock::UnlockError> for Error {
+    fn from(error: crate::workflow::unlock::UnlockError) -> Self {
+        match error {
+            crate::workflow::unlock::UnlockError::UserAbort => Error::UserAbort,
+            crate::workflow::unlock::UnlockError::IncorrectPassword => Error::Generic,
+        }
+    }
+}
+
 use pb::response::Response;
 
 /// Creates an Error response. Corresponds to commander.c:_report_error().

--- a/src/rust/bitbox02-rust/src/hww/api/show_mnemonic.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/show_mnemonic.rs
@@ -62,7 +62,7 @@ fn create_random_unique_words(word: &str, length: u8) -> (u8, Vec<&str>) {
 }
 
 pub async fn process() -> Result<Response, Error> {
-    unlock::unlock_keystore("Unlock device").await?;
+    unlock::unlock_keystore("Unlock device", unlock::CanCancel::Yes).await?;
 
     let mnemonic_sentence = keystore::get_bip39_mnemonic()?;
 

--- a/src/rust/bitbox02/src/ui/ui_stub.rs
+++ b/src/rust/bitbox02/src/ui/ui_stub.rs
@@ -48,6 +48,7 @@ pub fn trinary_input_string_create_password<'a, F>(
     _title: &str,
     _special_chars: bool,
     _confirm_callback: F,
+    _cancel_callback: Option<ContinueCancelCb<'a>>,
 ) -> Component<'a>
 where
     F: FnMut(Password) + 'a,


### PR DESCRIPTION
Builds on #619

When showing mnemonic or creating a backup, the password entry to check the password cannot be aborted. This PR fixes this.