### PR TITLE
py/bitbox02: exception for empty multisig acct names on old firmware 

### DIFF
--- a/py/bitbox02/bitbox02/bitbox02/__init__.py
+++ b/py/bitbox02/bitbox02/bitbox02/__init__.py
@@ -16,7 +16,7 @@
 from __future__ import print_function
 import sys
 
-__version__ = "5.0.0"
+__version__ = "5.1.0"
 
 if sys.version_info.major != 3 or sys.version_info.minor < 6:
     print(

--- a/py/bitbox02/bitbox02/bitbox02/bitbox02.py
+++ b/py/bitbox02/bitbox02/bitbox02/bitbox02.py
@@ -327,8 +327,14 @@ class BitBox02(BitBoxCommonAPI):
     ) -> None:
         """
         Raises Bitbox02Exception with ERR_USER_ABORT on user abort.
+        If name is the empty string, it will be prompted on the device.
         """
         # pylint: disable=no-member,too-many-arguments
+
+        if name == "":
+            # prompt on device only available since v9.3.0
+            self._require_atleast(semver.VersionInfo(9, 3, 0))
+
         assert len(name) <= 30
 
         # pylint: disable=no-member


### PR DESCRIPTION
Empty account name means the user will be prompted on the device. This
feature is only available since 9.3.0. This patch informs the user to
upgrade if they use this feature, e.g. in HWI.