### PR TITLE
py/bitbox02: bump version to 5.3.0

### DIFF
--- a/py/bitbox02/bitbox02/bitbox02/__init__.py
+++ b/py/bitbox02/bitbox02/bitbox02/__init__.py
@@ -16,7 +16,7 @@
 from __future__ import print_function
 import sys
 
-__version__ = "5.2.0"
+__version__ = "5.3.0"
 
 if sys.version_info.major != 3 or sys.version_info.minor < 6:
     print(


### PR DESCRIPTION
Activate the antiklepto protocol in eth_sign(), eth_sign_msg() and btc_sign_msg().