### PR TITLE
scripts: improve jlink sequence - halt then load

### DIFF
--- a/scripts/template-bootloader.jlink
+++ b/scripts/template-bootloader.jlink
@@ -1,3 +1,3 @@
-loadfile $file
 r
+loadfile $file
 q

--- a/scripts/template-firmware.jlink
+++ b/scripts/template-firmware.jlink
@@ -1,3 +1,3 @@
-loadbin $file 0x10000
 r
+loadbin $file 0x10000
 q


### PR DESCRIPTION
I believe loadbin/loadfile commands do not halt the CPU of the target.
The correct way to flash is to first halt the CPU, then download the
bin to the target.

The "r" stands for "reset and halt".
I also believe loadbin/loadfile will reset the CPU once done. So, no
need for additional reset after load.

Docs, although you'll notice it's missing loadbin:
https://wiki.segger.com/J-Link_Commander

Remember my weird white dev device that refused to flash at some point?
It works with this sequence.
