### PR TITLE
rust/bitbox02: fix dangling pointers

### DIFF
--- a/src/rust/bitbox02/src/ui/types.rs
+++ b/src/rust/bitbox02/src/ui/types.rs
@@ -15,6 +15,8 @@
 extern crate alloc;
 use alloc::boxed::Box;
 
+use util::Survive;
+
 // Taking the constant straight from C, as it's excluding the null terminator.
 #[cfg_attr(feature = "testing", allow(dead_code))]
 pub(crate) const MAX_LABEL_SIZE: usize = bitbox02_sys::MAX_LABEL_SIZE as _;
@@ -64,29 +66,34 @@ pub struct ConfirmParams<'a> {
 
 impl<'a> ConfirmParams<'a> {
     #[cfg_attr(feature = "testing", allow(dead_code))]
-    pub(crate) fn to_c_params(&self) -> bitbox02_sys::confirm_params_t {
+    /// `title_scratch` and `body_scratch` exist to keep the data
+    /// alive for as long as the C params live.
+    pub(crate) fn to_c_params(
+        &self,
+        title_scatch: &'a mut [u8; MAX_LABEL_SIZE + 2],
+        body_scratch: &'a mut [u8; MAX_LABEL_SIZE + 2],
+    ) -> Survive<'a, bitbox02_sys::confirm_params_t> {
         // We truncate at a bit higher than MAX_LABEL_SIZE, so the label component will correctly
         // truncate and append '...'.
         const TRUNCATE_SIZE: usize = MAX_LABEL_SIZE + 1;
-
-        bitbox02_sys::confirm_params_t {
-            title: crate::str_to_cstr_force!(
-                crate::util::truncate_str(self.title, TRUNCATE_SIZE),
-                TRUNCATE_SIZE
-            )
-            .as_ptr(),
-            body: crate::str_to_cstr_force!(
-                crate::util::truncate_str(self.body, TRUNCATE_SIZE),
-                TRUNCATE_SIZE
-            )
-            .as_ptr(),
+        *title_scatch = crate::str_to_cstr_force!(
+            crate::util::truncate_str(self.title, TRUNCATE_SIZE),
+            TRUNCATE_SIZE
+        );
+        *body_scratch = crate::str_to_cstr_force!(
+            crate::util::truncate_str(self.body, TRUNCATE_SIZE),
+            TRUNCATE_SIZE
+        );
+        Survive::new(bitbox02_sys::confirm_params_t {
+            title: title_scatch.as_ptr(),
+            body: body_scratch.as_ptr(),
             font: self.font.as_ptr(),
             scrollable: self.scrollable,
             longtouch: self.longtouch,
             accept_only: self.accept_only,
             accept_is_nextarrow: self.accept_is_nextarrow,
             display_size: self.display_size as _,
-        }
+        })
     }
 }
 

--- a/src/rust/bitbox02/src/ui/ui.rs
+++ b/src/rust/bitbox02/src/ui/ui.rs
@@ -104,7 +104,7 @@ where
 
     let component = unsafe {
         bitbox02_sys::trinary_input_string_create_password(
-            crate::str_to_cstr_force!(title, MAX_LABEL_SIZE).as_ptr(),
+            crate::str_to_cstr_force!(title, MAX_LABEL_SIZE).as_ptr(), // copied in C
             special_chars,
             Some(c_confirm_callback::<F>),
             // passed to c_confirm_callback as `param`.
@@ -185,7 +185,7 @@ where
 
     let component = unsafe {
         bitbox02_sys::status_create(
-            crate::str_to_cstr_force!(text, MAX_LABEL_SIZE).as_ptr(),
+            crate::str_to_cstr_force!(text, MAX_LABEL_SIZE).as_ptr(), // copied in C
             status_success,
             Some(c_callback::<F>),
             Box::into_raw(Box::new(callback)) as *mut _, // passed to c_callback as `param`.
@@ -287,6 +287,7 @@ pub fn menu_create(params: MenuParams<'_>) -> Component<'_> {
             select_word_cb,
             select_word_cb_param,
             words.len() as _,
+            // copied in C
             title.map_or_else(|| core::ptr::null(), |title| title.as_ptr()),
             continue_on_last_cb,
             continue_on_last_cb_param,

--- a/src/rust/bitbox02/src/ui/ui.rs
+++ b/src/rust/bitbox02/src/ui/ui.rs
@@ -142,10 +142,13 @@ where
         let mut callback = Box::from_raw(param as *mut F2);
         callback(result);
     }
-
+    let mut title_scratch = [0; MAX_LABEL_SIZE + 2];
+    let mut body_scratch = [0; MAX_LABEL_SIZE + 2];
     let component = unsafe {
         bitbox02_sys::confirm_create(
-            &params.to_c_params(),
+            &params
+                .to_c_params(&mut title_scratch, &mut body_scratch)
+                .data,
             Some(c_callback::<F>),
             // passed to the C callback as `param`
             Box::into_raw(Box::new(result_callback)) as *mut _,

--- a/src/rust/util/src/lib.rs
+++ b/src/rust/util/src/lib.rs
@@ -25,6 +25,21 @@ pub fn zero(dst: &mut [u8]) {
     }
 }
 
+/// Survive forces T to live at least as long as lifetme 'a.
+pub struct Survive<'a, T: 'a> {
+    pub data: T,
+    phantom: core::marker::PhantomData<&'a T>,
+}
+
+impl<'a, T> Survive<'a, T> {
+    pub fn new(data: T) -> Self {
+        Survive {
+            data,
+            phantom: core::marker::PhantomData,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     extern crate std;


### PR DESCRIPTION
The title/body buffers are dropped by the end of `to_c_params()`, but
the pointer survived.