### PR TITLE
util: add decimal formatting utility function

### DIFF
--- a/src/rust/bitbox02-rust/src/apps/bitcoin/util.rs
+++ b/src/rust/bitbox02-rust/src/apps/bitcoin/util.rs
@@ -17,17 +17,10 @@ use alloc::string::String;
 
 /// Converts a satoshi value to a string, suffixed with `unit`, e.g. 1234567890 -> "12.3456789 BTC".
 pub fn format_amount(satoshi: u64, unit: &str) -> String {
-    const SATOSHI_IN_BTC: u64 = 100000000;
-    let amount = format!(
-        "{}.{:08}",
-        satoshi / SATOSHI_IN_BTC,
-        satoshi % SATOSHI_IN_BTC
-    );
-    format!(
-        "{} {}",
-        amount.trim_end_matches('0').trim_end_matches('.'),
-        unit
-    )
+    let mut s = util::decimal::format(satoshi, 8);
+    s.push(' ');
+    s.push_str(unit);
+    s
 }
 
 #[cfg(test)]

--- a/src/rust/util/src/decimal.rs
+++ b/src/rust/util/src/decimal.rs
@@ -1,0 +1,57 @@
+// Copyright 2021 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate alloc;
+use alloc::string::{String, ToString};
+
+pub trait Format: ToString {}
+
+impl Format for u64 {}
+
+/// Formats integer `value` as `value / 10^decimals`, with up to `decimals` decimal places.
+/// E.g. "123450" with decimals=3: "123.45".
+/// Value must consists only of '0'-'9' digits.
+pub fn format<F: Format>(value: F, decimals: usize) -> String {
+    let mut v: String = format!("{:0>width$}", value.to_string(), width = decimals + 1);
+    v.insert(v.len() - decimals, '.');
+    v.trim_end_matches('0').trim_end_matches('.').into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_int() {
+        assert_eq!(format(0u64, 0), "0");
+        assert_eq!(format(0u64, 2), "0");
+        assert_eq!(format(0u64, 6), "0");
+
+        assert_eq!(format(1u64, 0), "1");
+        assert_eq!(format(1u64, 1), "0.1");
+        assert_eq!(format(1u64, 2), "0.01");
+        assert_eq!(format(1u64, 6), "0.000001");
+
+        assert_eq!(format(12345u64, 0), "12345");
+        assert_eq!(format(12345u64, 1), "1234.5");
+        assert_eq!(format(12345u64, 2), "123.45");
+        assert_eq!(format(12345u64, 3), "12.345");
+        assert_eq!(format(12345u64, 4), "1.2345");
+        assert_eq!(format(12345u64, 5), "0.12345");
+        assert_eq!(format(12345u64, 6), "0.012345");
+        assert_eq!(format(12345u64, 7), "0.0012345");
+        assert_eq!(format(123450u64, 7), "0.012345");
+        assert_eq!(format(1234500u64, 7), "0.12345");
+    }
+}

--- a/src/rust/util/src/lib.rs
+++ b/src/rust/util/src/lib.rs
@@ -16,6 +16,7 @@
 pub mod ascii;
 pub mod bip32;
 pub mod c_types;
+pub mod decimal;
 pub mod name;
 
 // for `format!`


### PR DESCRIPTION
This is simpler than modular arithmetic and will also work with
bigints to format Ethereum values, avoiding bigint modular arithmetic.