### PR TITLE
rust/async_usb: add `next_request()` future primitive

### DIFF
--- a/src/hww.c
+++ b/src/hww.c
@@ -135,7 +135,7 @@ static void _process_packet(const in_buffer_t* in_req, hww_packet_rsp_t* out_rsp
 {
     out_rsp->status = HWW_RSP_NACK;
     // Spawn async task, which is polled in the main loop.
-    rust_async_usb_spawn_hww(rust_util_bytes(in_req->data, in_req->len));
+    rust_async_usb_on_request_hww(rust_util_bytes(in_req->data, in_req->len));
     // Lock USB stack so U2F requests get a BUSY response.
     usb_processing_lock(usb_processing_hww());
     // Some tasks have an 'early return' path that is not blocking. We spin the task once so we can

--- a/src/rust/bitbox02-rust-c/src/async_usb.rs
+++ b/src/rust/bitbox02-rust-c/src/async_usb.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use bitbox02_rust::async_usb::{on_next_request, spawn, waiting_for_next_request};
+use bitbox02_rust::hww::process_packet;
+
 #[no_mangle]
 pub extern "C" fn rust_async_usb_spin() {
     bitbox02_rust::async_usb::spin();
@@ -49,10 +52,12 @@ pub unsafe extern "C" fn rust_async_usb_copy_response(out: *mut bitbox02::buffer
 ///
 /// `usb_in` are the api request bytes.
 #[no_mangle]
-pub extern "C" fn rust_async_usb_spawn_hww(usb_in: crate::util::Bytes) {
-    use bitbox02_rust::async_usb::spawn;
-    use bitbox02_rust::hww::process_packet;
-    spawn(process_packet, &usb_in.as_ref());
+pub extern "C" fn rust_async_usb_on_request_hww(usb_in: crate::util::Bytes) {
+    if waiting_for_next_request() {
+        on_next_request(usb_in.as_ref());
+    } else {
+        spawn(process_packet, usb_in.as_ref());
+    }
 }
 
 #[no_mangle]

--- a/src/rust/bitbox02-rust/src/async_usb.rs
+++ b/src/rust/bitbox02-rust/src/async_usb.rs
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 //! This module provides the executor for tasks that are spawned with an API request and deliver a
-//! USB response.
+//! USB response. Terminology: host = computer, device = BitBox02.
 
 extern crate alloc;
 
-use crate::bb02_async::{spin as spin_task, Task};
+use crate::bb02_async::{option, spin as spin_task, Task};
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::cell::RefCell;
@@ -25,6 +25,34 @@ use core::task::Poll;
 
 type UsbOut = Vec<u8>;
 type UsbIn = Vec<u8>;
+
+/// If a task is running (see `UsbTaskState`), this state is active and manages waiting for another
+/// request from the host in an async fashion. This allows to have multi-request workflows in async.
+///
+/// Normal flow: request(A) -> response(A)
+/// Multirequess flow: request(A) -> response(WANT_B) -> request(B) -> response(A)
+enum WaitingForNextRequestState {
+    /// We are not waiting for another request from the host. This is the default state when
+    /// processing a request.
+    Idle,
+    /// Since we have a strict request<->response model, we always need to send a response before
+    /// getting another request. In this state, we are ready to send a response and are waiting for
+    /// the host to fetch it.
+    SendingResponse(UsbOut),
+    /// Host got the response, now we are waiting for the next request by the host.
+    AwaitingRequest,
+}
+
+/// A safer version of `Option<UsbIn>`. RefCell so we cannot accidentally borrow illegally.
+struct SafeNextRequest(RefCell<Option<UsbIn>>);
+
+/// Safety: this implements Sync even though it is not thread safe. This is okay, as we
+/// run only in a single thread in the BitBox02.
+unsafe impl Sync for SafeNextRequest {}
+
+/// An option resolving the `next_request()` future. It is `Some(...)` once a request we've been
+/// waiting for arrives. See `next_requset()` for more details.
+static NEXT_REQUEST: SafeNextRequest = SafeNextRequest(RefCell::new(None));
 
 /// Describes the global state of an api query. The documentation of
 /// the variants apply to the HWW stack, but have analogous meaning in
@@ -39,9 +67,12 @@ enum UsbTaskState<'a> {
     /// queue). This allows for the execeutor state to not be borrowed while the task is being
     /// executed, which allows the task itself to modify the executor state (otherwise we would have
     /// an illegal double-borrow of the state).
-    Running(Option<Task<'a, UsbOut>>),
+    ///
+    /// The second element manages waiting for another request while processing a request, allowing
+    /// multi-request workflows.
+    Running(Option<Task<'a, UsbOut>>, WaitingForNextRequestState),
     /// The task has finished and written the result, so the USB response is available. We are now
-    /// waiting for the client to fetch it (HWW_REQ_RETRY). For short-circuited or non-async api
+    /// waiting for the host to fetch it (HWW_REQ_RETRY). For short-circuited or non-async api
     /// calls, the result might be returned immediately in response to HWW_REQ_NEW.
     ResultAvailable(UsbOut),
 }
@@ -70,9 +101,36 @@ where
         UsbTaskState::Nothing => {
             let task: Task<UsbOut> = Box::pin(workflow(usb_in.to_vec()));
 
-            *state = UsbTaskState::Running(Some(task));
+            *state = UsbTaskState::Running(Some(task), WaitingForNextRequestState::Idle);
         }
-        _ => panic!("previous task still in progress"),
+        _ => panic!("spawn: wrong state"),
+    }
+}
+
+/// Returns true if a request is being processed and waiting for another request via the
+/// `next_request()` future.
+pub fn waiting_for_next_request() -> bool {
+    matches!(
+        *USB_TASK_STATE.0.borrow(),
+        UsbTaskState::Running(Some(_), WaitingForNextRequestState::AwaitingRequest)
+    )
+}
+
+/// Resolves the `next_request()` future. `waiting_for_next_request()` must be true when calling
+/// this, otherwise this function panics.
+pub fn on_next_request(usb_in: &[u8]) {
+    let mut state = USB_TASK_STATE.0.borrow_mut();
+    match *state {
+        UsbTaskState::Running(
+            Some(_),
+            ref mut next_request_state @ WaitingForNextRequestState::AwaitingRequest,
+        ) => {
+            // Resolve NEXT_REQUEST future.
+            *NEXT_REQUEST.0.borrow_mut() = Some(usb_in.to_vec());
+
+            *next_request_state = WaitingForNextRequestState::Idle;
+        }
+        _ => panic!("on_next_request: wrong state"),
     }
 }
 
@@ -85,10 +143,10 @@ pub fn spin() {
     // Pop task before polling, so that USB_TASK_STATE does not stay borrowed during the poll.
     let mut popped_task = match *USB_TASK_STATE.0.borrow_mut() {
         // Illegal state, `None` is only valid during the poll.
-        UsbTaskState::Running(None) => panic!("task not found"),
+        UsbTaskState::Running(None, _) => panic!("task not found"),
         // Get the task out, putting `None` in. This allows us to release the mutable borrow on the
         // state.
-        UsbTaskState::Running(ref mut task @ Some(_)) => task.take(),
+        UsbTaskState::Running(ref mut task @ Some(_), _) => task.take(),
         // Nothing to do.
         _ => None,
     };
@@ -99,7 +157,9 @@ pub fn spin() {
             }
             Poll::Pending => {
                 // Not done yet, put the task back for execution.
-                if let UsbTaskState::Running(ref mut task @ None) = *USB_TASK_STATE.0.borrow_mut() {
+                if let UsbTaskState::Running(ref mut task @ None, _) =
+                    *USB_TASK_STATE.0.borrow_mut()
+                {
                     *task = popped_task;
                 } else {
                     panic!("spin: illegal executor state");
@@ -115,24 +175,33 @@ pub enum CopyResponseErr {
     NotReady,
 }
 
-/// To be called in response to the client asking for the result of a
+/// To be called in response to the host asking for the result of a
 /// task.
 ///
 /// If a result is available (state = ResultAvailable), this copies
 /// the usb response to `dst` and moves the state to `Nothing`, and
 /// returns the Ok(<number of bytes written>).
 ///
-/// If there is no task running, returns `Err(true)` if a task is
-/// pending and a response is expected in the future, or `Err(false)`
-/// if no task is running.
+/// If there is no task running, returns `Err(CopyResponseErr::NotReady)` if a task is pending and a
+/// response is expected in the future, or `Err(CopyResponseErr::NotRunning)` if no task is running.
 pub fn copy_response(dst: &mut [u8]) -> Result<usize, CopyResponseErr> {
     let mut state = USB_TASK_STATE.0.borrow_mut();
     match *state {
         UsbTaskState::Nothing => Err(CopyResponseErr::NotRunning),
-        UsbTaskState::Running(_) => Err(CopyResponseErr::NotReady),
+        UsbTaskState::Running(Some(_), ref mut next_request_state) => {
+            if let WaitingForNextRequestState::SendingResponse(ref response) = next_request_state {
+                let len = response.len();
+                dst[..len].copy_from_slice(&response);
+                *next_request_state = WaitingForNextRequestState::AwaitingRequest;
+                Ok(len)
+            } else {
+                Err(CopyResponseErr::NotReady)
+            }
+        }
+        UsbTaskState::Running(_, _) => Err(CopyResponseErr::NotReady),
         UsbTaskState::ResultAvailable(ref response) => {
             let len = response.len();
-            dst[..len].copy_from_slice(&response.as_ref());
+            dst[..len].copy_from_slice(&response);
             *state = UsbTaskState::Nothing;
             Ok(len)
         }
@@ -143,11 +212,27 @@ pub fn copy_response(dst: &mut [u8]) -> Result<usize, CopyResponseErr> {
 /// running.
 pub fn cancel() -> bool {
     let mut state = USB_TASK_STATE.0.borrow_mut();
-    if let UsbTaskState::Running(_) = *state {
+    if let UsbTaskState::Running(_, _) = *state {
         *state = UsbTaskState::Nothing;
         return true;
     }
     false
+}
+
+/// Must be called during the execution of a usb task. This sends out the response to the host and
+/// awaits the next request.
+pub async fn next_request(response: UsbOut) -> UsbIn {
+    let mut state = USB_TASK_STATE.0.borrow_mut();
+    match *state {
+        UsbTaskState::Running(None, ref mut next_request_state) => {
+            *next_request_state = WaitingForNextRequestState::SendingResponse(response);
+            // release borrow
+            drop(state);
+
+            option(&NEXT_REQUEST.0).await
+        }
+        _ => panic!("next_request() called in wrong state"),
+    }
 }
 
 #[cfg(test)]
@@ -156,6 +241,8 @@ mod tests {
     use super::*;
     use std::prelude::v1::*;
 
+    use bitbox02::testing::MUTEX;
+
     fn assert_panics<F: FnOnce() + std::panic::UnwindSafe>(f: F) {
         assert!(std::panic::catch_unwind(f).is_err());
     }
@@ -163,6 +250,8 @@ mod tests {
     /// Test spawning a task, spinning it, and getting the result.
     #[test]
     fn test_full_cycle() {
+        let _guard = MUTEX.lock().unwrap();
+
         async fn task(usb_in: UsbIn) -> UsbOut {
             assert_eq!(usb_in, [1, 2, 3].to_vec());
             [4, 5, 6, 7].to_vec()
@@ -201,5 +290,46 @@ mod tests {
             // Response ok.
             assert_eq!(&response[..4], &[4, 5, 6, 7]);
         }
+    }
+
+    #[test]
+    fn test_next_request() {
+        let _guard = MUTEX.lock().unwrap();
+
+        async fn task(usb_in: UsbIn) -> UsbOut {
+            assert_eq!(&usb_in, &[1, 2, 3]);
+            let next_req = next_request([4, 5, 6, 7].to_vec()).await;
+            assert_eq!(&next_req, &[8, 9, 10]);
+
+            let next_req = next_request([11, 12].to_vec()).await;
+            assert_eq!(&next_req, &[13, 14]);
+            [15, 16, 17].to_vec()
+        }
+
+        let mut response = [0; 100];
+
+        spawn(task, &[1, 2, 3]);
+        spin();
+        // Intermediate response.
+        assert_eq!(Ok(4), copy_response(&mut response));
+        assert_eq!(&response[..4], &[4, 5, 6, 7]);
+
+        // Send follow-up request.
+        assert!(waiting_for_next_request());
+        on_next_request(&[8, 9, 10]);
+        spin();
+
+        // Intermediate response.
+        assert_eq!(Ok(2), copy_response(&mut response));
+        assert_eq!(&response[..2], &[11, 12]);
+
+        // Send follow-up request.
+        assert!(waiting_for_next_request());
+        on_next_request(&[13, 14]);
+        spin();
+
+        // Final response.
+        assert_eq!(Ok(3), copy_response(&mut response));
+        assert_eq!(&response[..3], &[15, 16, 17]);
     }
 }


### PR DESCRIPTION
There are some API workflows that require not only one
request<->response pair, but many request<->resonse pairs in
succession. Bitcoin transaction signing is one such workflow, where
the transaction is streamed in many requests (inputs, outputs,
previous transactions, etc.).

Currently those are all dispatched to individual functions, which
manipulate a global state see what should be processed next. That
sounds exactly what async functions are designed to simplify.

`let usb_in = next_request(usb_out).await;` can be called from any hww
task to wait for another request from the host.

This can turn for example btc signing into a linear async function, in
this style (pseudocode):

```
async fn process_tx(req: Request) -> Response {
    for i in 0..req.num_inputs {
       let input = api_next_request(want_input(i)).await;
       // process input
    }
    // ...
}
```

`api_next_request()` will be built on top of the `next_request()`
primitive to also handle noise and protobuf.