### PR TITLE
external: update libwally-core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Clone the repo
         uses: actions/checkout@v2
         with:
-          submodules: true
+          submodules: recursive
       - name: Pull CI container image
         run: ./.ci/run-container-ci pull
       - name: Run CI in container

--- a/src/apps/btc/btc_sign_msg.c
+++ b/src/apps/btc/btc_sign_msg.c
@@ -103,7 +103,13 @@ USE_RESULT app_btc_result_t app_btc_sign_msg(
 
     size_t offset = sizeof(msg_header) - 1;
     memcpy(formatted_msg, msg_header, offset);
-    offset += wally_varbuff_to_bytes(msg, msg_size, &formatted_msg[offset]);
+    size_t written;
+    if (wally_varbuff_to_bytes(
+            msg, msg_size, &formatted_msg[offset], sizeof(formatted_msg) - offset, &written) !=
+        WALLY_OK) {
+        return APP_BTC_ERR_UNKNOWN;
+    }
+    offset += written;
     uint8_t hash[32] = {0};
     rust_sha256(formatted_msg, offset, hash);
     rust_sha256(hash, sizeof(hash), hash);


### PR DESCRIPTION
To 46da3615b8e0837964f443d6b113ad500ea89f97.

This is a bit ahead of the official latest 0.8.0 release, to include
this commit, which adds secp256k1-zpk as a submodule instead of as a
source-copy inside libwally-core:

https://github.com/ElementsProject/libwally-core/commit/1da463088e64189d04c21073eb8861be1b717ad1

This will make it a lot easier for us use a custom fork of secp256k1,
which we might want to add anti nonce covert channel protection.

The new release also gets rid of all custom commits to libwally-core
and secp256k1, which are now all merged and released upstream.