### PR TITLE
Rust eth address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 9.3.1
+## 9.4.0 [version may change, pending release]
+- ETHPubRequest api call now fails if a an invalid contract address is provided also if `display` is
+  false.
+
+## 9.3.1 [tagged 2020-12-01]
 - Fix a bug where the device could freeze and become unresponsive.
 
 ## 9.3.0 [tagged 2020-11-23]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,9 +89,9 @@ endif()
 #
 # Versions MUST contain three parts and start with lowercase 'v'.
 # Example 'v1.0.0'. They MUST not contain a pre-release label such as '-beta'.
-set(FIRMWARE_VERSION "v9.3.1")
-set(FIRMWARE_BTC_ONLY_VERSION "v9.3.1")
-set(FIRMWARE_BITBOXBASE_VERSION "v9.3.1")
+set(FIRMWARE_VERSION "v9.4.0")
+set(FIRMWARE_BTC_ONLY_VERSION "v9.4.0")
+set(FIRMWARE_BITBOXBASE_VERSION "v9.4.0")
 set(BOOTLOADER_VERSION "v1.0.3")
 
 find_package(PythonInterp 3.6 REQUIRED)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -361,6 +361,7 @@ add_custom_target(rust-bindgen
     --whitelist-function lock_animation_stop
     --whitelist-function delay_us
     --rustified-enum keystore_error_t
+    --rustified-enum keystore_secp256k1_pubkey_format
     --whitelist-function util_format_datetime
     --whitelist-function util_version_short
     --whitelist-function delay_ms
@@ -405,6 +406,8 @@ add_custom_target(rust-bindgen
     --whitelist-function reset_reset
     --whitelist-function sd_card_inserted
     --whitelist-var BIP39_WORDLIST_LEN
+    --whitelist-function app_eth_params_get
+    --whitelist-function app_eth_erc20_params_get
     ${CMAKE_CURRENT_SOURCE_DIR}/rust/bitbox02-sys/wrapper.h --
     -DPB_NO_PACKED_STRUCTS=1 -DPB_FIELD_16BIT=1 -fshort-enums ${RUST_BINDGEN_FLAGS} ${RUST_INCLUDES}
   )

--- a/src/commander/commander_eth.c
+++ b/src/commander/commander_eth.c
@@ -17,31 +17,8 @@
 #include <stdint.h>
 #include <stdio.h>
 
-#include <apps/eth/eth.h>
 #include <apps/eth/eth_sign.h>
 #include <apps/eth/eth_sign_msg.h>
-
-#include <wally_bip32.h> // for BIP32_INITIAL_HARDENED_CHILD
-
-static commander_error_t _api_pub(const ETHPubRequest* request, PubResponse* response)
-{
-    app_eth_sign_error_t result = app_eth_address(
-        request->coin,
-        request->output_type,
-        request->keypath,
-        request->keypath_count,
-        response->pub,
-        sizeof(response->pub),
-        request->display,
-        request->contract_address);
-    if (result == APP_ETH_SIGN_ERR_USER_ABORT) {
-        return COMMANDER_ERR_USER_ABORT;
-    }
-    if (result != APP_ETH_SIGN_OK) {
-        return COMMANDER_ERR_GENERIC;
-    }
-    return COMMANDER_OK;
-}
 
 static commander_error_t _api_sign(const ETHSignRequest* request, ETHSignResponse* response)
 {
@@ -72,9 +49,6 @@ static commander_error_t _api_sign_msg(
 commander_error_t commander_eth(const ETHRequest* request, ETHResponse* response)
 {
     switch (request->which_request) {
-    case ETHRequest_pub_tag:
-        response->which_response = PubResponse_pub_tag;
-        return _api_pub(&(request->request.pub), &response->response.pub);
     case ETHRequest_sign_tag:
         response->which_response = ETHResponse_sign_tag;
         return _api_sign(&(request->request.sign), &response->response.sign);

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -61,6 +61,7 @@ dependencies = [
  "binascii",
  "bitbox02",
  "bitbox02-noise",
+ "ethereum",
  "hex",
  "prost",
  "sha2",

--- a/src/rust/bitbox02-rust-c/Cargo.toml
+++ b/src/rust/bitbox02-rust-c/Cargo.toml
@@ -63,5 +63,7 @@ testing = ["bitbox02/testing"]
 
 app-ethereum = [
   "ethereum", # this is a dependency
-  "bitbox02-rust/app-ethereum", # enable this feature in the dep
+  # enable this feature in the deps
+  "bitbox02-rust/app-ethereum",
+  "bitbox02/app-ethereum",
 ]

--- a/src/rust/bitbox02-rust-c/Cargo.toml
+++ b/src/rust/bitbox02-rust-c/Cargo.toml
@@ -63,4 +63,5 @@ testing = ["bitbox02/testing"]
 
 app-ethereum = [
   "ethereum", # this is a dependency
+  "bitbox02-rust/app-ethereum", # enable this feature in the dep
 ]

--- a/src/rust/bitbox02-rust/Cargo.toml
+++ b/src/rust/bitbox02-rust/Cargo.toml
@@ -28,6 +28,7 @@ doctest = false
 [dependencies]
 bitbox02 = {path = "../bitbox02"}
 util = {path = "../util"}
+ethereum = { path = "../apps/ethereum", optional = true }
 binascii = { version = "0.1.4", default-features = false, features = ["encode"] }
 bitbox02-noise = {path = "../bitbox02-noise"}
 hex = { version = "0.4", default-features = false }
@@ -47,4 +48,6 @@ default-features = false
 features = ["prost-derive"]
 
 [features]
-app-ethereum = []
+app-ethereum = [
+  "ethereum", # this is a dependency
+]

--- a/src/rust/bitbox02-rust/Cargo.toml
+++ b/src/rust/bitbox02-rust/Cargo.toml
@@ -50,4 +50,6 @@ features = ["prost-derive"]
 [features]
 app-ethereum = [
   "ethereum", # this is a dependency
+  # enable this feature in the deps
+  "bitbox02/app-ethereum",
 ]

--- a/src/rust/bitbox02-rust/Cargo.toml
+++ b/src/rust/bitbox02-rust/Cargo.toml
@@ -45,3 +45,6 @@ git = "https://github.com/danburkert/prost.git"
 rev = "6113789f70b69709820becba4242824b4fb3ffec"
 default-features = false
 features = ["prost-derive"]
+
+[features]
+app-ethereum = []

--- a/src/rust/bitbox02-rust/src/hww/api/ethereum.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/ethereum.rs
@@ -1,0 +1,32 @@
+// Copyright 2020 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(not(feature = "app-ethereum"))]
+compile_error!(
+    "Ethereum code is being compiled even though the app-ethereum feature is not enabled"
+);
+
+use super::pb;
+use super::Error;
+
+use pb::eth_request::Request;
+use pb::eth_response::Response;
+
+/// Handle a Ethereum protobuf api call.
+///
+/// Returns `None` if the call was not handled by Rust, in which case it should be handled by
+/// the C commander.
+pub async fn process_api(_request: &Request) -> Option<Result<Response, Error>> {
+    None
+}

--- a/src/rust/bitbox02-rust/src/hww/api/ethereum.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/ethereum.rs
@@ -17,6 +17,8 @@ compile_error!(
     "Ethereum code is being compiled even though the app-ethereum feature is not enabled"
 );
 
+mod pubrequest;
+
 use super::pb;
 use super::Error;
 
@@ -27,6 +29,9 @@ use pb::eth_response::Response;
 ///
 /// Returns `None` if the call was not handled by Rust, in which case it should be handled by
 /// the C commander.
-pub async fn process_api(_request: &Request) -> Option<Result<Response, Error>> {
-    None
+pub async fn process_api(request: &Request) -> Option<Result<Response, Error>> {
+    match request {
+        Request::Pub(ref request) => Some(pubrequest::process(request).await),
+        _ => None,
+    }
 }

--- a/src/rust/bitbox02-rust/src/hww/api/ethereum/pubrequest.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/ethereum/pubrequest.rs
@@ -1,0 +1,105 @@
+// Copyright 2020 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::pb;
+use super::Error;
+
+use pb::eth_pub_request::OutputType;
+use pb::eth_response::Response;
+
+use crate::workflow::confirm;
+use bitbox02::keystore;
+
+extern crate alloc;
+use alloc::string::String;
+use core::convert::TryInto;
+
+fn coin_title(coin: pb::EthCoin) -> &'static str {
+    match coin {
+        pb::EthCoin::Eth => "Ethereum",
+        pb::EthCoin::RopstenEth => "Ropsten",
+        pb::EthCoin::RinkebyEth => "Rinkeby",
+    }
+}
+
+async fn process_address(request: &pb::EthPubRequest) -> Result<Response, Error> {
+    let coin = pb::EthCoin::from_i32(request.coin).ok_or(Error::InvalidInput)?;
+    let params = bitbox02::app_eth::params_get(request.coin as _).ok_or(Error::InvalidInput)?;
+    // If a contract_address is provided, it has to be a supported ERC20-token.
+    let erc20_params: Option<bitbox02::app_eth::ERC20Params> =
+        if request.contract_address.is_empty() {
+            None
+        } else {
+            let address: [u8; 20] = request
+                .contract_address
+                .as_slice()
+                .try_into()
+                .or(Err(Error::InvalidInput))?;
+            Some(
+                bitbox02::app_eth::erc20_params_get(request.coin as _, address)
+                    .ok_or(Error::InvalidInput)?,
+            )
+        };
+
+    if !ethereum::keypath::is_valid_keypath_address(&request.keypath, params.bip44_coin) {
+        return Err(Error::InvalidInput);
+    }
+    let pubkey = bitbox02::keystore::secp256k1_pubkey_uncompressed(&request.keypath)
+        .or(Err(Error::InvalidInput))?;
+    let mut address = String::new();
+    ethereum::address::from_pubkey(&pubkey, &mut address).unwrap();
+
+    if request.display {
+        let title = match erc20_params {
+            Some(erc20_params) => erc20_params.name,
+            None => coin_title(coin),
+        };
+        let params = confirm::Params {
+            title,
+            title_autowrap: true,
+            body: &address,
+            scrollable: true,
+            ..Default::default()
+        };
+        if !confirm::confirm(&params).await {
+            return Err(Error::UserAbort);
+        }
+    }
+
+    Ok(Response::Pub(pb::PubResponse { r#pub: address }))
+}
+
+fn process_xpub(request: &pb::EthPubRequest) -> Result<Response, Error> {
+    if request.display {
+        // No xpub user verification for now.
+        return Err(Error::InvalidInput);
+    }
+
+    let params = bitbox02::app_eth::params_get(request.coin as _).ok_or(Error::InvalidInput)?;
+    if !ethereum::keypath::is_valid_keypath_xpub(&request.keypath, params.bip44_coin) {
+        return Err(Error::InvalidInput);
+    }
+    let xpub = keystore::encode_xpub_at_keypath(&request.keypath, keystore::xpub_type_t::XPUB)
+        .or(Err(Error::InvalidInput))?;
+
+    Ok(Response::Pub(pb::PubResponse { r#pub: xpub }))
+}
+
+pub async fn process(request: &pb::EthPubRequest) -> Result<Response, Error> {
+    let output_type = OutputType::from_i32(request.output_type).ok_or(Error::InvalidInput)?;
+    match output_type {
+        OutputType::Address => process_address(request).await,
+        OutputType::Xpub => process_xpub(request),
+    }
+}

--- a/src/rust/bitbox02-rust/src/hww/api/ethereum/pubrequest.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/ethereum/pubrequest.rs
@@ -103,3 +103,307 @@ pub async fn process(request: &pb::EthPubRequest) -> Result<Response, Error> {
         OutputType::Xpub => process_xpub(request),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+    use super::*;
+
+    use crate::bb02_async::block_on;
+    use bitbox02::testing::{mock, Data, MUTEX};
+    use std::boxed::Box;
+    use util::bip32::HARDENED;
+
+    #[test]
+    pub fn test_process_xpub() {
+        let _guard = MUTEX.lock().unwrap();
+
+        const EXPECTED_XPUB: &str = "xpub";
+        let request = pb::EthPubRequest {
+            output_type: OutputType::Xpub as _,
+            keypath: [44 + HARDENED, 60 + HARDENED, 0 + HARDENED, 0].to_vec(),
+            coin: pb::EthCoin::Eth as _,
+            display: false,
+            contract_address: b"".to_vec(),
+        };
+
+        // All good.
+        mock(Data {
+            eth_params_get: Some(Box::new(|coin| {
+                assert_eq!(coin, pb::EthCoin::Eth as _);
+                Some(bitbox02::app_eth::Params {
+                    bip44_coin: 60 + HARDENED,
+                    chain_id: 1,
+                    unit: "ETH",
+                })
+            })),
+            keystore_encode_xpub_at_keypath: Some(Box::new(|_, xpub_type| {
+                assert_eq!(xpub_type, keystore::xpub_type_t::XPUB);
+                Ok(EXPECTED_XPUB.into())
+            })),
+            ..Default::default()
+        });
+        assert_eq!(
+            block_on(process(&request)),
+            Ok(Response::Pub(pb::PubResponse {
+                r#pub: EXPECTED_XPUB.into()
+            }))
+        );
+
+        // Params not found.
+        mock(Data {
+            eth_params_get: Some(Box::new(|_| None)),
+            ..Default::default()
+        });
+        assert_eq!(block_on(process(&request)), Err(Error::InvalidInput));
+
+        // Wrong keypath (wrong expected coin)
+        mock(Data {
+            eth_params_get: Some(Box::new(|_| {
+                Some(bitbox02::app_eth::Params {
+                    bip44_coin: 61 + HARDENED,
+                    chain_id: 1,
+                    unit: "ETH",
+                })
+            })),
+            ..Default::default()
+        });
+        assert_eq!(block_on(process(&request)), Err(Error::InvalidInput));
+
+        // xpub fetching/encoding failed.
+        mock(Data {
+            eth_params_get: Some(Box::new(|_| {
+                Some(bitbox02::app_eth::Params {
+                    bip44_coin: 60 + HARDENED,
+                    chain_id: 1,
+                    unit: "ETH",
+                })
+            })),
+            keystore_encode_xpub_at_keypath: Some(Box::new(|_, _| Err(()))),
+            ..Default::default()
+        });
+        assert_eq!(block_on(process(&request)), Err(Error::InvalidInput));
+    }
+
+    #[test]
+    pub fn test_process_address() {
+        let _guard = MUTEX.lock().unwrap();
+
+        const PUBKEY: [u8; 65] = [
+            0x04, 0xd8, 0xae, 0xa8, 0x0d, 0x2d, 0xbc, 0xeb, 0xbe, 0x10, 0xfd, 0xfa, 0xc2, 0xd2,
+            0xdb, 0x19, 0x64, 0x15, 0x5b, 0xa9, 0x9e, 0x0d, 0xd7, 0xbf, 0xd5, 0xcf, 0xfe, 0xd9,
+            0x7a, 0x1c, 0xae, 0xf7, 0xd0, 0xb9, 0x07, 0x2d, 0x9c, 0x0f, 0x50, 0x49, 0x30, 0xef,
+            0x59, 0xb7, 0x52, 0xd4, 0xfe, 0xa0, 0xcb, 0xde, 0x3e, 0x27, 0x3e, 0xe9, 0x54, 0xd8,
+            0xda, 0xc8, 0xee, 0x03, 0x1a, 0x4e, 0xd1, 0x71, 0xfd,
+        ];
+        const ADDRESS: &str = "0xF4C21710Ef8b5a5Ec4bd3780A687FE083446e67B";
+
+        let request = &pb::EthPubRequest {
+            output_type: OutputType::Address as _,
+            keypath: [44 + HARDENED, 60 + HARDENED, 0 + HARDENED, 0, 0].to_vec(),
+            coin: pb::EthCoin::Eth as _,
+            display: false,
+            contract_address: b"".to_vec(),
+        };
+
+        // All good.
+        mock(Data {
+            eth_params_get: Some(Box::new(|coin| {
+                assert_eq!(coin, pb::EthCoin::Eth as _);
+                Some(bitbox02::app_eth::Params {
+                    bip44_coin: 60 + HARDENED,
+                    chain_id: 1,
+                    unit: "ETH",
+                })
+            })),
+            keystore_secp256k1_pubkey_uncompressed: Some(Box::new(|_| Ok(PUBKEY))),
+            ..Default::default()
+        });
+        assert_eq!(
+            block_on(process(&request)),
+            Ok(Response::Pub(pb::PubResponse {
+                r#pub: ADDRESS.into()
+            }))
+        );
+
+        // All good, with display.
+        mock(Data {
+            eth_params_get: Some(Box::new(|_| {
+                Some(bitbox02::app_eth::Params {
+                    bip44_coin: 60 + HARDENED,
+                    chain_id: 1,
+                    unit: "ETH",
+                })
+            })),
+            keystore_secp256k1_pubkey_uncompressed: Some(Box::new(|_| Ok(PUBKEY))),
+            ui_confirm_create_body: Some("0xF4C21710Ef8b5a5Ec4bd3780A687FE083446e67B".into()),
+            ui_confirm_create_result: Some(true),
+            ..Default::default()
+        });
+        assert_eq!(
+            block_on(process(&pb::EthPubRequest {
+                output_type: OutputType::Address as _,
+                keypath: [44 + HARDENED, 60 + HARDENED, 0 + HARDENED, 0, 0].to_vec(),
+                coin: pb::EthCoin::Eth as _,
+                display: true,
+                contract_address: b"".to_vec(),
+            })),
+            Ok(Response::Pub(pb::PubResponse {
+                r#pub: ADDRESS.into()
+            }))
+        );
+
+        // Params not found.
+        mock(Data {
+            eth_params_get: Some(Box::new(|_| None)),
+            ..Default::default()
+        });
+        assert_eq!(block_on(process(&request)), Err(Error::InvalidInput));
+
+        // Wrong keypath (wrong expected coin)
+        mock(Data {
+            eth_params_get: Some(Box::new(|_| {
+                Some(bitbox02::app_eth::Params {
+                    bip44_coin: 61 + HARDENED,
+                    chain_id: 1,
+                    unit: "ETH",
+                })
+            })),
+            ..Default::default()
+        });
+        assert_eq!(block_on(process(&request)), Err(Error::InvalidInput));
+
+        // Wrong keypath (account too high)
+        mock(Data {
+            eth_params_get: Some(Box::new(|_| {
+                Some(bitbox02::app_eth::Params {
+                    bip44_coin: 60 + HARDENED,
+                    chain_id: 1,
+                    unit: "ETH",
+                })
+            })),
+            ..Default::default()
+        });
+        assert_eq!(
+            block_on(process(&pb::EthPubRequest {
+                output_type: OutputType::Address as _,
+                keypath: [44 + HARDENED, 60 + HARDENED, 0 + HARDENED, 0, 100].to_vec(),
+                coin: pb::EthCoin::Eth as _,
+                display: false,
+                contract_address: b"".to_vec(),
+            })),
+            Err(Error::InvalidInput)
+        );
+    }
+
+    #[test]
+    pub fn test_process_erc20_address() {
+        let _guard = MUTEX.lock().unwrap();
+
+        const PUBKEY: [u8; 65] = [
+            0x04, 0xd8, 0xae, 0xa8, 0x0d, 0x2d, 0xbc, 0xeb, 0xbe, 0x10, 0xfd, 0xfa, 0xc2, 0xd2,
+            0xdb, 0x19, 0x64, 0x15, 0x5b, 0xa9, 0x9e, 0x0d, 0xd7, 0xbf, 0xd5, 0xcf, 0xfe, 0xd9,
+            0x7a, 0x1c, 0xae, 0xf7, 0xd0, 0xb9, 0x07, 0x2d, 0x9c, 0x0f, 0x50, 0x49, 0x30, 0xef,
+            0x59, 0xb7, 0x52, 0xd4, 0xfe, 0xa0, 0xcb, 0xde, 0x3e, 0x27, 0x3e, 0xe9, 0x54, 0xd8,
+            0xda, 0xc8, 0xee, 0x03, 0x1a, 0x4e, 0xd1, 0x71, 0xfd,
+        ];
+        const ADDRESS: &str = "0xF4C21710Ef8b5a5Ec4bd3780A687FE083446e67B";
+        const CONTRACT_ADDRESS: [u8; 20] = *b"aaaaaaaaaaaaaaaaaaaa";
+
+        let request = &pb::EthPubRequest {
+            output_type: OutputType::Address as _,
+            keypath: [44 + HARDENED, 60 + HARDENED, 0 + HARDENED, 0, 0].to_vec(),
+            coin: pb::EthCoin::Eth as _,
+            display: false,
+            contract_address: CONTRACT_ADDRESS.to_vec(),
+        };
+
+        // All good.
+        mock(Data {
+            eth_params_get: Some(Box::new(|coin| {
+                assert_eq!(coin, pb::EthCoin::Eth as _);
+                Some(bitbox02::app_eth::Params {
+                    bip44_coin: 60 + HARDENED,
+                    chain_id: 1,
+                    unit: "ETH",
+                })
+            })),
+            eth_erc20_params_get: Some(Box::new(|coin, contract_address| {
+                assert_eq!(coin, pb::EthCoin::Eth as _);
+                assert_eq!(contract_address, CONTRACT_ADDRESS);
+                Some(bitbox02::app_eth::ERC20Params {
+                    unit: "ETH",
+                    name: "ERC20 token",
+                    contract_address: CONTRACT_ADDRESS,
+                    decimals: 6,
+                })
+            })),
+            keystore_secp256k1_pubkey_uncompressed: Some(Box::new(|_| Ok(PUBKEY))),
+            ..Default::default()
+        });
+        assert_eq!(
+            block_on(process(&request)),
+            Ok(Response::Pub(pb::PubResponse {
+                r#pub: ADDRESS.into()
+            }))
+        );
+
+        // All good, with display.
+        mock(Data {
+            eth_params_get: Some(Box::new(|_| {
+                Some(bitbox02::app_eth::Params {
+                    bip44_coin: 60 + HARDENED,
+                    chain_id: 1,
+                    unit: "ETH",
+                })
+            })),
+            eth_erc20_params_get: Some(Box::new(|_, _| {
+                Some(bitbox02::app_eth::ERC20Params {
+                    unit: "ETH",
+                    name: "ERC20 token",
+                    contract_address: CONTRACT_ADDRESS,
+                    decimals: 6,
+                })
+            })),
+            keystore_secp256k1_pubkey_uncompressed: Some(Box::new(|_| Ok(PUBKEY))),
+            ui_confirm_create_body: Some("0xF4C21710Ef8b5a5Ec4bd3780A687FE083446e67B".into()),
+            ui_confirm_create_result: Some(true),
+            ..Default::default()
+        });
+        assert_eq!(
+            block_on(process(&pb::EthPubRequest {
+                output_type: OutputType::Address as _,
+                keypath: [44 + HARDENED, 60 + HARDENED, 0 + HARDENED, 0, 0].to_vec(),
+                coin: pb::EthCoin::Eth as _,
+                display: true,
+                contract_address: CONTRACT_ADDRESS.to_vec(),
+            })),
+            Ok(Response::Pub(pb::PubResponse {
+                r#pub: ADDRESS.into()
+            }))
+        );
+
+        // ERC20 params not found / invalid contract address.
+        mock(Data {
+            eth_params_get: Some(Box::new(|_| {
+                Some(bitbox02::app_eth::Params {
+                    bip44_coin: 60 + HARDENED,
+                    chain_id: 1,
+                    unit: "ETH",
+                })
+            })),
+            eth_erc20_params_get: Some(Box::new(|_, _| None)),
+            ..Default::default()
+        });
+        assert_eq!(
+            block_on(process(&pb::EthPubRequest {
+                output_type: OutputType::Address as _,
+                keypath: [44 + HARDENED, 60 + HARDENED, 0 + HARDENED, 0, 0].to_vec(),
+                coin: pb::EthCoin::Eth as _,
+                display: false,
+                contract_address: CONTRACT_ADDRESS.to_vec(),
+            })),
+            Err(Error::InvalidInput)
+        );
+    }
+}

--- a/src/rust/bitbox02-sys/wrapper.h
+++ b/src/rust/bitbox02-sys/wrapper.h
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <apps/eth/eth_params.h>
 #include <backup/backup.h>
 #include <bitboxbase.pb.h>
 #include <bitboxbase/bitboxbase_screensaver.h>

--- a/src/rust/bitbox02/Cargo.toml
+++ b/src/rust/bitbox02/Cargo.toml
@@ -29,3 +29,5 @@ lazy_static = { version = "1.4.0", optional = true }
 [features]
 # Only to be enabled in unit tests.
 testing = ["lazy_static"]
+
+app-ethereum = []

--- a/src/rust/bitbox02/src/app_eth.rs
+++ b/src/rust/bitbox02/src/app_eth.rs
@@ -1,0 +1,68 @@
+// Copyright 2020 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub struct Params {
+    pub bip44_coin: u32,
+    pub chain_id: u8,
+    pub unit: &'static str,
+}
+
+pub fn params_get(coin: bitbox02_sys::ETHCoin) -> Option<Params> {
+    let params = unsafe { bitbox02_sys::app_eth_params_get(coin).as_ref()? };
+    Some(Params {
+        bip44_coin: params.bip44_coin,
+        chain_id: params.chain_id,
+        unit: {
+            let s = unsafe {
+                let len = crate::util::strlen_ptr(params.unit);
+                core::slice::from_raw_parts(params.unit, len as _)
+            };
+            core::str::from_utf8(&s[..]).unwrap()
+        },
+    })
+}
+
+pub struct ERC20Params {
+    pub unit: &'static str,
+    pub name: &'static str,
+    pub contract_address: [u8; 20],
+    pub decimals: u8,
+}
+
+pub fn erc20_params_get(
+    coin: bitbox02_sys::ETHCoin,
+    contract_address: [u8; 20],
+) -> Option<ERC20Params> {
+    let params = unsafe {
+        bitbox02_sys::app_eth_erc20_params_get(coin, contract_address.as_ptr()).as_ref()?
+    };
+    Some(ERC20Params {
+        unit: {
+            let s = unsafe {
+                let len = crate::util::strlen_ptr(params.unit);
+                core::slice::from_raw_parts(params.unit, len as _)
+            };
+            core::str::from_utf8(&s[..]).unwrap()
+        },
+        name: {
+            let s = unsafe {
+                let len = crate::util::strlen_ptr(params.name);
+                core::slice::from_raw_parts(params.name, len as _)
+            };
+            core::str::from_utf8(&s[..]).unwrap()
+        },
+        contract_address: params.contract_address,
+        decimals: params.decimals,
+    })
+}

--- a/src/rust/bitbox02/src/app_eth.rs
+++ b/src/rust/bitbox02/src/app_eth.rs
@@ -18,6 +18,7 @@ pub struct Params {
     pub unit: &'static str,
 }
 
+#[cfg(not(feature = "testing"))]
 pub fn params_get(coin: bitbox02_sys::ETHCoin) -> Option<Params> {
     let params = unsafe { bitbox02_sys::app_eth_params_get(coin).as_ref()? };
     Some(Params {
@@ -33,6 +34,12 @@ pub fn params_get(coin: bitbox02_sys::ETHCoin) -> Option<Params> {
     })
 }
 
+#[cfg(feature = "testing")]
+pub fn params_get(coin: bitbox02_sys::ETHCoin) -> Option<Params> {
+    let data = crate::testing::DATA.0.borrow();
+    data.eth_params_get.as_ref().unwrap()(coin)
+}
+
 pub struct ERC20Params {
     pub unit: &'static str,
     pub name: &'static str,
@@ -40,6 +47,7 @@ pub struct ERC20Params {
     pub decimals: u8,
 }
 
+#[cfg(not(feature = "testing"))]
 pub fn erc20_params_get(
     coin: bitbox02_sys::ETHCoin,
     contract_address: [u8; 20],
@@ -65,4 +73,13 @@ pub fn erc20_params_get(
         contract_address: params.contract_address,
         decimals: params.decimals,
     })
+}
+
+#[cfg(feature = "testing")]
+pub fn erc20_params_get(
+    coin: bitbox02_sys::ETHCoin,
+    contract_address: [u8; 20],
+) -> Option<ERC20Params> {
+    let data = crate::testing::DATA.0.borrow();
+    data.eth_erc20_params_get.as_ref().unwrap()(coin, contract_address)
 }

--- a/src/rust/bitbox02/src/keystore_stub.rs
+++ b/src/rust/bitbox02/src/keystore_stub.rs
@@ -56,9 +56,12 @@ pub fn get_bip39_word(_idx: u16) -> Result<&'static str, ()> {
 }
 
 pub fn secp256k1_pubkey_uncompressed(
-    _keypath: &[u32],
+    keypath: &[u32],
 ) -> Result<[u8; EC_PUBLIC_KEY_UNCOMPRESSED_LEN], ()> {
-    panic!("not implemented")
+    let data = crate::testing::DATA.0.borrow();
+    data.keystore_secp256k1_pubkey_uncompressed
+        .as_ref()
+        .unwrap()(keypath)
 }
 
 pub fn encode_xpub_at_keypath(keypath: &[u32], xpub_type: xpub_type_t) -> Result<String, ()> {

--- a/src/rust/bitbox02/src/lib.rs
+++ b/src/rust/bitbox02/src/lib.rs
@@ -30,6 +30,7 @@ extern crate lazy_static;
 #[cfg(feature = "testing")]
 pub mod testing;
 
+pub mod app_eth;
 #[cfg_attr(feature = "testing", path = "backup_stub.rs")]
 pub mod backup;
 pub mod commander;

--- a/src/rust/bitbox02/src/lib.rs
+++ b/src/rust/bitbox02/src/lib.rs
@@ -30,6 +30,7 @@ extern crate lazy_static;
 #[cfg(feature = "testing")]
 pub mod testing;
 
+#[cfg(feature = "app-ethereum")]
 pub mod app_eth;
 #[cfg_attr(feature = "testing", path = "backup_stub.rs")]
 pub mod backup;

--- a/src/rust/bitbox02/src/testing.rs
+++ b/src/rust/bitbox02/src/testing.rs
@@ -35,6 +35,13 @@ pub struct Data {
     pub backup_create: Option<Box<dyn Fn(u32, u32) -> Result<(), super::backup::Error>>>,
     pub keystore_encode_xpub_at_keypath:
         Option<Box<dyn Fn(&[u32], super::keystore::xpub_type_t) -> Result<String, ()>>>,
+    pub keystore_secp256k1_pubkey_uncompressed: Option<
+        Box<dyn Fn(&[u32]) -> Result<[u8; super::keystore::EC_PUBLIC_KEY_UNCOMPRESSED_LEN], ()>>,
+    >,
+    pub eth_params_get:
+        Option<Box<dyn Fn(bitbox02_sys::ETHCoin) -> Option<super::app_eth::Params>>>,
+    pub eth_erc20_params_get:
+        Option<Box<dyn Fn(bitbox02_sys::ETHCoin, [u8; 20]) -> Option<super::app_eth::ERC20Params>>>,
 }
 
 pub struct SafeData(pub RefCell<Data>);


### PR DESCRIPTION
the C `app_eth_address()` can be removed once `app_eth_sign_msg()` is ported as well.

This ports retrieving the ETH xpub and showing ETH addresses, including ERC20 tokens.

First two commits are from https://github.com/digitalbitbox/bitbox02-firmware/pull/628, which can be merged soon. It depends on it for `encode_xpub_at_keypath()`.