### PR TITLE
apps/btc/multisig: confirm script type and keypath during registration

### DIFF
--- a/src/apps/btc/btc.c
+++ b/src/apps/btc/btc.c
@@ -249,7 +249,8 @@ app_btc_result_t app_btc_register_script_config(
         return APP_BTC_ERR_INVALID_INPUT;
     }
 
-    if (!apps_btc_confirm_multisig_extended("Register", coin, name, multisig, xpub_type)) {
+    if (!apps_btc_confirm_multisig_extended(
+            "Register", coin, name, multisig, xpub_type, keypath, keypath_len)) {
         return APP_BTC_ERR_USER_ABORT;
     }
 

--- a/src/apps/btc/btc.c
+++ b/src/apps/btc/btc.c
@@ -137,10 +137,7 @@ app_btc_result_t app_btc_address_multisig(
 
     const char* title = "Receive to";
 
-    BTCRegisterScriptConfigRequest_XPubType ignored =
-        BTCRegisterScriptConfigRequest_XPubType_AUTO_ELECTRUM;
-    if (!apps_btc_confirm_multisig(
-            title, coin, multisig_registered_name, multisig, false, ignored)) {
+    if (!apps_btc_confirm_multisig_basic(title, coin, multisig_registered_name, multisig)) {
         return APP_BTC_ERR_USER_ABORT;
     }
 
@@ -252,7 +249,7 @@ app_btc_result_t app_btc_register_script_config(
         return APP_BTC_ERR_INVALID_INPUT;
     }
 
-    if (!apps_btc_confirm_multisig("Register", coin, name, multisig, true, xpub_type)) {
+    if (!apps_btc_confirm_multisig_extended("Register", coin, name, multisig, xpub_type)) {
         return APP_BTC_ERR_USER_ABORT;
     }
 

--- a/src/apps/btc/btc_sign_validate.c
+++ b/src/apps/btc/btc_sign_validate.c
@@ -61,10 +61,8 @@ app_btc_result_t app_btc_sign_validate_init_script_configs(
             // Not previously registered -> fail.
             return APP_BTC_ERR_INVALID_INPUT;
         }
-        BTCRegisterScriptConfigRequest_XPubType ignored =
-            BTCRegisterScriptConfigRequest_XPubType_AUTO_ELECTRUM;
-        if (!apps_btc_confirm_multisig(
-                "Spend from", coin, multisig_registered_name, multisig, false, ignored)) {
+        if (!apps_btc_confirm_multisig_basic(
+                "Spend from", coin, multisig_registered_name, multisig)) {
             return APP_BTC_ERR_USER_ABORT;
         }
         return APP_BTC_OK;

--- a/src/apps/btc/confirm_multisig.c
+++ b/src/apps/btc/confirm_multisig.c
@@ -21,13 +21,11 @@
 
 #include <stdio.h>
 
-bool apps_btc_confirm_multisig(
+bool apps_btc_confirm_multisig_basic(
     const char* title,
     BTCCoin coin,
     const char* name,
-    const BTCScriptConfig_Multisig* multisig,
-    bool verify_xpubs,
-    BTCRegisterScriptConfigRequest_XPubType xpub_type)
+    const BTCScriptConfig_Multisig* multisig)
 {
     char basic_info[100] = {0};
     int snprintf_result = snprintf(
@@ -55,12 +53,18 @@ bool apps_btc_confirm_multisig(
         .scrollable = true,
         .accept_is_nextarrow = true,
     };
-    if (!workflow_confirm_blocking(&params_name)) {
-        return false;
-    }
+    return workflow_confirm_blocking(&params_name);
+}
 
-    if (!verify_xpubs) {
-        return true;
+bool apps_btc_confirm_multisig_extended(
+    const char* title,
+    BTCCoin coin,
+    const char* name,
+    const BTCScriptConfig_Multisig* multisig,
+    BTCRegisterScriptConfigRequest_XPubType xpub_type)
+{
+    if (!apps_btc_confirm_multisig_basic(title, coin, name, multisig)) {
+        return false;
     }
 
     BTCPubRequest_XPubType output_xpub_type;
@@ -128,25 +132,25 @@ bool apps_btc_confirm_multisig(
         }
         char confirm[XPUB_ENCODED_LEN + 100] = {0};
         if (i == multisig->our_xpub_index) {
-            snprintf_result = snprintf(
+            int result = snprintf(
                 confirm,
                 sizeof(confirm),
                 "Cosigner %lu/%lu (this device): %s",
                 (unsigned long)(i + 1),
                 (unsigned long)num_cosigners,
                 xpub_str);
-            if (snprintf_result < 0 || snprintf_result >= (int)sizeof(confirm)) {
+            if (result < 0 || result >= (int)sizeof(confirm)) {
                 Abort("apps_btc_confirm_multisig/1");
             }
         } else {
-            snprintf_result = snprintf(
+            int result = snprintf(
                 confirm,
                 sizeof(confirm),
                 "Cosigner %lu/%lu: %s",
                 (unsigned long)(i + 1),
                 (unsigned long)num_cosigners,
                 xpub_str);
-            if (snprintf_result < 0 || snprintf_result >= (int)sizeof(confirm)) {
+            if (result < 0 || result >= (int)sizeof(confirm)) {
                 Abort("apps_btc_confirm_multisig/2");
             }
         }

--- a/src/apps/btc/confirm_multisig.h
+++ b/src/apps/btc/confirm_multisig.h
@@ -20,28 +20,43 @@
 #include <stdbool.h>
 
 /**
- * Confirms a multisig setup with the user.
+ * Confirms a multisig setup with the user during send/receive.
  * Verified are:
  * - coin
  * - multisig type (m-of-n)
  * - name given by the user
- * - if verify_xpubs, all xpubs (formatted as Zpubs on mainnet; Vpubs on testnet).
  * @param[in] title the title shown in each confirmation screen
  * @param[in] coin coin to be confirmed
  * @param[in] name User given name of the multisig account.
  * @param[in] multisig multisig details
- * @param[in] verify_xpubs if true, all cosigner xpubs are verified.
+ */
+USE_RESULT bool apps_btc_confirm_multisig_basic(
+    const char* title,
+    BTCCoin coin,
+    const char* name,
+    const BTCScriptConfig_Multisig* multisig);
+
+/**
+ * Confirms a multisig setup with the user during account registration.
+ * Verified are:
+ * - coin
+ * - multisig type (m-of-n)
+ * - name given by the user
+ * - all xpubs (formatted according to `xpub_type`).
+ * @param[in] title the title shown in each confirmation screen
+ * @param[in] coin coin to be confirmed
+ * @param[in] name User given name of the multisig account.
+ * @param[in] multisig multisig details
  * @param[in] xpub_type: if AUTO_ELECTRUM, will automatically format xpubs as `Zpub/Vpub`,
  * `Ypub/UPub` depending on the script type, to match Electrum's formatting. If AUTO_XPUB_TPUB,
  * format as xpub (mainnets) or tpub (testnets). Only applies if `verify_xpubs` is true.
  * @return true if the user accepts all confirmation screens, false otherwise.
  */
-USE_RESULT bool apps_btc_confirm_multisig(
+USE_RESULT bool apps_btc_confirm_multisig_extended(
     const char* title,
     BTCCoin coin,
     const char* name,
     const BTCScriptConfig_Multisig* multisig,
-    bool verify_xpubs,
     BTCRegisterScriptConfigRequest_XPubType xpub_type);
 
 #endif

--- a/src/apps/btc/confirm_multisig.h
+++ b/src/apps/btc/confirm_multisig.h
@@ -42,6 +42,8 @@ USE_RESULT bool apps_btc_confirm_multisig_basic(
  * - coin
  * - multisig type (m-of-n)
  * - name given by the user
+ * - script type (e.g. p2wsh, p2wsh-p2sh)
+ * - account keypath
  * - all xpubs (formatted according to `xpub_type`).
  * @param[in] title the title shown in each confirmation screen
  * @param[in] coin coin to be confirmed
@@ -57,6 +59,8 @@ USE_RESULT bool apps_btc_confirm_multisig_extended(
     BTCCoin coin,
     const char* name,
     const BTCScriptConfig_Multisig* multisig,
-    BTCRegisterScriptConfigRequest_XPubType xpub_type);
+    BTCRegisterScriptConfigRequest_XPubType xpub_type,
+    const uint32_t* keypath,
+    size_t keypath_len);
 
 #endif

--- a/src/rust/bitbox02-rust-c/src/bip32.rs
+++ b/src/rust/bitbox02-rust-c/src/bip32.rs
@@ -1,0 +1,27 @@
+// Copyright 2020 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use core::fmt::Write;
+use util::c_types::size_t;
+
+/// Safety: keypath must be a valid buffer of `usize` elements of `uint32_t`-sized elements.
+#[no_mangle]
+pub unsafe extern "C" fn rust_bip32_to_string(
+    keypath: *const u32,
+    keypath_len: size_t,
+    mut out: crate::util::CStrMut,
+) {
+    let keypath_string = util::bip32::to_string(core::slice::from_raw_parts(keypath, keypath_len));
+    out.write_str(keypath_string.as_str()).unwrap()
+}

--- a/src/rust/bitbox02-rust-c/src/lib.rs
+++ b/src/rust/bitbox02-rust-c/src/lib.rs
@@ -30,6 +30,8 @@ mod util;
 #[cfg(feature = "firmware")]
 mod async_usb;
 #[cfg(feature = "firmware")]
+mod bip32;
+#[cfg(feature = "firmware")]
 mod noise;
 #[cfg(feature = "firmware")]
 mod sha2;

--- a/src/rust/util/src/lib.rs
+++ b/src/rust/util/src/lib.rs
@@ -18,6 +18,10 @@ pub mod bip32;
 pub mod c_types;
 pub mod name;
 
+// for `format!`
+#[macro_use]
+extern crate alloc;
+
 /// Guaranteed to wipe the provided buffer
 pub fn zero(dst: &mut [u8]) {
     for p in dst {

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -173,7 +173,7 @@ set(TEST_LIST
    app_btc
    "-Wl,--wrap=keystore_get_xpub,--wrap=btc_common_is_valid_keypath_xpub,--wrap=btc_common_is_valid_keypath_address_simple,--wrap=btc_common_encode_xpub,--wrap=btc_common_outputhash_from_pubkeyhash"
    app_btc_multisig
-   "-Wl,--wrap=memory_multisig_get_by_hash,--wrap=apps_btc_confirm_multisig"
+   "-Wl,--wrap=memory_multisig_get_by_hash,--wrap=apps_btc_confirm_multisig_basic"
    app_btc_common
    ""
    app_btc_confirm_locktime_rbf
@@ -191,7 +191,7 @@ set(TEST_LIST
    btc_sign
    "-Wl,--wrap=workflow_verify_recipient,--wrap=workflow_confirm_blocking,--wrap=workflow_verify_total,--wrap=apps_btc_confirm_locktime_rbf,--wrap=btc_common_format_amount,--wrap=btc_common_is_valid_keypath_address_simple"
    app_btc_sign_multisig
-   "-Wl,--wrap=workflow_verify_recipient,--wrap=workflow_verify_total,--wrap=apps_btc_confirm_locktime_rbf,--wrap=memory_multisig_get_by_hash,--wrap=apps_btc_confirm_multisig"
+   "-Wl,--wrap=workflow_verify_recipient,--wrap=workflow_verify_total,--wrap=apps_btc_confirm_locktime_rbf,--wrap=memory_multisig_get_by_hash,--wrap=apps_btc_confirm_multisig_basic"
    memory
    "-Wl,--wrap=memory_read_chunk_mock,--wrap=memory_write_chunk_mock,--wrap=rust_noise_generate_static_private_key,--wrap=memory_read_shared_bootdata_mock,--wrap=memory_write_to_address_mock"
    memory_functional

--- a/test/unit-test/test_app_btc_multisig.c
+++ b/test/unit-test/test_app_btc_multisig.c
@@ -39,19 +39,17 @@ bool __wrap_memory_multisig_get_by_hash(const uint8_t* hash, char* name_out)
     return true;
 }
 
-bool __wrap_apps_btc_confirm_multisig(
+bool __wrap_apps_btc_confirm_multisig_basic(
     const char* title,
     BTCCoin coin,
     const char* name,
     const BTCScriptConfig_Multisig* multisig,
-    bool verify_xpubs,
-    BTCRegisterScriptConfigRequest_XPubType xpub_type)
+    bool verify_xpubs)
 {
     assert_string_equal(title, "Receive to");
     check_expected(coin);
     assert_string_equal(name, _multisig_name);
     check_expected(multisig);
-    assert_false(verify_xpubs);
     return true;
 }
 
@@ -208,8 +206,9 @@ static void _test_app_btc_address_multisig(void** state)
         }
 
         char out[XPUB_ENCODED_LEN] = {0};
-        expect_value(__wrap_apps_btc_confirm_multisig, coin, test_case->coin);
-        expect_memory(__wrap_apps_btc_confirm_multisig, multisig, &multisig, sizeof(multisig));
+        expect_value(__wrap_apps_btc_confirm_multisig_basic, coin, test_case->coin);
+        expect_memory(
+            __wrap_apps_btc_confirm_multisig_basic, multisig, &multisig, sizeof(multisig));
         bool result = app_btc_address_multisig(
             test_case->coin,
             &multisig,

--- a/test/unit-test/test_app_btc_sign_multisig.c
+++ b/test/unit-test/test_app_btc_sign_multisig.c
@@ -36,18 +36,16 @@ bool __wrap_memory_multisig_get_by_hash(const uint8_t* hash, char* name_out)
     return true;
 }
 
-bool __wrap_apps_btc_confirm_multisig(
+bool __wrap_apps_btc_confirm_multisig_basic(
     const char* title,
     BTCCoin coin,
     const char* name,
-    const BTCScriptConfig_Multisig* multisig,
-    bool verify_xpubs)
+    const BTCScriptConfig_Multisig* multisig)
 {
     assert_string_equal(title, "Spend from");
     check_expected(coin);
     assert_string_equal(name, _multisig_name);
     check_expected(multisig);
-    assert_false(verify_xpubs);
     return true;
 }
 
@@ -244,9 +242,9 @@ static void _test_tx(const _tx* tx, const uint8_t* expected_signature)
 
     BTCSignNextResponse next = {0};
 
-    expect_value(__wrap_apps_btc_confirm_multisig, coin, tx->init_req.coin);
+    expect_value(__wrap_apps_btc_confirm_multisig_basic, coin, tx->init_req.coin);
     expect_memory(
-        __wrap_apps_btc_confirm_multisig,
+        __wrap_apps_btc_confirm_multisig_basic,
         multisig,
         &tx->init_req.script_configs[0].script_config.config.multisig,
         sizeof(BTCScriptConfig_Multisig));


### PR DESCRIPTION
Currently we allow only:

m/48'/0'/0'/1' for p2wsh-p2sh
m/48'/0'/0'/2' for p2wsh

Since we only support so few keypaths and script types, we could get
away with skipping verification of them.

We also want to whitelist m/48'/0'/0' for both script types, which is
the keypath used by Nunchuk for any script type. Then it becomes more
important to verify the script type and keypath that is being
registered. 