### PR TITLE
workflow/mnemonic/get: confirm 24th word

### DIFF
--- a/src/rust/bitbox02-rust/src/workflow/mnemonic.rs
+++ b/src/rust/bitbox02-rust/src/workflow/mnemonic.rs
@@ -171,7 +171,21 @@ pub async fn get() -> Result<zeroize::Zeroizing<String>, ()> {
                     }
                     continue;
                 }
-                Ok(choice_idx) => Ok(choices[choice_idx as usize].clone()),
+                Ok(choice_idx) => {
+                    // Confirm word picked from menu again, as a typo here would be extremely annoying.
+                    // Double checking is also safer, as the user might not even realize they made a typo.
+                    let word = choices[choice_idx as usize].clone();
+                    if !super::confirm::confirm(&confirm::Params {
+                        title: &title,
+                        body: &word,
+                        ..Default::default()
+                    })
+                    .await
+                    {
+                        continue;
+                    }
+                    Ok(word)
+                }
             }
         } else {
             trinary_input_string::enter(


### PR DESCRIPTION
The 24th word is selected from 8 valid candidaes in a menu. The arrows
and the 'select' button are close to each other, so a typo could
happen quite easily. A typo at this stage is very annoying, but also
the user might not even realize it, and they would proceed thinking
they got the right word.