### PR TITLE
rust/api: add scaffold to handle nested ETH requests

### DIFF
--- a/src/rust/bitbox02-rust-c/Cargo.toml
+++ b/src/rust/bitbox02-rust-c/Cargo.toml
@@ -62,4 +62,5 @@ testing = ["bitbox02/testing"]
 
 app-ethereum = [
   "ethereum", # this is a dependency
+  "bitbox02-rust/app-ethereum", # enable this feature in the dep
 ]

--- a/src/rust/bitbox02-rust/Cargo.toml
+++ b/src/rust/bitbox02-rust/Cargo.toml
@@ -44,3 +44,6 @@ git = "https://github.com/danburkert/prost.git"
 rev = "6113789f70b69709820becba4242824b4fb3ffec"
 default-features = false
 features = ["prost-derive"]
+
+[features]
+app-ethereum = []

--- a/src/rust/bitbox02-rust/src/hww/api.rs
+++ b/src/rust/bitbox02-rust/src/hww/api.rs
@@ -16,6 +16,9 @@ mod pb {
     include!("./api/shiftcrypto.bitbox02.rs");
 }
 
+#[cfg(feature = "app-ethereum")]
+mod ethereum;
+
 mod backup;
 mod device_info;
 mod error;
@@ -98,6 +101,14 @@ async fn process_api(request: &Request) -> Option<Result<Response, Error>> {
         Request::CheckBackup(ref request) => Some(backup::check(request).await),
         Request::CreateBackup(ref request) => Some(backup::create(request).await),
         Request::ShowMnemonic(_) => Some(show_mnemonic::process().await),
+
+        #[cfg(feature = "app-ethereum")]
+        Request::Eth(pb::EthRequest {
+            request: Some(ref request),
+        }) => ethereum::process(request).await,
+        #[cfg(not(feature = "app-ethereum"))]
+        Request::Eth(_) => Some(Err(Error::Disabled)),
+
         _ => None,
     }
 }

--- a/src/rust/bitbox02-rust/src/hww/api/ethereum.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/ethereum.rs
@@ -1,0 +1,24 @@
+// Copyright 2020 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::pb;
+use super::Error;
+
+use pb::eth_request::Request;
+use pb::response::Response;
+
+// a `None` result means that the call will fall back to C.
+pub async fn process(_request: &Request) -> Option<Result<Response, Error>> {
+    None
+}


### PR DESCRIPTION
And only compile it in in the Multi edition, using the app-ethereum
Rust feature.

Similar to the top-level api processing, None is returned to fall back
to C, while we migrate step by step.