### PR TITLE
CMakeLists: bump version to 9.2.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,9 +89,9 @@ endif()
 #
 # Versions MUST contain three parts and start with lowercase 'v'.
 # Example 'v1.0.0'. They MUST not contain a pre-release label such as '-beta'.
-set(FIRMWARE_VERSION "v9.2.0")
-set(FIRMWARE_BTC_ONLY_VERSION "v9.2.0")
-set(FIRMWARE_BITBOXBASE_VERSION "v9.2.0")
+set(FIRMWARE_VERSION "v9.2.1")
+set(FIRMWARE_BTC_ONLY_VERSION "v9.2.1")
+set(FIRMWARE_BITBOXBASE_VERSION "v9.2.1")
 set(BOOTLOADER_VERSION "v1.0.2")
 
 find_package(PythonInterp 3.6 REQUIRED)


### PR DESCRIPTION
Fixes a reproducible builds issue of 9.2.0.