### PR TITLE
rust/async: return value directly from the option future

### DIFF
--- a/src/rust/bitbox02-rust/src/bb02_async.rs
+++ b/src/rust/bitbox02-rust/src/bb02_async.rs
@@ -37,16 +37,16 @@ pub fn spin<O>(task: &mut Task<O>) -> Poll<O> {
 pub struct AsyncOption<'a, O>(&'a RefCell<Option<O>>);
 
 impl<O> core::future::Future for AsyncOption<'_, O> {
-    type Output = ();
+    type Output = O;
     fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
-        match *self.0.borrow() {
+        match self.0.borrow_mut().take() {
             None => Poll::Pending,
-            Some(_) => Poll::Ready(()),
+            Some(output) => Poll::Ready(output),
         }
     }
 }
 
-/// Waits for an option to contain a value and returns a copy of that value.
+/// Waits for an option to contain a value and returns that value, leaving `None` in its place.
 /// E.g. `assert_eq!(option(&Some(42)).await, 42)`.
 pub fn option<'a, O>(option: &'a RefCell<Option<O>>) -> AsyncOption<'a, O> {
     AsyncOption(&option)

--- a/src/rust/bitbox02-rust/src/workflow/cancel.rs
+++ b/src/rust/bitbox02-rust/src/workflow/cancel.rs
@@ -50,10 +50,7 @@ pub async fn with_cancel<R>(
     *result_cell.borrow_mut() = None;
     component.screen_stack_push();
     loop {
-        option(&result_cell).await;
-
-        // Take result out of cell, leaving None in its place.
-        let result = result_cell.borrow_mut().take().unwrap();
+        let result = option(&result_cell).await;
         if let Err(Error::Cancelled) = result {
             let params = confirm::Params {
                 title,

--- a/src/rust/bitbox02-rust/src/workflow/confirm.rs
+++ b/src/rust/bitbox02-rust/src/workflow/confirm.rs
@@ -25,7 +25,5 @@ pub async fn confirm(params: &Params<'_>) -> bool {
         *result.borrow_mut() = Some(accepted);
     });
     component.screen_stack_push();
-    option(&result).await;
-    let result = result.borrow();
-    result.unwrap()
+    option(&result).await
 }

--- a/src/rust/bitbox02-rust/src/workflow/password.rs
+++ b/src/rust/bitbox02-rust/src/workflow/password.rs
@@ -49,10 +49,9 @@ pub async fn enter(
         },
     );
     component.screen_stack_push();
-    option(&result).await;
-    drop(component);
-    let result: Result<Password, ()> = result.into_inner().unwrap();
-    result.or(Err(super::cancel::Error::Cancelled))
+    option(&result)
+        .await
+        .or(Err(super::cancel::Error::Cancelled))
 }
 
 /// Prompt the user to enter a password twice. A warning is displayed

--- a/src/rust/bitbox02-rust/src/workflow/sdcard.rs
+++ b/src/rust/bitbox02-rust/src/workflow/sdcard.rs
@@ -21,5 +21,5 @@ pub async fn sdcard(insert: bool) {
         *result.borrow_mut() = Some(());
     });
     component.screen_stack_push();
-    option(&result).await;
+    option(&result).await
 }

--- a/src/rust/bitbox02-rust/src/workflow/status.rs
+++ b/src/rust/bitbox02-rust/src/workflow/status.rs
@@ -21,5 +21,5 @@ pub async fn status(title: &str, status_success: bool) {
         *result.borrow_mut() = Some(());
     });
     component.screen_stack_push();
-    option(&result).await;
+    option(&result).await
 }


### PR DESCRIPTION
Before, the pattern was:

option(&opt).await;
let result = opt.borrow().unwrap()

With unwrap assuming that the option is Some() after the '.await'.

This is unergonomic and has potential for panic. Better:

let result = option(&opt).await;