### PR TITLE
Anti-Klepto part 2) add signer nonce commitment functions

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,6 +21,7 @@ set(DBB-FIRMWARE-SOURCES
   ${CMAKE_SOURCE_DIR}/src/commander/commander_states.c
   ${CMAKE_SOURCE_DIR}/src/commander/protobuf.c
   ${CMAKE_SOURCE_DIR}/src/keystore.c
+  ${CMAKE_SOURCE_DIR}/src/keystore/keystore_antiklepto.c
   ${CMAKE_SOURCE_DIR}/src/random.c
   ${CMAKE_SOURCE_DIR}/src/hardfault.c
   ${CMAKE_SOURCE_DIR}/src/util.c

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -24,7 +24,7 @@
 #include <secp256k1.h>
 #include <wally_bip32.h>
 #include <wally_bip39.h> // for BIP39_WORDLIST_LEN
-#include <wally_crypto.h> // for EC_PUBLIC_KEY_UNCOMPRESSED_LEN
+#include <wally_crypto.h> // for EC_PUBLIC_KEY_UNCOMPRESSED_LEN and EC_PUBLIC_KEY_LEN
 
 #define KEYSTORE_MAX_SEED_LENGTH (32)
 #define KEYSTORE_U2F_SEED_LENGTH SHA256_LEN
@@ -189,6 +189,25 @@ USE_RESULT bool keystore_secp256k1_pubkey_uncompressed(
     const uint32_t* keypath,
     size_t keypath_len,
     uint8_t* pubkey_out);
+
+/**
+ * Get a commitment to the original nonce before tweaking it with the host nonce. This is part of
+ * the ECDSA Anti-Klepto Protocol. For more details, check the docs of
+ * `secp256k1_ecdsa_anti_klepto_signer_commit`.
+ * @param[in] keypath derivation keypath
+ * @param[in] keypath_len size of keypath buffer
+ * @param[in] msg32 32 byte message which will be signed by `keystore_secp256k1_sign`.
+ * @param[in] host_commitment must be `sha256(sha256(tag)||shas256(tag)||host_nonce)` where
+ * host_nonce is passed to `keystore_secp256k1_sign()`. See
+ * `secp256k1_ecdsa_anti_klepto_host_commit()`.
+ * @param[out] client_commitment_out EC_PUBLIC_KEY_LEN bytes compressed signer nonce pubkey.
+ */
+USE_RESULT bool keystore_secp256k1_nonce_commit(
+    const uint32_t* keypath,
+    size_t keypath_len,
+    const uint8_t* msg32,
+    const uint8_t* host_commitment,
+    uint8_t* client_commitment_out);
 
 // clang-format off
 /**

--- a/src/keystore/keystore_antiklepto.c
+++ b/src/keystore/keystore_antiklepto.c
@@ -1,0 +1,78 @@
+// Copyright 2020 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "keystore_antiklepto.h"
+#include "keystore.h"
+
+#include <hardfault.h>
+#include <util.h>
+
+typedef struct {
+    uint32_t keypath[10];
+    size_t keypath_len;
+    uint8_t msg[32];
+} _signdata_t;
+
+static _signdata_t _signdata;
+static bool _has_signdata;
+
+bool keystore_antiklepto_secp256k1_commit(
+    const uint32_t* keypath,
+    size_t keypath_len,
+    const uint8_t* msg32,
+    const uint8_t* host_commitment,
+    uint8_t* signer_commitment_out)
+{
+    if (keypath_len > sizeof(_signdata.keypath) / sizeof(uint32_t)) {
+        Abort("keystore_antiklepto_secp256k1_commit: keypath too long");
+    }
+    if (_has_signdata) {
+        return false;
+    }
+
+    if (!keystore_secp256k1_nonce_commit(
+            keypath, keypath_len, msg32, host_commitment, signer_commitment_out)) {
+        return false;
+    }
+    memcpy(_signdata.keypath, keypath, keypath_len * sizeof(uint32_t));
+    _signdata.keypath_len = keypath_len;
+    memcpy(_signdata.msg, msg32, sizeof(_signdata.msg));
+    _has_signdata = true;
+    return true;
+}
+
+bool keystore_antiklepto_secp256k1_sign(
+    const uint8_t* host_nonce32,
+    uint8_t* sig_compact_out,
+    int* recid_out)
+{
+    if (!_has_signdata) {
+        return false;
+    }
+    bool result = keystore_secp256k1_sign(
+        _signdata.keypath,
+        _signdata.keypath_len,
+        _signdata.msg,
+        host_nonce32,
+        sig_compact_out,
+        recid_out);
+    keystore_antiklepto_clear();
+    return result;
+}
+
+void keystore_antiklepto_clear(void)
+{
+    _has_signdata = false;
+    util_zero(&_signdata, sizeof(_signdata));
+}

--- a/src/keystore/keystore_antiklepto.h
+++ b/src/keystore/keystore_antiklepto.h
@@ -1,0 +1,57 @@
+// Copyright 2020 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _KEYSTORE_ANTIKLEPTO_H_
+#define _KEYSTORE_ANTIKLEPTO_H_
+
+#include "compiler_util.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/**
+ * This is part of the ECDSA Anti-Klepto Protocol.
+ * Calls `keystore_secp256k1_antiklepto_commit()`, but it caches the keypath and msg32 to be used
+ * when signing. Refer there for documentation on the parameters. Must use
+ * `keystore_antiklepto_clear()` to abort the signing process, or call
+ * `keystore_antiklepto_secp256k1_sign()` to sign.
+ * @return false if there is previous uncleared cache data or `keystore_secp256k1_antiklepto_commit`
+ * fails.
+ */
+USE_RESULT bool keystore_antiklepto_secp256k1_commit(
+    const uint32_t* keypath,
+    size_t keypath_len,
+    const uint8_t* msg32,
+    const uint8_t* host_commitment,
+    uint8_t* signer_commitment_out);
+
+/**
+ * This is part of the ECDSA Anti-Klepto Protocol.
+ * Calls keystore_secp256k1_sign by using the cached keypath and msg32 from
+ * `keystore_antiklepto_secp256k1_commit()`.
+ * @return false if there is no cached data or keystore_secp256k1_sign() fails.
+ */
+USE_RESULT bool keystore_antiklepto_secp256k1_sign(
+    const uint8_t* host_nonce32,
+    uint8_t* sig_compact_out,
+    int* recid_out);
+
+/**
+ * Clears the signing data, allowing a restart after `keystore_antiklepto_secp256k1_commit()` was
+ * called.
+ */
+void keystore_antiklepto_clear(void);
+
+#endif

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -162,6 +162,8 @@ set(TEST_LIST
    "-Wl,--wrap=random_32_bytes,--wrap=workflow_confirm_dismiss"
    keystore
    "-Wl,--wrap=secp256k1_anti_klepto_sign,--wrap=memory_is_initialized,--wrap=memory_is_seeded,--wrap=memory_get_failed_unlock_attempts,--wrap=memory_reset_failed_unlock_attempts,--wrap=memory_increment_failed_unlock_attempts,--wrap=memory_set_encrypted_seed_and_hmac,--wrap=memory_get_encrypted_seed_and_hmac,--wrap=reset_reset,--wrap=salt_hash_data,--wrap=cipher_aes_hmac_encrypt"
+   keystore_antiklepto
+   "-Wl,--wrap=keystore_secp256k1_nonce_commit,--wrap=keystore_secp256k1_sign"
    keystore_functional
    "-Wl,--wrap=memory_is_initialized,--wrap=memory_is_seeded,--wrap=memory_set_encrypted_seed_and_hmac,--wrap=memory_get_encrypted_seed_and_hmac,--wrap=memory_get_salt_root,--wrap=memory_get_failed_unlock_attempts,--wrap=memory_reset_failed_unlock_attempts,--wrap=memory_increment_failed_unlock_attempts,--wrap=securechip_kdf"
    gestures

--- a/test/unit-test/test_keystore_antiklepto.c
+++ b/test/unit-test/test_keystore_antiklepto.c
@@ -1,0 +1,199 @@
+// Copyright 2020 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <cmocka.h>
+
+#include <keystore.h>
+#include <keystore/keystore_antiklepto.h>
+
+#include <secp256k1_ecdsa_s2c.h>
+#include <wally_bip32.h>
+#include <wally_crypto.h>
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnested-externs"
+
+static uint8_t _mock_seed[32] = {
+    0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22,
+    0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44,
+};
+
+static uint8_t _mock_bip39_seed[64] = {
+    0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22,
+    0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44,
+    0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22,
+    0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44,
+};
+
+bool __wrap_keystore_secp256k1_sign(
+    const uint32_t* keypath,
+    size_t keypath_len,
+    const uint8_t* msg32,
+    const uint8_t* host_nonce32,
+    uint8_t* sig_compact_out,
+    int* recid_out)
+{
+    check_expected(keypath);
+    check_expected(keypath_len);
+    check_expected(msg32);
+    check_expected(host_nonce32);
+    check_expected(sig_compact_out);
+    check_expected(recid_out);
+    return __real_keystore_secp256k1_sign(
+        keypath, keypath_len, msg32, host_nonce32, sig_compact_out, recid_out);
+}
+
+bool __wrap_keystore_secp256k1_nonce_commit(
+    const uint32_t* keypath,
+    size_t keypath_len,
+    const uint8_t* msg32,
+    const uint8_t* host_commitment,
+    uint8_t* signer_commitment_out)
+{
+    check_expected(keypath);
+    check_expected(keypath_len);
+    check_expected(msg32);
+    check_expected(host_commitment);
+    check_expected(signer_commitment_out);
+    return __real_keystore_secp256k1_nonce_commit(
+        keypath, keypath_len, msg32, host_commitment, signer_commitment_out);
+}
+
+static void _test_keystore_antiklepto(void** state)
+{
+    mock_state(_mock_seed, _mock_bip39_seed);
+
+    uint32_t keypath[] = {
+        84 + BIP32_INITIAL_HARDENED_CHILD,
+        1 + BIP32_INITIAL_HARDENED_CHILD,
+        0 + BIP32_INITIAL_HARDENED_CHILD,
+        0,
+        0,
+    };
+
+    uint8_t msg[32];
+    memset(msg, 0x23, sizeof(msg));
+
+    uint8_t host_nonce[32];
+    memset(host_nonce, 0x55, sizeof(host_nonce));
+
+    uint8_t signer_commitment[33] = {0};
+
+    uint8_t sig[64];
+    int recid;
+
+    // No cached data yet.
+    assert_false(keystore_antiklepto_secp256k1_sign(host_nonce, sig, &recid));
+
+    // Run multiple times to make sure the signing cache works a expected.
+    for (int i = 0; i < 3; i++) {
+        // Modify params to check that the right thing is cached.
+        keypath[4] = i;
+        msg[0] = i;
+        host_nonce[0] = i;
+        uint8_t host_nonce_commitment[32];
+
+        // Protocol steps are described in secp256k1/include/secp256k1_ecdsa_s2c.h under "ECDSA
+        // Anti-Klepto Protocol".
+
+        // Protocol step 1.
+        assert_true(secp256k1_ecdsa_anti_klepto_host_commit(
+            wally_get_secp_context(), host_nonce_commitment, host_nonce));
+
+        { // Commit - protocol step 2.
+            expect_memory(
+                __wrap_keystore_secp256k1_nonce_commit, keypath, keypath, sizeof(keypath));
+            expect_value(__wrap_keystore_secp256k1_nonce_commit, keypath_len, 5);
+            expect_memory(__wrap_keystore_secp256k1_nonce_commit, msg32, msg, sizeof(msg));
+            expect_memory(
+                __wrap_keystore_secp256k1_nonce_commit,
+                host_commitment,
+                host_nonce_commitment,
+                sizeof(host_nonce_commitment));
+            expect_value(
+                __wrap_keystore_secp256k1_nonce_commit, signer_commitment_out, signer_commitment);
+            assert_true(keystore_antiklepto_secp256k1_commit(
+                keypath, 5, msg, host_nonce_commitment, signer_commitment));
+
+            // Can't commit again, already has cached data
+            assert_false(keystore_antiklepto_secp256k1_commit(
+                keypath, 5, msg, host_nonce_commitment, signer_commitment));
+
+            // After clearing, we can commit again.
+            keystore_antiklepto_clear();
+            expect_memory(
+                __wrap_keystore_secp256k1_nonce_commit, keypath, keypath, sizeof(keypath));
+            expect_value(__wrap_keystore_secp256k1_nonce_commit, keypath_len, 5);
+            expect_memory(__wrap_keystore_secp256k1_nonce_commit, msg32, msg, sizeof(msg));
+            expect_memory(
+                __wrap_keystore_secp256k1_nonce_commit,
+                host_commitment,
+                host_nonce_commitment,
+                sizeof(host_nonce_commitment));
+            expect_value(
+                __wrap_keystore_secp256k1_nonce_commit, signer_commitment_out, signer_commitment);
+            assert_true(keystore_antiklepto_secp256k1_commit(
+                keypath, 5, msg, host_nonce_commitment, signer_commitment));
+        }
+        // Protocol step 3: host_nonce sent from host to signer to be used in step 4
+        { // Sign - protocol step 4.
+            expect_memory(__wrap_keystore_secp256k1_sign, keypath, keypath, sizeof(keypath));
+            expect_value(__wrap_keystore_secp256k1_sign, keypath_len, 5);
+            expect_memory(__wrap_keystore_secp256k1_sign, msg32, msg, sizeof(msg));
+            expect_memory(
+                __wrap_keystore_secp256k1_sign, host_nonce32, host_nonce, sizeof(host_nonce));
+            expect_value(__wrap_keystore_secp256k1_sign, sig_compact_out, sig);
+            expect_value(__wrap_keystore_secp256k1_sign, recid_out, &recid);
+            assert_true(keystore_antiklepto_secp256k1_sign(host_nonce, sig, &recid));
+        }
+
+        // Protocol step 5: host verification.
+        secp256k1_ecdsa_signature parsed_signature;
+        assert_true(secp256k1_ecdsa_signature_parse_compact(
+            wally_get_secp_context(), &parsed_signature, sig));
+        uint8_t pubkey[EC_PUBLIC_KEY_UNCOMPRESSED_LEN];
+        assert_true(keystore_secp256k1_pubkey_uncompressed(keypath, 5, pubkey));
+        secp256k1_pubkey parsed_pubkey;
+        assert_true(secp256k1_ec_pubkey_parse(
+            wally_get_secp_context(), &parsed_pubkey, pubkey, sizeof(pubkey)));
+        secp256k1_ecdsa_s2c_opening opening;
+        assert_true(secp256k1_ecdsa_s2c_opening_parse(
+            wally_get_secp_context(), &opening, signer_commitment));
+        assert_true(secp256k1_anti_klepto_host_verify(
+            wally_get_secp_context(),
+            &parsed_signature,
+            msg,
+            &parsed_pubkey,
+            host_nonce,
+            &opening));
+    }
+}
+
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(_test_keystore_antiklepto),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}
+
+#pragma GCC diagnostic pop


### PR DESCRIPTION
Builds on https://github.com/digitalbitbox/bitbox02-firmware/pull/697

Since we have a few places where me make signatures (transactions, msg signing), we make one antiklepto module to reuse the state machine that would have to be replicated everywhere.