### PR TITLE
keystore: fix memory leak in use of keystore_bip39_get_word

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 9.4.0 [version may change, pending release]
 - ETHPubRequest api call now fails if a an invalid contract address is provided also if `display` is
   false.
+- Fix a memory leak (freeing a malloc'd string - no a functional or security issue)
 
 ## 9.3.1 [tagged 2020-12-01]
 - Fix a bug where the device could freeze and become unresponsive.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -327,6 +327,7 @@ add_custom_target(rust-bindgen
     --use-core
     --ctypes-prefix util::c_types
     --rustified-enum backup_error_t
+    --whitelist-function wally_free_string
     --whitelist-function backup_check
     --whitelist-function backup_create
     --whitelist-function memory_is_initialized

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -67,6 +67,7 @@ dependencies = [
  "sha2",
  "sha3",
  "util",
+ "zeroize",
 ]
 
 [[package]]

--- a/src/rust/bitbox02-rust/Cargo.toml
+++ b/src/rust/bitbox02-rust/Cargo.toml
@@ -34,6 +34,7 @@ bitbox02-noise = {path = "../bitbox02-noise"}
 hex = { version = "0.4", default-features = false }
 sha2 = { version = "0.9.2", default-features = false }
 sha3 = { version = "0.9.1", default-features = false, optional = true }
+zeroize = "1.1.0"
 
 # For stack allocated strings
 [dependencies.arrayvec]

--- a/src/rust/bitbox02-rust/src/hww/api/show_mnemonic.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/show_mnemonic.rs
@@ -26,6 +26,10 @@ use bitbox02::keystore;
 
 const NUM_RANDOM_WORDS: u8 = 5;
 
+/// Return 5 words from the BIP39 wordlist, 4 of which are random, and
+/// one of them is provided `word`. Returns the position of `word` in
+/// the list of words, and the lis of words.  This is used to test if
+/// the user wrote down the seed words properly.
 fn create_random_unique_words(word: &str, length: u8) -> (u8, Vec<zeroize::Zeroizing<String>>) {
     fn rand16() -> u16 {
         let mut rand = [0u8; 32];
@@ -62,6 +66,10 @@ fn create_random_unique_words(word: &str, length: u8) -> (u8, Vec<zeroize::Zeroi
     (index_word, result)
 }
 
+/// Handle the ShowMnemonic API call. This shows the seed encoded as
+/// 12/18/24 BIP39 English words. Afterwards, for each word, the user
+/// is asked to pick the right word among 5 words, to check if they
+/// wrote it down correctly.
 pub async fn process() -> Result<Response, Error> {
     unlock::unlock_keystore("Unlock device", unlock::CanCancel::Yes).await?;
 

--- a/src/rust/bitbox02-sys/wrapper.h
+++ b/src/rust/bitbox02-sys/wrapper.h
@@ -45,6 +45,7 @@
 #include <ui/ugui/ugui.h>
 #include <util.h>
 #include <wally_bip39.h>
+#include <wally_core.h>
 #include <wally_crypto.h>
 #include <workflow/confirm.h>
 

--- a/src/rust/bitbox02/src/keystore_stub.rs
+++ b/src/rust/bitbox02/src/keystore_stub.rs
@@ -51,7 +51,7 @@ pub fn get_bip39_mnemonic() -> Result<zeroize::Zeroizing<String>, ()> {
     panic!("not implemented")
 }
 
-pub fn get_bip39_word(_idx: u16) -> Result<&'static str, ()> {
+pub fn get_bip39_word(_idx: u16) -> Result<zeroize::Zeroizing<String>, ()> {
     panic!("not implemented")
 }
 


### PR DESCRIPTION
The function malloc's the word, but the Rust FFI layer assumed it was
a static string. It was functionally correct, as the address was
static, but there was a memory leak due to a missing free().