### PR TITLE
rust/workflow/confirm: convert to Result return type

### DIFF
--- a/src/rust/bitbox02-rust-c/src/bitboxbase.rs
+++ b/src/rust/bitbox02-rust-c/src/bitboxbase.rs
@@ -55,8 +55,8 @@ pub fn confirm_pairing(
     bitbox02::leds_turn_small_led(0, false);
     bitbox02::leds_turn_small_led(4, false);
     match res {
-        true => bitbox02::commander::Error::COMMANDER_OK,
-        false => bitbox02::commander::Error::COMMANDER_ERR_USER_ABORT,
+        Ok(()) => bitbox02::commander::Error::COMMANDER_OK,
+        Err(pairing::UserAbort) => bitbox02::commander::Error::COMMANDER_ERR_USER_ABORT,
     }
 }
 

--- a/src/rust/bitbox02-rust/src/hww/api/backup.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/backup.rs
@@ -36,9 +36,7 @@ pub async fn check(
                     ..Default::default()
                 };
 
-                if !confirm::confirm(&params).await {
-                    return Err(Error::UserAbort);
-                }
+                confirm::confirm(&params).await?;
 
                 let params = confirm::Params {
                     title: "ID?",
@@ -47,9 +45,7 @@ pub async fn check(
                     ..Default::default()
                 };
 
-                if !confirm::confirm(&params).await {
-                    return Err(Error::UserAbort);
-                }
+                confirm::confirm(&params).await?;
 
                 status::status("Backup valid", true).await;
             }
@@ -109,9 +105,7 @@ pub async fn create(
             body: &date_string,
             ..Default::default()
         };
-        if !confirm::confirm(&params).await {
-            return Err(Error::UserAbort);
-        }
+        confirm::confirm(&params).await?;
         if bitbox02::memory::set_seed_birthdate(timestamp).is_err() {
             return Err(Error::Memory);
         }

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin.rs
@@ -94,9 +94,7 @@ async fn xpub(
             scrollable: true,
             ..Default::default()
         };
-        if !confirm::confirm(&confirm_params).await {
-            return Err(Error::UserAbort);
-        }
+        confirm::confirm(&confirm_params).await?;
     }
     Ok(Response::Pub(pb::PubResponse { r#pub: xpub }))
 }
@@ -116,9 +114,7 @@ async fn address_simple(
             scrollable: true,
             ..Default::default()
         };
-        if !confirm::confirm(&confirm_params).await {
-            return Err(Error::UserAbort);
-        }
+        confirm::confirm(&confirm_params).await?;
     }
     Ok(Response::Pub(pb::PubResponse { r#pub: address }))
 }

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin/signmsg.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin/signmsg.rs
@@ -66,9 +66,7 @@ pub async fn process(request: &pb::BtcSignMessageRequest) -> Result<Response, Er
         accept_is_nextarrow: true,
         ..Default::default()
     };
-    if !confirm::confirm(&confirm_params).await {
-        return Err(Error::UserAbort);
-    }
+    confirm::confirm(&confirm_params).await?;
 
     let confirm_params = confirm::Params {
         title: "Address",
@@ -77,9 +75,7 @@ pub async fn process(request: &pb::BtcSignMessageRequest) -> Result<Response, Er
         accept_is_nextarrow: true,
         ..Default::default()
     };
-    if !confirm::confirm(&confirm_params).await {
-        return Err(Error::UserAbort);
-    }
+    confirm::confirm(&confirm_params).await?;
 
     verify_message::verify(&request.msg).await?;
 

--- a/src/rust/bitbox02-rust/src/hww/api/error.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/error.rs
@@ -44,6 +44,12 @@ impl core::convert::From<crate::workflow::cancel::Error> for Error {
     }
 }
 
+impl core::convert::From<crate::workflow::confirm::UserAbort> for Error {
+    fn from(_error: crate::workflow::confirm::UserAbort) -> Self {
+        Error::UserAbort
+    }
+}
+
 impl core::convert::From<crate::workflow::verify_message::Error> for Error {
     fn from(error: crate::workflow::verify_message::Error) -> Self {
         match error {

--- a/src/rust/bitbox02-rust/src/hww/api/ethereum/pubrequest.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/ethereum/pubrequest.rs
@@ -72,9 +72,7 @@ async fn process_address(request: &pb::EthPubRequest) -> Result<Response, Error>
             scrollable: true,
             ..Default::default()
         };
-        if !confirm::confirm(&params).await {
-            return Err(Error::UserAbort);
-        }
+        confirm::confirm(&params).await?;
     }
 
     Ok(Response::Pub(pb::PubResponse { r#pub: address }))

--- a/src/rust/bitbox02-rust/src/hww/api/reset.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/reset.rs
@@ -27,9 +27,7 @@ pub async fn process() -> Result<Response, Error> {
         ..Default::default()
     };
 
-    if !confirm::confirm(&params).await {
-        return Err(Error::Generic);
-    }
+    confirm::confirm(&params).await.or(Err(Error::Generic))?;
 
     bitbox02::reset(true);
 

--- a/src/rust/bitbox02-rust/src/hww/api/set_device_name.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/set_device_name.rs
@@ -33,9 +33,7 @@ pub async fn process(
         ..Default::default()
     };
 
-    if !confirm::confirm(&params).await {
-        return Err(Error::UserAbort);
-    }
+    confirm::confirm(&params).await?;
 
     bitbox02::memory::set_device_name(&name)?;
 

--- a/src/rust/bitbox02-rust/src/hww/api/set_mnemonic_passphrase_enabled.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/set_mnemonic_passphrase_enabled.rs
@@ -29,9 +29,7 @@ pub async fn process(
         ..Default::default()
     };
 
-    if !confirm::confirm(&params).await {
-        return Err(Error::UserAbort);
-    }
+    confirm::confirm(&params).await?;
 
     if bitbox02::memory::set_mnemonic_passphrase_enabled(enabled).is_err() {
         return Err(Error::Memory);

--- a/src/rust/bitbox02-rust/src/hww/api/show_mnemonic.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/show_mnemonic.rs
@@ -88,10 +88,7 @@ pub async fn process() -> Result<Response, Error> {
         accept_is_nextarrow: true,
         ..Default::default()
     };
-
-    if !confirm::confirm(&params).await {
-        return Err(Error::UserAbort);
-    }
+    confirm::confirm(&params).await?;
 
     // Part 2) Confirm words
     for (word_idx, word) in words.iter().enumerate() {

--- a/src/rust/bitbox02-rust/src/workflow/cancel.rs
+++ b/src/rust/bitbox02-rust/src/workflow/cancel.rs
@@ -58,7 +58,7 @@ pub async fn with_cancel<R>(
                 ..Default::default()
             };
 
-            if !confirm::confirm(&params).await {
+            if let Err(confirm::UserAbort) = confirm::confirm(&params).await {
                 continue;
             }
         }

--- a/src/rust/bitbox02-rust/src/workflow/confirm.rs
+++ b/src/rust/bitbox02-rust/src/workflow/confirm.rs
@@ -16,13 +16,19 @@ use crate::bb02_async::option;
 
 pub use bitbox02::ui::{ConfirmParams as Params, Font};
 
+pub struct UserAbort;
+
 /// Returns true if the user accepts, false if the user rejects.
-pub async fn confirm(params: &Params<'_>) -> bool {
-    let result = core::cell::RefCell::new(None as Option<bool>);
+pub async fn confirm(params: &Params<'_>) -> Result<(), UserAbort> {
+    let result = core::cell::RefCell::new(None as Option<Result<(), UserAbort>>);
 
     // The component will set the result when the user accepted/rejected.
     let mut component = bitbox02::ui::confirm_create(&params, |accepted| {
-        *result.borrow_mut() = Some(accepted);
+        *result.borrow_mut() = if accepted {
+            Some(Ok(()))
+        } else {
+            Some(Err(UserAbort))
+        };
     });
     component.screen_stack_push();
     option(&result).await

--- a/src/rust/bitbox02-rust/src/workflow/mnemonic.rs
+++ b/src/rust/bitbox02-rust/src/workflow/mnemonic.rs
@@ -166,7 +166,7 @@ pub async fn get() -> Result<zeroize::Zeroizing<String>, ()> {
                         body: "Recovery words\ninvalid.\nRestart?",
                         ..Default::default()
                     };
-                    if super::confirm::confirm(&params).await {
+                    if let Ok(()) = confirm::confirm(&params).await {
                         return Err(());
                     }
                     continue;
@@ -175,16 +175,16 @@ pub async fn get() -> Result<zeroize::Zeroizing<String>, ()> {
                     // Confirm word picked from menu again, as a typo here would be extremely annoying.
                     // Double checking is also safer, as the user might not even realize they made a typo.
                     let word = choices[choice_idx as usize].clone();
-                    if !super::confirm::confirm(&confirm::Params {
+                    match confirm::confirm(&confirm::Params {
                         title: &title,
                         body: &word,
                         ..Default::default()
                     })
                     .await
                     {
-                        continue;
+                        Err(confirm::UserAbort) => continue,
+                        Ok(()) => Ok(word),
                     }
-                    Ok(word)
                 }
             }
         } else {
@@ -238,7 +238,7 @@ pub async fn get() -> Result<zeroize::Zeroizing<String>, ()> {
                             ..Default::default()
                         };
 
-                        if !super::confirm::confirm(&params).await {
+                        if let Err(confirm::UserAbort) = confirm::confirm(&params).await {
                             // Cancel cancelled.
                             continue;
                         }

--- a/src/rust/bitbox02-rust/src/workflow/pairing.rs
+++ b/src/rust/bitbox02-rust/src/workflow/pairing.rs
@@ -12,10 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::workflow::confirm;
+pub use confirm::UserAbort;
+
 use arrayvec::ArrayString;
 use core::fmt::Write;
 
-pub async fn confirm(hash: &[u8; 32]) -> bool {
+pub async fn confirm(hash: &[u8; 32]) -> Result<(), UserAbort> {
     let mut encoded = [0u8; 60];
     let encoded = binascii::b32encode(&hash[..], &mut encoded).unwrap();
 
@@ -32,8 +35,6 @@ pub async fn confirm(hash: &[u8; 32]) -> bool {
         &encoded[15..20]
     )
     .expect("failed to format");
-
-    use crate::workflow::confirm;
 
     let params = confirm::Params {
         title: "Pairing code",

--- a/src/rust/bitbox02-rust/src/workflow/password.rs
+++ b/src/rust/bitbox02-rust/src/workflow/password.rs
@@ -67,9 +67,7 @@ pub async fn enter_twice() -> Result<SafeInputString, ()> {
             ..Default::default()
         };
 
-        if !confirm::confirm(&params).await {
-            return Err(());
-        }
+        confirm::confirm(&params).await.or(Err(()))?;
     }
     status::status("Success", true).await;
     Ok(password)

--- a/src/rust/bitbox02-rust/src/workflow/unlock.rs
+++ b/src/rust/bitbox02-rust/src/workflow/unlock.rs
@@ -22,10 +22,10 @@ pub use password::CanCancel;
 
 /// Confirm the entered mnemonic passphrase with the user. Returns true if the user confirmed it,
 /// false if the user rejected it.
-async fn confirm_mnemonic_passphrase(passphrase: &str) -> bool {
+async fn confirm_mnemonic_passphrase(passphrase: &str) -> Result<(), confirm::UserAbort> {
     // Accept empty passphrase without confirmation.
     if passphrase.is_empty() {
-        return true;
+        return Ok(());
     }
 
     let params = confirm::Params {
@@ -36,10 +36,7 @@ async fn confirm_mnemonic_passphrase(passphrase: &str) -> bool {
         ..Default::default()
     };
 
-    if !confirm::confirm(&params).await {
-        // Can't happen because accept_only = true.
-        return false;
-    }
+    confirm::confirm(&params).await?;
 
     let params = confirm::Params {
         title: "Confirm",
@@ -106,7 +103,7 @@ pub async fn unlock_bip39() {
                     .await
                     .expect("not cancelable");
 
-            if confirm_mnemonic_passphrase(mnemonic_passphrase.as_str()).await {
+            if let Ok(()) = confirm_mnemonic_passphrase(mnemonic_passphrase.as_str()).await {
                 break;
             }
 

--- a/src/rust/bitbox02-rust/src/workflow/verify_message.rs
+++ b/src/rust/bitbox02-rust/src/workflow/verify_message.rs
@@ -24,6 +24,12 @@ pub enum Error {
     UserAbort,
 }
 
+impl core::convert::From<confirm::UserAbort> for Error {
+    fn from(_error: confirm::UserAbort) -> Self {
+        Error::UserAbort
+    }
+}
+
 /// Verify a message to be signed.
 ///
 /// If the bytes are all printable ascii chars, the message is
@@ -54,9 +60,7 @@ pub async fn verify(msg: &[u8]) -> Result<(), Error> {
                 longtouch: is_last,
                 ..Default::default()
             };
-            if !confirm::confirm(&params).await {
-                return Err(Error::UserAbort);
-            }
+            confirm::confirm(&params).await?;
         }
         Ok(())
     } else {
@@ -68,10 +72,7 @@ pub async fn verify(msg: &[u8]) -> Result<(), Error> {
             longtouch: true,
             ..Default::default()
         };
-        if confirm::confirm(&params).await {
-            Ok(())
-        } else {
-            Err(Error::UserAbort)
-        }
+        confirm::confirm(&params).await?;
+        Ok(())
     }
 }


### PR DESCRIPTION
Easier to propagate errors than checking for a bool.