### PR TITLE
external: upgrade cryptoauthlib

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -223,7 +223,6 @@ set_property(TARGET asf4-drivers PROPERTY INTERFACE_LINK_LIBRARIES "")
   )
   target_link_libraries(cryptoauthlib samd51a-ds asf4-drivers-min)
   set_property(TARGET cryptoauthlib PROPERTY INTERFACE_LINK_LIBRARIES "")
-  target_compile_definitions(cryptoauthlib PUBLIC ATCA_NO_POLL)
   target_include_directories(cryptoauthlib SYSTEM PUBLIC
     cryptoauthlib/lib
     ${CMAKE_CURRENT_SOURCE_DIR} # for the BitBox02-custom "atca_config.h"

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -192,37 +192,46 @@ set_property(TARGET asf4-drivers PROPERTY INTERFACE_LINK_LIBRARIES "")
     cryptoauthlib/lib/atca_cfgs.c
     cryptoauthlib/lib/atca_command.c
     cryptoauthlib/lib/atca_device.c
-    cryptoauthlib/lib/atca_execution.c
     cryptoauthlib/lib/atca_iface.c
     cryptoauthlib/lib/hal/atca_hal.c
     cryptoauthlib/lib/hal/hal_timer_start.c
-    cryptoauthlib/lib/basic/atca_basic.c
-    cryptoauthlib/lib/basic/atca_basic_counter.c
-    cryptoauthlib/lib/basic/atca_basic_gendig.c
-    cryptoauthlib/lib/basic/atca_basic_nonce.c
-    cryptoauthlib/lib/basic/atca_basic_checkmac.c
-    cryptoauthlib/lib/basic/atca_basic_info.c
-    cryptoauthlib/lib/basic/atca_basic_derivekey.c
-    cryptoauthlib/lib/basic/atca_basic_random.c
-    cryptoauthlib/lib/basic/atca_basic_selftest.c
-    cryptoauthlib/lib/basic/atca_basic_read.c
-    cryptoauthlib/lib/basic/atca_basic_privwrite.c
-    cryptoauthlib/lib/basic/atca_basic_verify.c
-    cryptoauthlib/lib/basic/atca_basic_write.c
-    cryptoauthlib/lib/basic/atca_basic_updateextra.c
-    cryptoauthlib/lib/basic/atca_basic_lock.c
-    cryptoauthlib/lib/basic/atca_basic_kdf.c
-    cryptoauthlib/lib/basic/atca_basic_genkey.c
-    cryptoauthlib/lib/basic/atca_basic_sign.c
+    cryptoauthlib/lib/atca_basic.c
+    cryptoauthlib/lib/atca_debug.c
+    cryptoauthlib/lib/calib/calib_basic.c
+    cryptoauthlib/lib/calib/calib_command.c
+    cryptoauthlib/lib/calib/calib_execution.c
+    cryptoauthlib/lib/calib/calib_counter.c
+    cryptoauthlib/lib/calib/calib_gendig.c
+    cryptoauthlib/lib/calib/calib_nonce.c
+    cryptoauthlib/lib/calib/calib_checkmac.c
+    cryptoauthlib/lib/calib/calib_info.c
+    cryptoauthlib/lib/calib/calib_derivekey.c
+    cryptoauthlib/lib/calib/calib_random.c
+    cryptoauthlib/lib/calib/calib_selftest.c
+    cryptoauthlib/lib/calib/calib_read.c
+    cryptoauthlib/lib/calib/calib_privwrite.c
+    cryptoauthlib/lib/calib/calib_verify.c
+    cryptoauthlib/lib/calib/calib_write.c
+    cryptoauthlib/lib/calib/calib_updateextra.c
+    cryptoauthlib/lib/calib/calib_lock.c
+    cryptoauthlib/lib/calib/calib_kdf.c
+    cryptoauthlib/lib/calib/calib_genkey.c
+    cryptoauthlib/lib/calib/calib_sign.c
     cryptoauthlib/lib/host/atca_host.c
     cryptoauthlib/lib/crypto/hashes/sha2_routines.c
     cryptoauthlib/lib/crypto/atca_crypto_sw_sha2.c
   )
   target_link_libraries(cryptoauthlib samd51a-ds asf4-drivers-min)
   set_property(TARGET cryptoauthlib PROPERTY INTERFACE_LINK_LIBRARIES "")
-  target_compile_definitions(cryptoauthlib PUBLIC ATCA_HAL_CUSTOM ATCA_NO_POLL)
-  target_include_directories(cryptoauthlib SYSTEM PUBLIC cryptoauthlib/lib)
-  target_compile_options(cryptoauthlib PRIVATE -Wno-pedantic -Wno-incompatible-pointer-types -Wno-unused-parameter -Wno-unused-variable -Wno-cast-qual)
+  target_compile_definitions(cryptoauthlib PUBLIC ATCA_NO_POLL)
+  target_include_directories(cryptoauthlib SYSTEM PUBLIC
+    cryptoauthlib/lib
+    ${CMAKE_CURRENT_SOURCE_DIR} # for the BitBox02-custom "atca_config.h"
+    )
+  target_compile_options(cryptoauthlib PRIVATE
+    -Wno-pedantic -Wno-incompatible-pointer-types -Wno-unused-parameter -Wno-unused-variable -Wno-cast-qual
+    -Wno-switch-default -Wno-format-nonliteral -Wno-missing-prototypes -Wno-missing-declarations
+  )
 endif() # CMAKE_CROSSCOMPILING
 
 # fatfs must to be linked together with a diskio middleware:

--- a/external/atca_config.h
+++ b/external/atca_config.h
@@ -1,0 +1,38 @@
+// Copyright 2020 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file is based on the snippet from cryptoauthlib/README.md:
+// https://github.com/digitalbitbox/cryptoauthlib/tree/v3.2.5#configuration
+
+/* Cryptoauthlib Configuration File */
+#ifndef ATCA_CONFIG_H
+#define ATCA_CONFIG_H
+
+/* Include HALS */
+// Shift: we currently use a custom HAL config, see `ATCAIfaceCfg cfg` in securechip.c.
+#define ATCA_HAL_CUSTOM
+
+/* Included device support */
+#define ATCA_ATECC608_SUPPORT
+
+/* \brief How long to wait after an initial wake failure for the POST to
+ *         complete.
+ * If Power-on self test (POST) is enabled, the self test will run on waking
+ * from sleep or during power-on, which delays the wake reply.
+ */
+#ifndef ATCA_POST_DELAY_MSEC
+#define ATCA_POST_DELAY_MSEC 25
+#endif
+
+#endif // ATCA_CONFIG_H

--- a/src/securechip/securechip.c
+++ b/src/securechip/securechip.c
@@ -110,9 +110,10 @@ static ATCA_STATUS _post_init(void* iface)
  *                         As output, the number of bytes received.
  * \return ATCA_SUCCESS on success, otherwise an error code.
  */
-static ATCA_STATUS _receive(void* iface, uint8_t* rxdata, uint16_t* rxlength)
+static ATCA_STATUS _receive(void* iface, uint8_t word_address, uint8_t* rxdata, uint16_t* rxlength)
 {
     (void)iface;
+    (void)word_address;
     uint8_t ret = i2c_ecc_read(rxdata, *rxlength);
     if (ret) {
         return ATCA_COMM_FAIL;
@@ -127,9 +128,10 @@ static ATCA_STATUS _receive(void* iface, uint8_t* rxdata, uint16_t* rxlength)
  * \param[in] txlength  number of bytes to send
  * \return ATCA_SUCCESS on success, otherwise an error code.
  */
-static ATCA_STATUS _send(void* iface, uint8_t* txdata, int txlength)
+static ATCA_STATUS _send(void* iface, uint8_t word_address, uint8_t* txdata, int txlength)
 {
     (void)iface;
+    (void)word_address;
     // txdata[0] is using _reserved byte of the ATCAPacket
     txdata[0] = I2C_ECC_CHIP_CMD;
     // Account for the _reserved byte, similar to
@@ -184,7 +186,7 @@ static ATCAIfaceCfg cfg = {
     // TODO: can likely use cryptoauthlib/lib/hal/hal_i2c_start.(c|h) for all or
     // some of the functionality, possibly using cfg_ateccx08a_i2c_default
     .iface_type = ATCA_CUSTOM_IFACE,
-    .devtype = ATECC608A,
+    .devtype = ATECC608,
     .atcacustom.halinit = &_init,
     .atcacustom.halpostinit = &_post_init,
     .atcacustom.halreceive = &_receive,


### PR DESCRIPTION
The library handling the secure chip.

https://github.com/digitalbitbox/cryptoauthlib/tree/v3.2.5

See also:

https://github.com/MicrochipTech/cryptoauthlib/wiki/Upgrading-to-v3.2#api-changes-between-v31x-and-v32x
