### PR TITLE
Multisig name on device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## 9.3.0 [version may change, pending release]
+- Enter multisig account name on the device if the name in BTCRegisterScriptConfigRequest is empty.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,9 +89,9 @@ endif()
 #
 # Versions MUST contain three parts and start with lowercase 'v'.
 # Example 'v1.0.0'. They MUST not contain a pre-release label such as '-beta'.
-set(FIRMWARE_VERSION "v9.2.1")
-set(FIRMWARE_BTC_ONLY_VERSION "v9.2.1")
-set(FIRMWARE_BITBOXBASE_VERSION "v9.2.1")
+set(FIRMWARE_VERSION "v9.3.0")
+set(FIRMWARE_BTC_ONLY_VERSION "v9.3.0")
+set(FIRMWARE_BITBOXBASE_VERSION "v9.3.0")
 set(BOOTLOADER_VERSION "v1.0.3")
 
 find_package(PythonInterp 3.6 REQUIRED)

--- a/messages/btc.proto
+++ b/messages/btc.proto
@@ -164,6 +164,7 @@ message BTCIsScriptConfigRegisteredResponse {
 
 message BTCRegisterScriptConfigRequest {
   BTCScriptConfigRegistration registration = 1;
+  // If empty, the name is entered on the device instead.
   string name = 2;
   enum XPubType {
     // Automatically choose to match Electrum's xpub format (e.g. Zpub/Vpub for p2wsh multisig mainnet/testnet).

--- a/src/apps/btc/btc.h
+++ b/src/apps/btc/btc.h
@@ -121,7 +121,7 @@ USE_RESULT bool app_btc_is_script_config_registered(
  * Stores a script configuration alongside a user chosen name on the device. If the user aborts,
  * nothing is stored.
  * @param[in] name Name to give to the script config. Must be at most MEMORY_MULTISIG_NAME_MAX_LEN
- * bytes (including null terminator).
+ * bytes (including null terminator). If it is the empty string, the name is entered on the device.
  * @return OK if the registration was successful, ERR_USER_ABORT if the user aborted, ERR_UNKNOWN
  * for unknown errors.
  */

--- a/src/rust/bitbox02-rust-c/src/util.rs
+++ b/src/rust/bitbox02-rust-c/src/util.rs
@@ -142,6 +142,10 @@ pub struct CStrMut {
 }
 
 impl CStrMut {
+    pub fn cap(&self) -> usize {
+        self.cap
+    }
+
     /// Create a new growable string with capacity `cap`. Only allowed for non-null pointers with
     /// length or null pointers with 0 length due to limitation in `core::slice`. Unsafe because it
     /// will read until it finds a null character.

--- a/src/rust/bitbox02-rust/src/hww/api/shiftcrypto.bitbox02.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/shiftcrypto.bitbox02.rs
@@ -452,6 +452,7 @@ pub struct BtcIsScriptConfigRegisteredResponse {
 pub struct BtcRegisterScriptConfigRequest {
     #[prost(message, optional, tag="1")]
     pub registration: ::core::option::Option<BtcScriptConfigRegistration>,
+    /// If empty, the name is entered on the device instead.
     #[prost(string, tag="2")]
     pub name: ::prost::alloc::string::String,
     #[prost(enumeration="btc_register_script_config_request::XPubType", tag="3")]

--- a/src/rust/bitbox02-rust/src/workflow.rs
+++ b/src/rust/bitbox02-rust/src/workflow.rs
@@ -19,5 +19,6 @@ pub mod pairing;
 pub mod password;
 pub mod sdcard;
 pub mod status;
+pub mod trinary_input_string;
 pub mod unlock;
 pub mod verify_message;

--- a/src/rust/bitbox02-rust/src/workflow/trinary_input_string.rs
+++ b/src/rust/bitbox02-rust/src/workflow/trinary_input_string.rs
@@ -1,0 +1,49 @@
+// Copyright 2020 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub use bitbox02::ui::TrinaryInputStringParams as Params;
+
+use crate::bb02_async::option;
+use bitbox02::input::SafeInputString;
+use core::cell::RefCell;
+
+extern crate alloc;
+use alloc::boxed::Box;
+
+pub enum CanCancel {
+    No,
+    Yes,
+}
+
+/// If `can_cancel` is `Yes`, the workflow can be cancelled.
+/// If it is no, the result is always `Ok(())`.
+/// ```
+pub async fn enter(
+    params: &Params<'_>,
+    can_cancel: CanCancel,
+) -> Result<SafeInputString, super::cancel::Error> {
+    let result = RefCell::new(None as Option<Result<SafeInputString, ()>>); // Err means cancelled.
+    let mut component = bitbox02::ui::trinary_input_string_create(
+        &params,
+        |string| *result.borrow_mut() = Some(Ok(string)),
+        match can_cancel {
+            CanCancel::Yes => Some(Box::new(|| *result.borrow_mut() = Some(Err(())))),
+            CanCancel::No => None,
+        },
+    );
+    component.screen_stack_push();
+    option(&result)
+        .await
+        .or(Err(super::cancel::Error::Cancelled))
+}


### PR DESCRIPTION
Can test by showing a multisig receive address in send_message, and when prompted for the name, submit the empty string.