### PR TITLE
hww: add `next_request()` future handling noise and protobuf

### DIFF
--- a/src/rust/bitbox02-rust/src/hww.rs
+++ b/src/rust/bitbox02-rust/src/hww.rs
@@ -25,6 +25,25 @@ const OP_STATUS_SUCCESS: u8 = 0;
 const OP_STATUS_FAILURE: u8 = 1;
 const OP_STATUS_FAILURE_UNINITIALIZED: u8 = 2;
 
+/// Must be called during the execution of a usb task. This sends out the response to the host and
+/// awaits the next request. If the request is not a valid noise encrypted protofbuf api request
+/// message, `Err(Error::InvalidInput)` is returned.
+pub async fn next_request(
+    response: crate::pb::response::Response,
+) -> Result<crate::pb::request::Request, api::error::Error> {
+    let mut out = [OP_STATUS_SUCCESS].to_vec();
+    noise::encrypt(&api::encode(response), &mut out).or(Err(api::error::Error::NoiseEncrypt))?;
+    let request = crate::async_usb::next_request(out).await;
+    match request.split_first() {
+        Some((&noise::OP_NOISE_MSG, encrypted_request)) => {
+            let decrypted_request =
+                noise::decrypt(&encrypted_request).or(Err(api::error::Error::NoiseDecrypt))?;
+            api::decode(&decrypted_request[..])
+        }
+        _ => Err(api::error::Error::InvalidInput),
+    }
+}
+
 /// Process OP_UNLOCK.
 async fn api_unlock() -> Vec<u8> {
     match crate::workflow::unlock::unlock().await {

--- a/src/rust/bitbox02-rust/src/hww/api.rs
+++ b/src/rust/bitbox02-rust/src/hww/api.rs
@@ -14,6 +14,8 @@
 
 use crate::pb;
 
+pub(super) mod error;
+
 #[cfg(feature = "app-ethereum")]
 mod ethereum;
 
@@ -23,7 +25,6 @@ mod bitcoin;
 mod backup;
 mod device_info;
 mod electrum;
-mod error;
 mod reset;
 mod restore;
 mod rootfingerprint;

--- a/src/rust/bitbox02-rust/src/hww/api/error.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/error.rs
@@ -24,6 +24,8 @@ pub enum Error {
     InvalidState,
     Disabled,
     Duplicate,
+    NoiseEncrypt,
+    NoiseDecrypt,
 }
 
 impl core::convert::From<()> for Error {
@@ -107,6 +109,14 @@ pub fn make_error(err: Error) -> Response {
         Duplicate => pb::Error {
             code: 107,
             message: "duplicate entry".into(),
+        },
+        NoiseEncrypt => pb::Error {
+            code: 108,
+            message: "noise encryption failed".into(),
+        },
+        NoiseDecrypt => pb::Error {
+            code: 109,
+            message: "noise decryption failed".into(),
         },
     };
     Response::Error(err)


### PR DESCRIPTION
Builds on https://github.com/digitalbitbox/bitbox02-firmware/pull/694

Now, in any async api processing function, one can call
`let request = next_request(Response {...}).await?` to wait for
another request from the host.