### PR TITLE
rust: Always reubuild library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -515,8 +515,10 @@ endif()
 #  *  factory-setup-bitboxbase_rust_c
 foreach(type ${RUST_LIBS})
   set(lib ${RUST_BINARY_DIR}/feature-${type}/${RUST_TARGET_ARCH_DIR}/${RUST_PROFILE}/libbitbox02_rust_c.a)
+  # The dummy output is to always trigger rebuild (cargo is clever enough to
+  # only rebuild if something changed)
   add_custom_command(
-    OUTPUT ${lib} ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}/lib${type}_rust_c.a
+    OUTPUT ${lib} ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}/lib${type}_rust_c.a dummy
     COMMAND
       ${CMAKE_COMMAND} -E env
       CMAKE_CURRENT_BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR}


### PR DESCRIPTION
Make cannot know when to rebuild the rust library since it isn't aware
of the source->output dependencies. Cargo does output a "depfile" (which
can be used to teach Make/Ninja about dependencies) but CMake can only
use depfiles if the "Ninja" backend is used.

For now, we add an output that is never produced which will always
trigger a rebuild of the library. Cargo is clever enough to only rebuild
what is needed anyway.