### PR TITLE
keystore: move apps_btc_encode_xpub to keystore

### DIFF
--- a/src/apps/btc/btc.c
+++ b/src/apps/btc/btc.c
@@ -70,7 +70,7 @@ bool app_btc_electrum_encryption_key(
     if (!keystore_get_xpub(keypath, keypath_len, &derived_xpub)) {
         return false;
     }
-    return btc_common_encode_xpub(&derived_xpub, BTCPubRequest_XPubType_XPUB, out, out_len);
+    return keystore_encode_xpub(&derived_xpub, XPUB, out, out_len);
 }
 
 bool app_btc_address_simple(

--- a/src/apps/btc/btc.c
+++ b/src/apps/btc/btc.c
@@ -45,11 +45,43 @@ bool app_btc_xpub(
         return false;
     }
 
-    struct ext_key derived_xpub __attribute__((__cleanup__(keystore_zero_xkey))) = {0};
-    if (!keystore_get_xpub(keypath, keypath_len, &derived_xpub)) {
+    xpub_type_t version;
+    switch (xpub_type) {
+    case BTCPubRequest_XPubType_TPUB:
+        version = TPUB;
+        break;
+    case BTCPubRequest_XPubType_XPUB:
+        version = XPUB;
+        break;
+    case BTCPubRequest_XPubType_YPUB:
+        version = YPUB;
+        break;
+    case BTCPubRequest_XPubType_ZPUB:
+        version = ZPUB;
+        break;
+    case BTCPubRequest_XPubType_VPUB:
+        version = VPUB;
+        break;
+    case BTCPubRequest_XPubType_UPUB:
+        version = UPUB;
+        break;
+    case BTCPubRequest_XPubType_CAPITAL_VPUB:
+        version = CAPITAL_VPUB;
+        break;
+    case BTCPubRequest_XPubType_CAPITAL_ZPUB:
+        version = CAPITAL_ZPUB;
+        break;
+    case BTCPubRequest_XPubType_CAPITAL_UPUB:
+        version = CAPITAL_UPUB;
+        break;
+    case BTCPubRequest_XPubType_CAPITAL_YPUB:
+        version = CAPITAL_YPUB;
+        break;
+    default:
         return false;
     }
-    return btc_common_encode_xpub(&derived_xpub, xpub_type, out, out_len);
+
+    return keystore_encode_xpub_at_keypath(keypath, keypath_len, version, out, out_len);
 }
 
 bool app_btc_electrum_encryption_key(
@@ -66,11 +98,7 @@ bool app_btc_electrum_encryption_key(
         return false;
     }
 
-    struct ext_key derived_xpub __attribute__((__cleanup__(keystore_zero_xkey))) = {0};
-    if (!keystore_get_xpub(keypath, keypath_len, &derived_xpub)) {
-        return false;
-    }
-    return keystore_encode_xpub(&derived_xpub, XPUB, out, out_len);
+    return keystore_encode_xpub_at_keypath(keypath, keypath_len, XPUB, out, out_len);
 }
 
 bool app_btc_address_simple(

--- a/src/apps/btc/btc_common.c
+++ b/src/apps/btc/btc_common.c
@@ -27,17 +27,6 @@
 
 #define MULTISIG_P2WSH_MAX_SIGNERS 15
 
-static const uint8_t _xpub_version[4] = {0x04, 0x88, 0xb2, 0x1e};
-static const uint8_t _ypub_version[4] = {0x04, 0x9d, 0x7c, 0xb2};
-static const uint8_t _zpub_version[4] = {0x04, 0xb2, 0x47, 0x46};
-static const uint8_t _tpub_version[4] = {0x04, 0x35, 0x87, 0xcf};
-static const uint8_t _vpub_version[4] = {0x04, 0x5f, 0x1c, 0xf6};
-static const uint8_t _upub_version[4] = {0x04, 0x4a, 0x52, 0x62};
-static const uint8_t _capital_vpub_version[4] = {0x02, 0x57, 0x54, 0x83};
-static const uint8_t _capital_zpub_version[4] = {0x02, 0xaa, 0x7e, 0xd3};
-static const uint8_t _capital_upub_version[4] = {0x02, 0x42, 0x89, 0xef};
-static const uint8_t _capital_ypub_version[4] = {0x02, 0x95, 0xb4, 0x3f};
-
 const char* btc_common_coin_name(BTCCoin coin)
 {
     static const char* _coin_btc = "Bitcoin";
@@ -118,60 +107,43 @@ bool btc_common_encode_xpub(
     char* out,
     size_t out_len)
 {
-    char* xpub_string = NULL;
-    uint8_t bytes[BIP32_SERIALIZED_LEN] = {0};
-    if (bip32_key_serialize(derived_xpub, BIP32_FLAG_KEY_PUBLIC, bytes, sizeof(bytes)) !=
-        WALLY_OK) {
-        return false;
-    }
-    const uint8_t* version;
+    xpub_type_t version;
     switch (xpub_type) {
     case BTCPubRequest_XPubType_TPUB:
-        version = _tpub_version;
+        version = TPUB;
         break;
     case BTCPubRequest_XPubType_VPUB:
-        version = _vpub_version;
+        version = VPUB;
         break;
     case BTCPubRequest_XPubType_UPUB:
-        version = _upub_version;
+        version = UPUB;
         break;
     case BTCPubRequest_XPubType_XPUB:
-        version = _xpub_version;
+        version = XPUB;
         break;
     case BTCPubRequest_XPubType_YPUB:
-        version = _ypub_version;
+        version = YPUB;
         break;
     case BTCPubRequest_XPubType_ZPUB:
-        version = _zpub_version;
+        version = ZPUB;
         break;
     case BTCPubRequest_XPubType_CAPITAL_VPUB:
-        version = _capital_vpub_version;
+        version = CAPITAL_VPUB;
         break;
     case BTCPubRequest_XPubType_CAPITAL_ZPUB:
-        version = _capital_zpub_version;
+        version = CAPITAL_ZPUB;
         break;
     case BTCPubRequest_XPubType_CAPITAL_UPUB:
-        version = _capital_upub_version;
+        version = CAPITAL_UPUB;
         break;
     case BTCPubRequest_XPubType_CAPITAL_YPUB:
-        version = _capital_ypub_version;
+        version = CAPITAL_YPUB;
         break;
     default:
         return false;
     }
 
-    // Overwrite bip32 version (libwally doesn't give the option to provide a
-    // different one)
-    memcpy(bytes, version, 4);
-    int ret =
-        wally_base58_from_bytes(bytes, BIP32_SERIALIZED_LEN, BASE58_FLAG_CHECKSUM, &xpub_string);
-    util_zero(bytes, sizeof(bytes));
-    if (ret != WALLY_OK) {
-        return false;
-    }
-    int sprintf_result = snprintf(out, out_len, "%s", xpub_string);
-    wally_free_string(xpub_string);
-    return sprintf_result >= 0 && sprintf_result < (int)out_len;
+    return keystore_encode_xpub(derived_xpub, version, out, out_len);
 }
 
 /**

--- a/src/apps/btc/btc_common.c
+++ b/src/apps/btc/btc_common.c
@@ -101,51 +101,6 @@ bool btc_common_is_valid_keypath_address_multisig(
         keypath, keypath_len, expected_coin, script_type);
 }
 
-bool btc_common_encode_xpub(
-    const struct ext_key* derived_xpub,
-    BTCPubRequest_XPubType xpub_type,
-    char* out,
-    size_t out_len)
-{
-    xpub_type_t version;
-    switch (xpub_type) {
-    case BTCPubRequest_XPubType_TPUB:
-        version = TPUB;
-        break;
-    case BTCPubRequest_XPubType_VPUB:
-        version = VPUB;
-        break;
-    case BTCPubRequest_XPubType_UPUB:
-        version = UPUB;
-        break;
-    case BTCPubRequest_XPubType_XPUB:
-        version = XPUB;
-        break;
-    case BTCPubRequest_XPubType_YPUB:
-        version = YPUB;
-        break;
-    case BTCPubRequest_XPubType_ZPUB:
-        version = ZPUB;
-        break;
-    case BTCPubRequest_XPubType_CAPITAL_VPUB:
-        version = CAPITAL_VPUB;
-        break;
-    case BTCPubRequest_XPubType_CAPITAL_ZPUB:
-        version = CAPITAL_ZPUB;
-        break;
-    case BTCPubRequest_XPubType_CAPITAL_UPUB:
-        version = CAPITAL_UPUB;
-        break;
-    case BTCPubRequest_XPubType_CAPITAL_YPUB:
-        version = CAPITAL_YPUB;
-        break;
-    default:
-        return false;
-    }
-
-    return keystore_encode_xpub(derived_xpub, version, out, out_len);
-}
-
 /**
  * convert uint64_t to string. %llu / %lld not supported by our arm libc.
  * param[in] value value to format.

--- a/src/apps/btc/btc_common.h
+++ b/src/apps/btc/btc_common.h
@@ -22,6 +22,7 @@
 #include <stdint.h>
 
 #include <compiler_util.h>
+#include <keystore.h>
 
 #include <hww.pb.h>
 
@@ -34,9 +35,6 @@
 // current expected max pk script size is a m-of-15 multisig. 700 is also enough for m-of-20, which
 // is technically possible to extend to if needed.
 #define MAX_PK_SCRIPT_SIZE (700)
-
-// Max. length of an xpub string, including the null terminator.
-#define XPUB_ENCODED_LEN 113
 
 /**
  * Returns the coin name to be used in confirm dialogs ("Bitcoin", "Litecoin", etc.). Aborts for an
@@ -90,7 +88,7 @@ USE_RESULT bool btc_common_is_valid_keypath_address_multisig(
 
 /**
  * Encode an xpub as a base58 string.
- * @param[in] dervived_xpub the xpub to encode.
+ * @param[in] derived_xpub the xpub to encode.
  * @param[in] xpub_type determines the xpub format, e.g. xpub, ypub, zpub, ...
  * @param[out] out resulting string, must be at least of size `XPUB_ENCODED_LEN` (including the null
  * terminator).

--- a/src/apps/btc/btc_common.h
+++ b/src/apps/btc/btc_common.h
@@ -87,21 +87,6 @@ USE_RESULT bool btc_common_is_valid_keypath_address_multisig(
     uint32_t expected_coin);
 
 /**
- * Encode an xpub as a base58 string.
- * @param[in] derived_xpub the xpub to encode.
- * @param[in] xpub_type determines the xpub format, e.g. xpub, ypub, zpub, ...
- * @param[out] out resulting string, must be at least of size `XPUB_ENCODED_LEN` (including the null
- * terminator).
- * @param[in] out_len size of `out`.
- * @return false on failure, true on success.
- */
-USE_RESULT bool btc_common_encode_xpub(
-    const struct ext_key* derived_xpub,
-    BTCPubRequest_XPubType xpub_type,
-    char* out,
-    size_t out_len);
-
-/**
  * Converts a satoshi value to a string with the BTC unit, e.g. 1234567890 -> "12.34567890 BTC".
  * @param[in] satoshi Amount in Satoshi.
  * @param[in] unit suffix.

--- a/src/apps/btc/confirm_multisig.c
+++ b/src/apps/btc/confirm_multisig.c
@@ -17,6 +17,7 @@
 
 #include <apps/common/bip32.h>
 #include <hardfault.h>
+#include <keystore.h>
 #include <rust/rust.h>
 #include <workflow/confirm.h>
 
@@ -100,7 +101,7 @@ bool apps_btc_confirm_multisig_extended(
         return false;
     }
 
-    BTCPubRequest_XPubType output_xpub_type;
+    xpub_type_t output_xpub_type;
     switch (xpub_type) {
     case BTCRegisterScriptConfigRequest_XPubType_AUTO_ELECTRUM:
         switch (coin) {
@@ -108,10 +109,10 @@ bool apps_btc_confirm_multisig_extended(
         case BTCCoin_LTC:
             switch (multisig->script_type) {
             case BTCScriptConfig_Multisig_ScriptType_P2WSH:
-                output_xpub_type = BTCPubRequest_XPubType_CAPITAL_ZPUB;
+                output_xpub_type = CAPITAL_ZPUB;
                 break;
             case BTCScriptConfig_Multisig_ScriptType_P2WSH_P2SH:
-                output_xpub_type = BTCPubRequest_XPubType_CAPITAL_YPUB;
+                output_xpub_type = CAPITAL_YPUB;
                 break;
             default:
                 return false;
@@ -121,10 +122,10 @@ bool apps_btc_confirm_multisig_extended(
         case BTCCoin_TLTC:
             switch (multisig->script_type) {
             case BTCScriptConfig_Multisig_ScriptType_P2WSH:
-                output_xpub_type = BTCPubRequest_XPubType_CAPITAL_VPUB;
+                output_xpub_type = CAPITAL_VPUB;
                 break;
             case BTCScriptConfig_Multisig_ScriptType_P2WSH_P2SH:
-                output_xpub_type = BTCPubRequest_XPubType_CAPITAL_UPUB;
+                output_xpub_type = CAPITAL_UPUB;
                 break;
             default:
                 return false;
@@ -138,11 +139,11 @@ bool apps_btc_confirm_multisig_extended(
         switch (coin) {
         case BTCCoin_BTC:
         case BTCCoin_LTC:
-            output_xpub_type = BTCPubRequest_XPubType_XPUB;
+            output_xpub_type = XPUB;
             break;
         case BTCCoin_TBTC:
         case BTCCoin_TLTC:
-            output_xpub_type = BTCPubRequest_XPubType_TPUB;
+            output_xpub_type = TPUB;
             break;
         default:
             Abort("confirm multisig: unknown coin");
@@ -160,7 +161,7 @@ bool apps_btc_confirm_multisig_extended(
             return false;
         }
         char xpub_str[XPUB_ENCODED_LEN] = {0};
-        if (!btc_common_encode_xpub(&xpub, output_xpub_type, xpub_str, sizeof(xpub_str))) {
+        if (!keystore_encode_xpub(&xpub, output_xpub_type, xpub_str, sizeof(xpub_str))) {
             return false;
         }
         char confirm[XPUB_ENCODED_LEN + 100] = {0};

--- a/src/apps/common/bip32.h
+++ b/src/apps/common/bip32.h
@@ -16,6 +16,7 @@
 #define _APPS_COMMON_BIP32_H
 
 #include <stdbool.h>
+#include <stddef.h>
 
 #include <common.pb.h>
 #include <compiler_util.h>

--- a/src/apps/eth/eth.c
+++ b/src/apps/eth/eth.c
@@ -70,11 +70,7 @@ app_eth_sign_error_t app_eth_address(
         if (!rust_ethereum_keypath_is_valid_xpub(keypath, keypath_len, params->bip44_coin)) {
             return APP_ETH_SIGN_ERR_INVALID_INPUT;
         }
-        struct ext_key derived_xpub __attribute__((__cleanup__(keystore_zero_xkey))) = {0};
-        if (!keystore_get_xpub(keypath, keypath_len, &derived_xpub)) {
-            return APP_ETH_SIGN_ERR_INVALID_INPUT;
-        }
-        if (!keystore_encode_xpub(&derived_xpub, XPUB, out, out_len)) {
+        if (!keystore_encode_xpub_at_keypath(keypath, keypath_len, XPUB, out, out_len)) {
             return APP_ETH_SIGN_ERR_UNKNOWN;
         }
         break;

--- a/src/apps/eth/eth.c
+++ b/src/apps/eth/eth.c
@@ -15,7 +15,6 @@
 #include "eth.h"
 #include "eth_params.h"
 #include "eth_verify.h"
-#include <apps/btc/btc_common.h>
 #include <workflow/confirm.h>
 
 #include <keystore.h>
@@ -75,7 +74,7 @@ app_eth_sign_error_t app_eth_address(
         if (!keystore_get_xpub(keypath, keypath_len, &derived_xpub)) {
             return APP_ETH_SIGN_ERR_INVALID_INPUT;
         }
-        if (!btc_common_encode_xpub(&derived_xpub, BTCPubRequest_XPubType_XPUB, out, out_len)) {
+        if (!keystore_encode_xpub(&derived_xpub, XPUB, out, out_len)) {
             return APP_ETH_SIGN_ERR_UNKNOWN;
         }
         break;

--- a/src/keystore.c
+++ b/src/keystore.c
@@ -626,3 +626,76 @@ bool keystore_get_u2f_seed(uint8_t* seed_out)
     }
     return true;
 }
+
+static const uint8_t _xpub_version[4] = {0x04, 0x88, 0xb2, 0x1e};
+static const uint8_t _ypub_version[4] = {0x04, 0x9d, 0x7c, 0xb2};
+static const uint8_t _zpub_version[4] = {0x04, 0xb2, 0x47, 0x46};
+static const uint8_t _tpub_version[4] = {0x04, 0x35, 0x87, 0xcf};
+static const uint8_t _vpub_version[4] = {0x04, 0x5f, 0x1c, 0xf6};
+static const uint8_t _upub_version[4] = {0x04, 0x4a, 0x52, 0x62};
+static const uint8_t _capital_vpub_version[4] = {0x02, 0x57, 0x54, 0x83};
+static const uint8_t _capital_zpub_version[4] = {0x02, 0xaa, 0x7e, 0xd3};
+static const uint8_t _capital_upub_version[4] = {0x02, 0x42, 0x89, 0xef};
+static const uint8_t _capital_ypub_version[4] = {0x02, 0x95, 0xb4, 0x3f};
+
+bool keystore_encode_xpub(
+    const struct ext_key* xpub,
+    xpub_type_t xpub_type,
+    char* out,
+    size_t out_len)
+{
+    char* xpub_string = NULL;
+    uint8_t bytes[BIP32_SERIALIZED_LEN] = {0};
+    if (bip32_key_serialize(xpub, BIP32_FLAG_KEY_PUBLIC, bytes, sizeof(bytes)) != WALLY_OK) {
+        return false;
+    }
+
+    const uint8_t* version;
+    switch (xpub_type) {
+    case XPUB:
+        version = _xpub_version;
+        break;
+    case YPUB:
+        version = _ypub_version;
+        break;
+    case ZPUB:
+        version = _zpub_version;
+        break;
+    case TPUB:
+        version = _tpub_version;
+        break;
+    case VPUB:
+        version = _vpub_version;
+        break;
+    case UPUB:
+        version = _upub_version;
+        break;
+    case CAPITAL_VPUB:
+        version = _capital_vpub_version;
+        break;
+    case CAPITAL_ZPUB:
+        version = _capital_zpub_version;
+        break;
+    case CAPITAL_UPUB:
+        version = _capital_upub_version;
+        break;
+    case CAPITAL_YPUB:
+        version = _capital_ypub_version;
+        break;
+    default:
+        return false;
+    }
+
+    // Overwrite bip32 version (libwally doesn't give the option to provide a
+    // different one)
+    memcpy(bytes, version, 4);
+    int ret =
+        wally_base58_from_bytes(bytes, BIP32_SERIALIZED_LEN, BASE58_FLAG_CHECKSUM, &xpub_string);
+    util_zero(bytes, sizeof(bytes));
+    if (ret != WALLY_OK) {
+        return false;
+    }
+    int sprintf_result = snprintf(out, out_len, "%s", xpub_string);
+    wally_free_string(xpub_string);
+    return sprintf_result >= 0 && sprintf_result < (int)out_len;
+}

--- a/src/keystore.c
+++ b/src/keystore.c
@@ -699,3 +699,17 @@ bool keystore_encode_xpub(
     wally_free_string(xpub_string);
     return sprintf_result >= 0 && sprintf_result < (int)out_len;
 }
+
+USE_RESULT bool keystore_encode_xpub_at_keypath(
+    const uint32_t* keypath,
+    size_t keypath_len,
+    xpub_type_t xpub_type,
+    char* out,
+    size_t out_len)
+{
+    struct ext_key derived_xpub __attribute__((__cleanup__(keystore_zero_xkey))) = {0};
+    if (!keystore_get_xpub(keypath, keypath_len, &derived_xpub)) {
+        return false;
+    }
+    return keystore_encode_xpub(&derived_xpub, xpub_type, out, out_len);
+}

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -27,6 +27,9 @@
 #define KEYSTORE_MAX_SEED_LENGTH (32)
 #define KEYSTORE_U2F_SEED_LENGTH SHA256_LEN
 
+// Max. length of an xpub string, including the null terminator.
+#define XPUB_ENCODED_LEN 113
+
 typedef enum {
     KEYSTORE_OK,
     KEYSTORE_ERR_INCORRECT_PASSWORD,
@@ -205,5 +208,33 @@ USE_RESULT bool keystore_secp256k1_sign(
  * @return true if succes
  */
 USE_RESULT bool keystore_get_u2f_seed(uint8_t* seed_out);
+
+typedef enum {
+    XPUB,
+    YPUB,
+    ZPUB,
+    TPUB,
+    VPUB,
+    UPUB,
+    CAPITAL_VPUB,
+    CAPITAL_ZPUB,
+    CAPITAL_UPUB,
+    CAPITAL_YPUB,
+} xpub_type_t;
+/**
+ * Encode an xpub as a base58 string.
+ * @param[in] xpub the xpub to encode.
+ * @param[in] xpub_type determines the xpub format.
+ * etc.
+ * @param[out] out resulting string, must be at least of size `XPUB_ENCODED_LEN` (including the null
+ * terminator).
+ * @param[in] out_len size of `out`.
+ * @return false on failure, true on success.
+ */
+USE_RESULT bool keystore_encode_xpub(
+    const struct ext_key* xpub,
+    xpub_type_t xpub_type,
+    char* out,
+    size_t out_len);
 
 #endif

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -237,4 +237,15 @@ USE_RESULT bool keystore_encode_xpub(
     char* out,
     size_t out_len);
 
+/**
+ * Encode an xpub as a base58 string at the given `keypath`.
+ * Args the same as `keystore_encode_xpub`.
+ */
+USE_RESULT bool keystore_encode_xpub_at_keypath(
+    const uint32_t* keypath,
+    size_t keypath_len,
+    xpub_type_t xpub_type,
+    char* out,
+    size_t out_len);
+
 #endif

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -171,7 +171,7 @@ set(TEST_LIST
    apps_common_bip32
    ""
    app_btc
-   "-Wl,--wrap=keystore_get_xpub,--wrap=btc_common_is_valid_keypath_xpub,--wrap=btc_common_is_valid_keypath_address_simple,--wrap=btc_common_encode_xpub,--wrap=btc_common_outputhash_from_pubkeyhash"
+   "-Wl,--wrap=keystore_get_xpub,--wrap=btc_common_is_valid_keypath_xpub,--wrap=btc_common_is_valid_keypath_address_simple,--wrap=keystore_encode_xpub,--wrap=btc_common_outputhash_from_pubkeyhash"
    app_btc_multisig
    "-Wl,--wrap=memory_multisig_get_by_hash,--wrap=apps_btc_confirm_multisig_basic"
    app_btc_common

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -171,7 +171,7 @@ set(TEST_LIST
    apps_common_bip32
    ""
    app_btc
-   "-Wl,--wrap=keystore_get_xpub,--wrap=btc_common_is_valid_keypath_xpub,--wrap=btc_common_is_valid_keypath_address_simple,--wrap=keystore_encode_xpub,--wrap=btc_common_outputhash_from_pubkeyhash"
+   "-Wl,--wrap=keystore_get_xpub,--wrap=btc_common_is_valid_keypath_xpub,--wrap=btc_common_is_valid_keypath_address_simple,--wrap=keystore_encode_xpub_at_keypath,--wrap=btc_common_outputhash_from_pubkeyhash"
    app_btc_multisig
    "-Wl,--wrap=memory_multisig_get_by_hash,--wrap=apps_btc_confirm_multisig_basic"
    app_btc_common

--- a/test/unit-test/test_app_btc.c
+++ b/test/unit-test/test_app_btc.c
@@ -28,20 +28,31 @@
 
 #include <wally_bip32.h>
 
+static uint8_t _mock_seed[32] = {
+    0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22,
+    0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44,
+};
+
+// sudden tenant fault inject concert weather maid people chunk youth stumble grit
+static uint8_t _mock_bip39_seed[64] =
+    "\x5a\x11\x5b\xcd\xbe\x0f\xe1\x70\x0e\x60\x95\x74\xf3\x57\xb0\x8d\xca\x37\x15\xb0\x35\xe6\xc7"
+    "\x76\x77\x0a\xc7\xa0\xab\x2e\x2f\xea\x84\x0b\xa2\x76\x35\x06\xfa\x9c\x39\xde\x4d\xef\x27\xf6"
+    "\xf8\xeb\xce\x36\x37\x02\xe9\x83\xe5\x49\xbd\x7d\xef\x14\xa0\x31\xbf\xdd";
+
 // We mock all called functions to make sure they are actually called. For some,
 // the real function is called as it's easier to check all function input/output
 // this way.
 
-bool __real_keystore_encode_xpub(const struct ext_key*, const uint8_t*, char*, size_t);
-bool __wrap_keystore_encode_xpub(
-    const struct ext_key* derived_xpub,
+bool __real_keystore_encode_xpub_at_keypath(const uint32_t*, size_t, const uint8_t*, char*, size_t);
+bool __wrap_keystore_encode_xpub_at_keypath(
+    const uint32_t* keypath,
+    size_t keypath_len,
     const uint8_t* version,
     char* out,
     size_t out_len)
 {
     check_expected(out_len);
-    assert_true(__real_keystore_encode_xpub(derived_xpub, version, out, out_len));
-    return mock();
+    return __real_keystore_encode_xpub_at_keypath(keypath, keypath_len, version, out, out_len);
 }
 bool __wrap_btc_common_is_valid_keypath_xpub(
     BTCPubRequest_XPubType xpub_type,
@@ -119,51 +130,51 @@ static xpub_testcase_t _xpub_tests[] = {
     {
         .coin = BTCCoin_BTC,
         .xpub_type = BTCPubRequest_XPubType_TPUB,
-        .out = "tpubD6NzVbkrYhZ4Y2oG1D7odp1qL1DBqrbzFQvTUv9pYVZmTwhiTLQmcNYM7KkioXEs7A7t2H9nSU4BrFQ"
-               "2uWgsH1N3bzWnnqwe7z6EBNnJ3Hx",
+        .out = "tpubDCYSHq3Y2yqZYw2yxYFczWpbbr9yqLXK5V9hADr7czfhvSbVBZ2Up9ouUeJU4ibNvVuHBZywbVtt4Xw"
+               "37wAgwWhy5LQsVk5w441qoaEytzZ",
     },
     {
         .coin = BTCCoin_BTC,
         .xpub_type = BTCPubRequest_XPubType_VPUB,
-        .out = "vpub5SLqN2bLY4WeZeEAtJZU1iVTewpdyE7vsZHiZaJuSa47cTQYsoEZDoZEpskmHCynVyMMukSnz3X3PVg"
-               "J5G1bo6YYoiNdwVeRzaNXeC1Tqgo",
+        .out = "vpub5YWHAFt22Lo9aYTtqdhHNRJDvnmRxi3FhdWxEt1CX5A44xJKc1rGRapoCCJWYQLJKK8m53Gx95MjbnD"
+               "JHgVRTbtUH4GiePniveJ9GMSBipu",
     },
     {
         .coin = BTCCoin_BTC,
         .xpub_type = BTCPubRequest_XPubType_UPUB,
-        .out = "upub57Wa4MvRPNyAiM343wmqodPxUygC2c8RxSmVnBR24ZgEZMbKd94zbju6ofoBHJKs6LEZAGrEXPAVWD4"
-               "jMZbazrrwwNgDMapwirJtFbjQ8Nj",
+        .out = "upub5Dg1rbD6sfFfjFGn1GufALCikpcz263knWzjTV7K94nB1rV6MMghoXAfAzLvYVgNug1xKZgPgR1BiVb"
+               "jZz5QfNCsQiaJ4UyEevEVsqHSu6Q",
     },
 
     {
         .coin = BTCCoin_BTC,
         .xpub_type = BTCPubRequest_XPubType_XPUB,
-        .out = "xpub661MyMwAqRbcGEcQZ28iRtgTzt7XrU6vhnLA8N6gCaosif31P7ZgTvsWsHfwH2HdKFayQhduuNE9A4u"
-               "RWeqdPZukYPmV7KHQY2VpRNV7PiJ",
+        .out = "xpub6CAombDrKht7H8r8WMGXnbVEGj4Kqx2FXrZPofnyH5upB9vn7LBPfi95EcDgYDe98bNNZzU54Q4qNMS"
+               "Rj5KT45Fg1jfZpDRhU6RS3WjHkqg",
     },
     {
         .coin = BTCCoin_BTC,
         .xpub_type = BTCPubRequest_XPubType_YPUB,
-        .out = "ypub6QqdH2c5z7967XoXPNvLdymyArFyo66RctrNukzZabBkmkrEdmjF5zXetVdXGvwYithnABEUN2ah3MW"
-               "zEMFeBobMQjTuhE6tokZTouiD6jm",
+        .out = "ypub6X155FtmUPRb8S3FLi49zgajShCmna1kSy5cb4grf6HhEFk1MzLxHmoDFpBGY8J4YEVBKU4dX4RPFe3"
+               "zSmjTrJwGt5MzQ8FBjpV5S9fvhh3",
     },
     {
         .coin = BTCCoin_BTC,
         .xpub_type = BTCPubRequest_XPubType_ZPUB,
-        .out = "zpub6jftahH18ngZxpzeDjhxr4sULpQRji5vY1Nbh9tSxbZdprfTtRtoi4Bnuhb7GqbU8Xpaueq2pgwEve8"
-               "Yx3fez3GxH5ALH8vP5Ud7CUbyUKz",
+        .out = "zpub6qqLNvZgd4y4yjENB4qnCmgEcfMDjC1FN5bqNTak36faHMZEceWWuqTMH28rY2wywsbz4wfByimw8vf"
+               "ZAU9UeYcskR4Qz34g1YYipg8DatS",
     },
     {
         .coin = BTCCoin_BTC,
         .xpub_type = BTCPubRequest_XPubType_CAPITAL_VPUB,
-        .out = "Vpub5dEvVGKn7251zDPYpy2SqnqGNjruBaoXBpwPUqaSpLtXEdyTeCcqJvRAdaiEqeCgjSRLnLSusFuYWfJ"
-               "4NVAYwafDeBV3Lu7RtJeQEBLEptm",
+        .out = "Vpub5jQNHVcTbJMX17dGnJAGCVe2eaohB4ir1uAdA9GjtqzTh8sENREYWhgizuFz6qZCYnCjwdH52HkEiwq"
+               "4aueNc6197XP83oFipNa1rGqkiFZ",
     },
     {
         .coin = BTCCoin_BTC,
         .xpub_type = BTCPubRequest_XPubType_CAPITAL_ZPUB,
-        .out = "Zpub6vZyhw1ShkEwPQA2AQAwg9DH4cSgx4mWrH2GcR9zLNQ3T3ENeqH5oB3iiQYaqGpNMztZnEq9huKk3ok"
-               "KFGpc8XPd7YGjgYPNyCtynNreibs",
+        .out = "Zpub72jRWAJ8C2XSQJPk7jJm2r23LTPUwYgqgMFWHirHQsVyuY89P3tnzxKH5j6L6UAtBLfxwXfJrwASG6H"
+               "KThJRo2jYatApPSXfuGpbQf7Q5V3",
     },
 };
 
@@ -222,14 +233,20 @@ static void _test_app_btc_xpub(void** state)
         assert_false(result);
     }
 
-    for (int bools = 0; bools < 8; bools++) {
+    for (int bools = 0; bools < 4; bools++) {
         bool keypath_valid = bools & 1;
-        bool get_xpub_success = bools & 2;
-        bool encode_success = bools & 4;
+        bool encode_success = bools & 2;
         for (size_t test_case_index = 0;
              test_case_index < sizeof(_xpub_tests) / sizeof(xpub_testcase_t);
              test_case_index++) {
             const xpub_testcase_t* test_case = &_xpub_tests[test_case_index];
+
+            if (encode_success) {
+                mock_state(_mock_seed, _mock_bip39_seed);
+            } else {
+                mock_state(NULL, NULL);
+            }
+
             char out[XPUB_ENCODED_LEN] = {0};
             uint32_t expected_keypath[3] = {1, 2, 3};
             expect_value(__wrap_btc_common_is_valid_keypath_xpub, xpub_type, test_case->xpub_type);
@@ -240,20 +257,11 @@ static void _test_app_btc_xpub(void** state)
                 sizeof(expected_keypath) / sizeof(uint32_t));
             will_return(__wrap_btc_common_is_valid_keypath_xpub, keypath_valid);
             if (keypath_valid) {
-                expect_memory(__wrap_keystore_get_xpub, keypath, expected_keypath, 3);
-                expect_value(
-                    __wrap_keystore_get_xpub,
-                    keypath_len,
-                    sizeof(expected_keypath) / sizeof(uint32_t));
-                will_return(__wrap_keystore_get_xpub, get_xpub_success);
-            }
-            if (keypath_valid && get_xpub_success) {
-                expect_value(__wrap_keystore_encode_xpub, out_len, sizeof(out));
-                will_return(__wrap_keystore_encode_xpub, encode_success);
+                expect_value(__wrap_keystore_encode_xpub_at_keypath, out_len, sizeof(out));
             }
             bool result = app_btc_xpub(
                 test_case->coin, test_case->xpub_type, expected_keypath, 3, out, sizeof(out));
-            assert_int_equal(result, keypath_valid && get_xpub_success && encode_success);
+            assert_int_equal(result, keypath_valid && encode_success);
             if (result) {
                 assert_string_equal(out, test_case->out);
             }
@@ -266,24 +274,21 @@ static void _test_app_btc_electrum_encryption_key(void** satte)
 #define ELECTRUM_WALLET_ENCRYPTION_KEYPATH_LEVEL_ONE (4541509 + BIP32_INITIAL_HARDENED_CHILD)
 #define ELECTRUM_WALLET_ENCRYPTION_KEYPATH_LEVEL_TWO (1112098098 + BIP32_INITIAL_HARDENED_CHILD)
 
+    mock_state(_mock_seed, _mock_bip39_seed);
+
     uint32_t keypath[2] = {ELECTRUM_WALLET_ENCRYPTION_KEYPATH_LEVEL_ONE,
                            ELECTRUM_WALLET_ENCRYPTION_KEYPATH_LEVEL_TWO};
 
     char out[XPUB_ENCODED_LEN] = {0};
-    expect_memory(__wrap_keystore_get_xpub, keypath, keypath, 2);
-    expect_value(__wrap_keystore_get_xpub, keypath_len, sizeof(keypath) / sizeof(uint32_t));
-    will_return(__wrap_keystore_get_xpub, true);
-
-    expect_value(__wrap_keystore_encode_xpub, out_len, sizeof(out));
-    will_return(__wrap_keystore_encode_xpub, true);
+    expect_value(__wrap_keystore_encode_xpub_at_keypath, out_len, sizeof(out));
 
     bool result = app_btc_electrum_encryption_key(
         keypath, sizeof(keypath) / sizeof(uint32_t), out, sizeof(out));
     assert_true(result);
     assert_string_equal(
         out,
-        "xpub661MyMwAqRbcGEcQZ28iRtgTzt7XrU6vhnLA8N6gCaosif31P7ZgTvsWsHfwH2HdKFayQhduuNE9A4uRWeqdPZ"
-        "ukYPmV7KHQY2VpRNV7PiJ");
+        "xpub6ALhrsD27cSNqAYEkG6LTFdhyE9ipvpAY7RoGrpw9rCuvk6sjP1FQ3x4x6a5Y9BuE8JXttdXMuiffab5EqAKuM"
+        "XRyF92AKLPhCs55hBmcAM");
 
     uint32_t keypath_invalid[2] = {ELECTRUM_WALLET_ENCRYPTION_KEYPATH_LEVEL_ONE, 0};
     result = app_btc_electrum_encryption_key(

--- a/test/unit-test/test_app_btc.c
+++ b/test/unit-test/test_app_btc.c
@@ -32,15 +32,15 @@
 // the real function is called as it's easier to check all function input/output
 // this way.
 
-bool __real_btc_common_encode_xpub(const struct ext_key*, const uint8_t*, char*, size_t);
-bool __wrap_btc_common_encode_xpub(
+bool __real_keystore_encode_xpub(const struct ext_key*, const uint8_t*, char*, size_t);
+bool __wrap_keystore_encode_xpub(
     const struct ext_key* derived_xpub,
     const uint8_t* version,
     char* out,
     size_t out_len)
 {
     check_expected(out_len);
-    assert_true(__real_btc_common_encode_xpub(derived_xpub, version, out, out_len));
+    assert_true(__real_keystore_encode_xpub(derived_xpub, version, out, out_len));
     return mock();
 }
 bool __wrap_btc_common_is_valid_keypath_xpub(
@@ -248,8 +248,8 @@ static void _test_app_btc_xpub(void** state)
                 will_return(__wrap_keystore_get_xpub, get_xpub_success);
             }
             if (keypath_valid && get_xpub_success) {
-                expect_value(__wrap_btc_common_encode_xpub, out_len, sizeof(out));
-                will_return(__wrap_btc_common_encode_xpub, encode_success);
+                expect_value(__wrap_keystore_encode_xpub, out_len, sizeof(out));
+                will_return(__wrap_keystore_encode_xpub, encode_success);
             }
             bool result = app_btc_xpub(
                 test_case->coin, test_case->xpub_type, expected_keypath, 3, out, sizeof(out));
@@ -274,8 +274,8 @@ static void _test_app_btc_electrum_encryption_key(void** satte)
     expect_value(__wrap_keystore_get_xpub, keypath_len, sizeof(keypath) / sizeof(uint32_t));
     will_return(__wrap_keystore_get_xpub, true);
 
-    expect_value(__wrap_btc_common_encode_xpub, out_len, sizeof(out));
-    will_return(__wrap_btc_common_encode_xpub, true);
+    expect_value(__wrap_keystore_encode_xpub, out_len, sizeof(out));
+    will_return(__wrap_keystore_encode_xpub, true);
 
     bool result = app_btc_electrum_encryption_key(
         keypath, sizeof(keypath) / sizeof(uint32_t), out, sizeof(out));

--- a/test/unit-test/test_app_btc_common.c
+++ b/test/unit-test/test_app_btc_common.c
@@ -94,77 +94,6 @@ static void _test_btc_common_format_amount(void** state)
     }
 }
 
-static void _test_btc_common_encode_xpub(void** state)
-{
-    struct ext_key xpub = {0};
-    assert_int_equal(
-        bip32_key_from_seed(
-            (const unsigned char*)"seedseedseedseed",
-            BIP32_ENTROPY_LEN_128,
-            BIP32_VER_MAIN_PRIVATE,
-            BIP32_FLAG_SKIP_HASH,
-            &xpub),
-        WALLY_OK);
-    assert_int_equal(bip32_key_strip_private_key(&xpub), WALLY_OK);
-    char out[XPUB_ENCODED_LEN] = {0};
-    assert_false(btc_common_encode_xpub(&xpub, BTCPubRequest_XPubType_XPUB, out, 110));
-
-    assert_true(btc_common_encode_xpub(&xpub, BTCPubRequest_XPubType_TPUB, out, sizeof(out)));
-    assert_string_equal(
-        out,
-        "tpubD6NzVbkrYhZ4X8SrpdvxUfkKsPg5iSLHQqmQ2e7MGczVsJskvL4uD62ckffe8zi4BVtbZXRCsVDythz1eNN3fN"
-        "S2A14YakBkWLBbyJiVFQ9");
-    assert_true(btc_common_encode_xpub(&xpub, BTCPubRequest_XPubType_XPUB, out, sizeof(out)));
-    assert_string_equal(
-        out,
-        "xpub661MyMwAqRbcFLG1NSwsGkQxYGaRj3qDsDB6g64CviEc82D3r7Dp4eMnWdarcVkpPbMgwwuLLPPwCXVQFWWomv"
-        "yj6QKEuDXWvNbCDF98tgM");
-    assert_true(btc_common_encode_xpub(&xpub, BTCPubRequest_XPubType_YPUB, out, sizeof(out)));
-    assert_string_equal(
-        out,
-        "ypub6QqdH2c5z7966dT8CojVUqWTiEisffpinKhKTUx6JicVB82H6mPNgi1vXqYScQQjoEUVhRVto3kV5p6xyCvpaA"
-        "fKxk1fV8M1C6eqbq4wvip");
-    assert_true(btc_common_encode_xpub(&xpub, BTCPubRequest_XPubType_ZPUB, out, sizeof(out)));
-    assert_string_equal(
-        out,
-        "zpub6jftahH18ngZwveF3AX7gvbxtCsKcHpDhSDYEsqygizNEDqWMRYwJmg4Z3W2cK4fCsbJSu6TFi72y6iXguLqNQ"
-        "Lvq5i653AVTpiUzQXvTSr");
-    assert_true(btc_common_encode_xpub(&xpub, BTCPubRequest_XPubType_VPUB, out, sizeof(out)));
-    assert_string_equal(
-        out,
-        "vpub5SLqN2bLY4WeYjsmhjNcraDxCLHXqorE2z8f7JGSAhUr1pabLntgpX3WUDfgcgSyaK85SziDR4gqRxGGp7gnBT"
-        "cXMivPjPtYNvTuS6sWM3J");
-    assert_true(btc_common_encode_xpub(&xpub, BTCPubRequest_XPubType_UPUB, out, sizeof(out)));
-    assert_string_equal(
-        out,
-        "upub57Wa4MvRPNyAhSgesNazeV8T2N95uBrj7scSKuNYnh6xximN68j8CTPNT1i6cmo4Ag1GhX7exQLHYfei6RGmPD"
-        "vvVPDy9V547CQG3b2p2sZ");
-    assert_true(
-        btc_common_encode_xpub(&xpub, BTCPubRequest_XPubType_CAPITAL_VPUB, out, sizeof(out)));
-    assert_string_equal(
-        out,
-        "Vpub5dEvVGKn7251yK39ePqbgeZkv8Ko4AXpMFnL2ZXyYUKFe19W7CGxuduSGvdAB7fsonC4KaiLJH5LZ7t37LqjKw"
-        "jCCC2o8oMYGejn221hXB7");
-    assert_true(
-        btc_common_encode_xpub(&xpub, BTCPubRequest_XPubType_CAPITAL_ZPUB, out, sizeof(out)));
-    assert_string_equal(
-        out,
-        "Zpub6vZyhw1ShkEwNVocypz6WzwmbzuapeVp1hsDA97X4VpmrQQR7pwDPtXzMkTWAkHZSLfHKV6a8vVY6GLHz8VnWt"
-        "TbfYpVUSdVMYzMaJxms8u");
-    assert_true(
-        btc_common_encode_xpub(&xpub, BTCPubRequest_XPubType_CAPITAL_UPUB, out, sizeof(out)));
-    assert_string_equal(
-        out,
-        "Upub5JQfBberxLXY81r2p33yUZUFkABM7YYKS9G7FAe6ATwNauLGrY7QHaFJFifaBD1xQ95Fa77mqcinfqGUPeRiXi"
-        "3bKrLNYtY3zvg8dWPdbfj");
-    assert_true(
-        btc_common_encode_xpub(&xpub, BTCPubRequest_XPubType_CAPITAL_YPUB, out, sizeof(out)));
-    assert_string_equal(
-        out,
-        "Ypub6bjiQGLXZ4hTXCcW9UCUJurGS2m8t2WK6bLzNkDdgVStoJbBsAmempsrLYVvAqde2hYUa1W1gG8zCyijGS5mie"
-        "mzoD84tXp15pviBjgS4df");
-}
-
 typedef struct {
     uint32_t threshold;
     size_t xpubs_count;
@@ -701,7 +630,6 @@ int main(void)
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(_test_btc_common_format_amount_invalid_params),
         cmocka_unit_test(_test_btc_common_format_amount),
-        cmocka_unit_test(_test_btc_common_encode_xpub),
         cmocka_unit_test(_test_btc_common_pkscript_from_multisig),
         cmocka_unit_test(_test_btc_common_pkscript_from_multisig_unhappy),
         cmocka_unit_test(_test_btc_common_multisig_is_valid),

--- a/test/unit-test/test_apps_common_bip32.c
+++ b/test/unit-test/test_apps_common_bip32.c
@@ -20,6 +20,7 @@
 #include <apps/btc/btc_common.h>
 #include <apps/common/bip32.h>
 #include <btc_util.h>
+#include <keystore.h>
 
 static void _test_apps_common_bip32_xpub_from_protobuf(void** state)
 {
@@ -31,8 +32,7 @@ static void _test_apps_common_bip32_xpub_from_protobuf(void** state)
     assert_true(apps_common_bip32_xpub_from_protobuf(&xpub_in, &xpub));
 
     char xpub_str[XPUB_ENCODED_LEN] = {0};
-    assert_true(
-        btc_common_encode_xpub(&xpub, BTCPubRequest_XPubType_XPUB, xpub_str, sizeof(xpub_str)));
+    assert_true(keystore_encode_xpub(&xpub, XPUB, xpub_str, sizeof(xpub_str)));
     assert_string_equal(xpub_str, test_xpub);
 }
 

--- a/test/unit-test/test_keystore.c
+++ b/test/unit-test/test_keystore.c
@@ -437,6 +437,73 @@ static void _test_keystore_get_bip39_mnemonic(void** state)
     assert_true(keystore_get_bip39_mnemonic(mnemonic, strlen(expected_mnemonic) + 1));
 }
 
+static void _test_keystore_encode_xpub(void** state)
+{
+    struct ext_key xpub = {0};
+    assert_int_equal(
+        bip32_key_from_seed(
+            (const unsigned char*)"seedseedseedseed",
+            BIP32_ENTROPY_LEN_128,
+            BIP32_VER_MAIN_PRIVATE,
+            BIP32_FLAG_SKIP_HASH,
+            &xpub),
+        WALLY_OK);
+    assert_int_equal(bip32_key_strip_private_key(&xpub), WALLY_OK);
+    char out[XPUB_ENCODED_LEN] = {0};
+    assert_false(keystore_encode_xpub(&xpub, XPUB, out, 110));
+
+    assert_true(keystore_encode_xpub(&xpub, TPUB, out, sizeof(out)));
+    assert_string_equal(
+        out,
+        "tpubD6NzVbkrYhZ4X8SrpdvxUfkKsPg5iSLHQqmQ2e7MGczVsJskvL4uD62ckffe8zi4BVtbZXRCsVDythz1eNN3fN"
+        "S2A14YakBkWLBbyJiVFQ9");
+    assert_true(keystore_encode_xpub(&xpub, XPUB, out, sizeof(out)));
+    assert_string_equal(
+        out,
+        "xpub661MyMwAqRbcFLG1NSwsGkQxYGaRj3qDsDB6g64CviEc82D3r7Dp4eMnWdarcVkpPbMgwwuLLPPwCXVQFWWomv"
+        "yj6QKEuDXWvNbCDF98tgM");
+    assert_true(keystore_encode_xpub(&xpub, YPUB, out, sizeof(out)));
+    assert_string_equal(
+        out,
+        "ypub6QqdH2c5z7966dT8CojVUqWTiEisffpinKhKTUx6JicVB82H6mPNgi1vXqYScQQjoEUVhRVto3kV5p6xyCvpaA"
+        "fKxk1fV8M1C6eqbq4wvip");
+    assert_true(keystore_encode_xpub(&xpub, ZPUB, out, sizeof(out)));
+    assert_string_equal(
+        out,
+        "zpub6jftahH18ngZwveF3AX7gvbxtCsKcHpDhSDYEsqygizNEDqWMRYwJmg4Z3W2cK4fCsbJSu6TFi72y6iXguLqNQ"
+        "Lvq5i653AVTpiUzQXvTSr");
+    assert_true(keystore_encode_xpub(&xpub, VPUB, out, sizeof(out)));
+    assert_string_equal(
+        out,
+        "vpub5SLqN2bLY4WeYjsmhjNcraDxCLHXqorE2z8f7JGSAhUr1pabLntgpX3WUDfgcgSyaK85SziDR4gqRxGGp7gnBT"
+        "cXMivPjPtYNvTuS6sWM3J");
+    assert_true(keystore_encode_xpub(&xpub, UPUB, out, sizeof(out)));
+    assert_string_equal(
+        out,
+        "upub57Wa4MvRPNyAhSgesNazeV8T2N95uBrj7scSKuNYnh6xximN68j8CTPNT1i6cmo4Ag1GhX7exQLHYfei6RGmPD"
+        "vvVPDy9V547CQG3b2p2sZ");
+    assert_true(keystore_encode_xpub(&xpub, CAPITAL_VPUB, out, sizeof(out)));
+    assert_string_equal(
+        out,
+        "Vpub5dEvVGKn7251yK39ePqbgeZkv8Ko4AXpMFnL2ZXyYUKFe19W7CGxuduSGvdAB7fsonC4KaiLJH5LZ7t37LqjKw"
+        "jCCC2o8oMYGejn221hXB7");
+    assert_true(keystore_encode_xpub(&xpub, CAPITAL_ZPUB, out, sizeof(out)));
+    assert_string_equal(
+        out,
+        "Zpub6vZyhw1ShkEwNVocypz6WzwmbzuapeVp1hsDA97X4VpmrQQR7pwDPtXzMkTWAkHZSLfHKV6a8vVY6GLHz8VnWt"
+        "TbfYpVUSdVMYzMaJxms8u");
+    assert_true(keystore_encode_xpub(&xpub, CAPITAL_UPUB, out, sizeof(out)));
+    assert_string_equal(
+        out,
+        "Upub5JQfBberxLXY81r2p33yUZUFkABM7YYKS9G7FAe6ATwNauLGrY7QHaFJFifaBD1xQ95Fa77mqcinfqGUPeRiXi"
+        "3bKrLNYtY3zvg8dWPdbfj");
+    assert_true(keystore_encode_xpub(&xpub, CAPITAL_YPUB, out, sizeof(out)));
+    assert_string_equal(
+        out,
+        "Ypub6bjiQGLXZ4hTXCcW9UCUJurGS2m8t2WK6bLzNkDdgVStoJbBsAmempsrLYVvAqde2hYUa1W1gG8zCyijGS5mie"
+        "mzoD84tXp15pviBjgS4df");
+}
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
@@ -448,6 +515,7 @@ int main(void)
         cmocka_unit_test(_test_keystore_unlock),
         cmocka_unit_test(_test_keystore_lock),
         cmocka_unit_test(_test_keystore_get_bip39_mnemonic),
+        cmocka_unit_test(_test_keystore_encode_xpub),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/test/unit-test/test_keystore_functional.c
+++ b/test/unit-test/test_keystore_functional.c
@@ -128,8 +128,7 @@ static void _check_pubs(
 
     assert_true(keystore_get_xpub(keypath, 3, &xpub));
     char xpub_serialized[120];
-    assert_true(btc_common_encode_xpub(
-        &xpub, BTCPubRequest_XPubType_XPUB, xpub_serialized, sizeof(xpub_serialized)));
+    assert_true(keystore_encode_xpub(&xpub, XPUB, xpub_serialized, sizeof(xpub_serialized)));
     assert_string_equal(xpub_serialized, expected_xpub);
 
     uint8_t hash160[20];


### PR DESCRIPTION
It is about key material (ext_key aka xpub) and is used not only in
BTC, but also in ETH and for computing the electrum encryption key.