### PR TITLE
rust: build prost from vendored sources

### DIFF
--- a/src/rust/.cargo/config
+++ b/src/rust/.cargo/config
@@ -3,3 +3,9 @@ replace-with = "vendored-sources"
 
 [source.vendored-sources]
 directory = "vendor"
+
+# Also build git sources from the vendored sources.
+[source."https://github.com/danburkert/prost.git"]
+git = "https://github.com/danburkert/prost.git"
+rev = "6113789f70b69709820becba4242824b4fb3ffec"
+replace-with = "vendored-sources"

--- a/src/rust/bitbox02-rust/Cargo.toml
+++ b/src/rust/bitbox02-rust/Cargo.toml
@@ -40,7 +40,7 @@ default-features = false
 
 [dependencies.prost]
 git = "https://github.com/danburkert/prost.git"
-# keep rev in sync with tools/prost-build/Cargo.toml
+# keep rev in sync with tools/prost-build/Cargo.toml and src/rust/.cargo/config
 rev = "6113789f70b69709820becba4242824b4fb3ffec"
 default-features = false
 features = ["prost-derive"]


### PR DESCRIPTION
All normal deps are already built from vendored sources.

Prost is a git source. Git sources are vendored with `cargo vendor`,
but not automatically build from the vendored sources with `cargo
build`. The added section in the .cargo/config is needed for that, as
explained by the `cargo vendor` output.

See also: https://github.com/rust-lang/cargo/issues/8792