### PR TITLE
qtouch: fix device lockup due to a race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 9.3.1
+- Fix a bug where the device could freeze and become unresponsive.
+
 ## 9.3.0 [tagged 2020-11-23]
 - Enter multisig account name on the device if the name in BTCRegisterScriptConfigRequest is empty.
 - Allow new keypaths: m/48'/coin'/account' for multisig, to enable compatibility with the Nunchuk wallet.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,9 +89,9 @@ endif()
 #
 # Versions MUST contain three parts and start with lowercase 'v'.
 # Example 'v1.0.0'. They MUST not contain a pre-release label such as '-beta'.
-set(FIRMWARE_VERSION "v9.3.0")
-set(FIRMWARE_BTC_ONLY_VERSION "v9.3.0")
-set(FIRMWARE_BITBOXBASE_VERSION "v9.3.0")
+set(FIRMWARE_VERSION "v9.3.1")
+set(FIRMWARE_BTC_ONLY_VERSION "v9.3.1")
+set(FIRMWARE_BITBOXBASE_VERSION "v9.3.1")
 set(BOOTLOADER_VERSION "v1.0.3")
 
 find_package(PythonInterp 3.6 REQUIRED)

--- a/src/qtouch/qtouch.c
+++ b/src/qtouch/qtouch.c
@@ -703,8 +703,10 @@ Notes    :  none
 ============================================================================*/
 void ADC0_1_Handler(void)
 {
+    CRITICAL_SECTION_ENTER()
     ADC0->INTFLAG.reg |= 1U;
     qtm_samd51_ptc_handler();
+    CRITICAL_SECTION_LEAVE()
 }
 
 #endif /* TOUCH_C */


### PR DESCRIPTION
There were occasional non-deterministic device freezes where
processing would stop completely.

Using gdb in semihosting, we saw that it gets stuck in
`qtm_measure_node()`, called from `qtm_samd51_ptc_handler()`.

Making the interrupt call a critical section, making the section
atomic, seems to fix the issue.

It is not 100% clear what was going on, but one theory is that the
interrupt is called while the interrupt is running, stepping on its
own feet. The more USB requests are processed, the more likely a
freeze was, which could mean that the usb requests make the execution
time of the qtouch interrupt longer, increasing the chance of a race
condition.