### PR TITLE
apps/btc: use sorted xpubs when registering multisig accounts

### DIFF
--- a/src/apps/btc/btc.c
+++ b/src/apps/btc/btc.c
@@ -257,7 +257,7 @@ app_btc_result_t app_btc_register_script_config(
     }
 
     uint8_t hash[SHA256_LEN] = {0};
-    if (!btc_common_multisig_hash_unsorted(coin, multisig, keypath, keypath_len, hash)) {
+    if (!btc_common_multisig_hash_sorted(coin, multisig, keypath, keypath_len, hash)) {
         return APP_BTC_ERR_UNKNOWN;
     }
     // This will rename the multisig config if it already exists.

--- a/src/apps/btc/btc.c
+++ b/src/apps/btc/btc.c
@@ -128,13 +128,9 @@ app_btc_result_t app_btc_address_multisig(
     }
 
     // Confirm previously registered multisig.
-    uint8_t multisig_hash[SHA256_LEN] = {0};
-    if (!btc_common_multisig_hash_unsorted(
-            coin, multisig, keypath, keypath_len - 2, multisig_hash)) {
-        return APP_BTC_ERR_UNKNOWN;
-    }
     char multisig_registered_name[MEMORY_MULTISIG_NAME_MAX_LEN] = {0};
-    if (!memory_multisig_get_by_hash(multisig_hash, multisig_registered_name)) {
+    if (!btc_common_multisig_name(
+            coin, multisig, keypath, keypath_len - 2, multisig_registered_name)) {
         // Not previously registered -> fail.
         return APP_BTC_ERR_INVALID_INPUT;
     }
@@ -204,13 +200,8 @@ bool app_btc_is_script_config_registered(
         return false;
     }
 
-    uint8_t hash[SHA256_LEN] = {0};
-    if (!btc_common_multisig_hash_unsorted(
-            coin, &script_config->config.multisig, keypath, keypath_len, hash)) {
-        return false;
-    }
-
-    *is_registered = memory_multisig_get_by_hash(hash, NULL);
+    *is_registered =
+        btc_common_multisig_name(coin, &script_config->config.multisig, keypath, keypath_len, NULL);
 
     return true;
 }

--- a/src/apps/btc/btc_common.c
+++ b/src/apps/btc/btc_common.c
@@ -20,6 +20,7 @@
 #include <apps/common/bip32.h>
 #include <hardfault.h>
 #include <keystore.h>
+#include <memory/memory.h>
 #include <rust/rust.h>
 #include <util.h>
 #include <wally_address.h>
@@ -813,4 +814,19 @@ bool btc_common_multisig_hash_sorted(
     uint8_t* hash_out)
 {
     return _multisig_hash(coin, multisig, true, keypath, keypath_len, hash_out);
+}
+
+bool btc_common_multisig_name(
+    BTCCoin coin,
+    const BTCScriptConfig_Multisig* multisig,
+    const uint32_t* keypath,
+    size_t keypath_len,
+    char* name_out)
+{
+    uint8_t hash[SHA256_LEN] = {0};
+    if (!btc_common_multisig_hash_unsorted(coin, multisig, keypath, keypath_len, hash)) {
+        return false;
+    }
+
+    return memory_multisig_get_by_hash(hash, name_out);
 }

--- a/src/apps/btc/btc_common.c
+++ b/src/apps/btc/btc_common.c
@@ -824,9 +824,18 @@ bool btc_common_multisig_name(
     char* name_out)
 {
     uint8_t hash[SHA256_LEN] = {0};
+
+    // First try using sorted xpubs (the default registration since v9.3.0).
+    if (!btc_common_multisig_hash_sorted(coin, multisig, keypath, keypath_len, hash)) {
+        return false;
+    }
+    if (memory_multisig_get_by_hash(hash, name_out)) {
+        return true;
+    }
+
+    // If that did not exist, try with unsorted xpubs for backwards compatibility.
     if (!btc_common_multisig_hash_unsorted(coin, multisig, keypath, keypath_len, hash)) {
         return false;
     }
-
     return memory_multisig_get_by_hash(hash, name_out);
 }

--- a/src/apps/btc/btc_common.h
+++ b/src/apps/btc/btc_common.h
@@ -271,4 +271,25 @@ USE_RESULT bool btc_common_multisig_hash_sorted(
     size_t keypath_len,
     uint8_t* hash_out);
 
+/**
+ * Get the name of a registered multisig account. If `name` is NULL, this serves as a check whether
+ * the account was registered.
+ *
+ * The individual params are not validated, they must be pre-validated!
+ *
+ * @param[in] coin The coin this multisig is used with.
+ * @param[in] multisig The multisig config details.
+ * @param[in] keypath Account-level keypath.
+ * @param[in] keypath_len number of elements in keypath.
+ * @param[out] name_out will contain the name. Must have at least `MEMORY_MULTISIG_NAME_MAX_LEN`
+ * bytes. Can be NULL.
+ * @return true on success, false on failure.
+ */
+USE_RESULT bool btc_common_multisig_name(
+    BTCCoin coin,
+    const BTCScriptConfig_Multisig* multisig,
+    const uint32_t* keypath,
+    size_t keypath_len,
+    char* name_out);
+
 #endif

--- a/src/apps/btc/btc_sign_validate.c
+++ b/src/apps/btc/btc_sign_validate.c
@@ -51,17 +51,13 @@ app_btc_result_t app_btc_sign_validate_init_script_configs(
                 coin_params->bip44_coin)) {
             return APP_BTC_ERR_INVALID_INPUT;
         }
-        uint8_t multisig_hash[SHA256_LEN] = {0};
-        if (!btc_common_multisig_hash_unsorted(
+        char multisig_registered_name[MEMORY_MULTISIG_NAME_MAX_LEN] = {0};
+        if (!btc_common_multisig_name(
                 coin,
                 multisig,
                 script_config->keypath,
                 script_config->keypath_count,
-                multisig_hash)) {
-            return APP_BTC_ERR_INVALID_INPUT;
-        };
-        char multisig_registered_name[MEMORY_MULTISIG_NAME_MAX_LEN] = {0};
-        if (!memory_multisig_get_by_hash(multisig_hash, multisig_registered_name)) {
+                multisig_registered_name)) {
             // Not previously registered -> fail.
             return APP_BTC_ERR_INVALID_INPUT;
         }

--- a/src/memory/memory.h
+++ b/src/memory/memory.h
@@ -244,8 +244,8 @@ USE_RESULT memory_result_t memory_multisig_set_by_hash(const uint8_t* hash, cons
 /**
  * Retrieves the name of a previously stored multisig config identified by `hash`.
  * @param[in] hash hash identifying the multisig config.
- * @param[out] name_out will contain the name. Must have at least
- * `MEMORY_MULTISIG_NAME_MAX_LEN` bytes. Can be NULL.
+ * @param[out] name_out will contain the name. Must have at least `MEMORY_MULTISIG_NAME_MAX_LEN`
+ * bytes. Can be NULL.
  * @return true if the multisig config was found, false otherwise.
  */
 USE_RESULT bool memory_multisig_get_by_hash(const uint8_t* hash, char* name_out);


### PR DESCRIPTION
Any order of xpubs identifies the same xpub account, and some
downstream projects pass them in in arbitrary order.

When checking for a registered account, we check with both the ordered
and unordered xpubs for backwards compatibility.