### PR TITLE
component/confirm_transaction: simplify callbacks

### DIFF
--- a/src/ui/components/confirm_transaction.h
+++ b/src/ui/components/confirm_transaction.h
@@ -21,26 +21,28 @@
  * Creates a confirm screen.
  * @param[in] amount of coins to send, including the unit suffix.
  * @param[in] address to send coins
- * @param[in] confirm_callback The callback triggered when the user pushes the confirm button.
- * @param[in] cancel_callback The callback triggered when the user pushes the cancel button.
+ * @param[in] callback The callback triggered when the user accepts or rejects. Is called at most
+ * once.
+ * @param[in] callback_param Passed to `callback`.
  */
 component_t* confirm_transaction_address_create(
     const char* amount,
     const char* address,
-    void (*confirm_callback)(void),
-    void (*cancel_callback)(void));
+    void (*callback)(bool accepted, void* param),
+    void* callback_param);
 
 /**
  * Creates a confirm screen.
  * @param[in] amount of coins to send, including the unit suffix.
  * @param[in] fee to send coins
- * @param[in] confirm_callback The callback triggered when the user pushes the confirm button.
- * @param[in] cancel_callback The callback triggered when the user pushes the cancel button.
+ * @param[in] callback The callback triggered when the user accepts or rejects. Is called at most
+ * once.
+ * @param[in] callback_param Passed to `callback`.
  */
 component_t* confirm_transaction_fee_create(
     const char* amount,
     const char* fee,
-    void (*confirm_callback)(void),
-    void (*cancel_callback)(void));
+    void (*callback)(bool accepted, void* param),
+    void* callback_param);
 
 #endif

--- a/src/workflow/verify_recipient.c
+++ b/src/workflow/verify_recipient.c
@@ -20,27 +20,20 @@
 #include <ui/components/confirm_transaction.h>
 #include <ui/screen_stack.h>
 
-static bool _result = false;
-static void _confirm(void)
+static void _callback(bool result, void* param)
 {
-    _result = true;
-    workflow_blocking_unblock();
-}
-
-static void _reject(void)
-{
-    _result = false;
+    *(bool*)param = result;
     workflow_blocking_unblock();
 }
 
 bool workflow_verify_recipient(const char* recipient, const char* amount)
 {
-    _result = false;
-    ui_screen_stack_push(confirm_transaction_address_create(amount, recipient, _confirm, _reject));
+    bool result = false;
+    ui_screen_stack_push(confirm_transaction_address_create(amount, recipient, _callback, &result));
     workflow_blocking_block();
     ui_screen_stack_pop();
-    if (!_result) {
+    if (!result) {
         workflow_status_blocking("Transaction\ncanceled", false);
     }
-    return _result;
+    return result;
 }

--- a/src/workflow/verify_total.c
+++ b/src/workflow/verify_total.c
@@ -19,26 +19,18 @@
 #include <ui/components/confirm_transaction.h>
 #include <ui/screen_stack.h>
 
-static bool _result = false;
-
-static void _confirm(void)
+static void _callback(bool result, void* param)
 {
-    _result = true;
-    workflow_blocking_unblock();
-}
-
-static void _reject(void)
-{
-    _result = false;
+    *(bool*)param = result;
     workflow_blocking_unblock();
 }
 
 bool workflow_verify_total(const char* total, const char* fee)
 {
-    _result = false;
-    ui_screen_stack_push(confirm_transaction_fee_create(total, fee, _confirm, _reject));
+    bool result = false;
+    ui_screen_stack_push(confirm_transaction_fee_create(total, fee, _callback, &result));
     workflow_blocking_block();
     ui_screen_stack_pop();
-    workflow_status_blocking(_result ? "Transaction\nconfirmed" : "Transaction\ncanceled", _result);
-    return _result;
+    workflow_status_blocking(result ? "Transaction\nconfirmed" : "Transaction\ncanceled", result);
+    return result;
 }


### PR DESCRIPTION
Make it easier to wrap it Rust.