### PR TITLE
apps/eth/sign: warn about unrecognized data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - RestoreFrommnemonic: ported to Rust. Will now return UserAbortError on user abort instead of GenericError.
 - Anti-klepto support for ETH transaction signing and for BTC and ETH message signing.
 - Add Uniswap ERC-20 token.
+- Display warning before confirming raw ETH data.
 
 ## 9.4.0 [released 2021-01-20]
 - ETHPubRequest api call now fails if a an invalid contract address is provided also if `display` is


### PR DESCRIPTION
Confirming the data field without understanding it can be a security
issue. Ideally, all popular contract invocations would be understood
and displayed in a human readable format - showing the raw data is the
last resort. However, the user must understand the meaning when
confirming it.