### PR TITLE
keystore: allow creation of 16 byte seeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Attempt to fix flaky SD behavior
 - Add securechip_model to DeviceInfo: ATECCC608A or ATECC608B.
 - Added reboot purpose for clearer UX: "Proceed to upgrade?" vs. "Go to startup settings?"
+- Allow creation of 128 bit seeds (12 BIP39 recovery words)
 
 ## 9.5.0 [released 2021-03-10]
 - RestoreFrommnemonic: ported to Rust. Will now return UserAbortError on user abort instead of GenericError.

--- a/py/bitbox02/bitbox02/bitbox02/bitbox02.py
+++ b/py/bitbox02/bitbox02/bitbox02/bitbox02.py
@@ -157,14 +157,18 @@ class BitBox02(BitBoxCommonAPI):
         request.device_name.name = device_name
         self._msg_query(request, expected_response="success")
 
-    def set_password(self) -> bool:
+    def set_password(self, entropy_size: int = 32) -> bool:
         """
         Returns True if the user entered the password correctly (passwords match).
-        Returns False otherwise.
+        Returns False otherwise. Entropy size determines the seed size in bytes; must be 16 or 32.
         """
+        assert entropy_size in (16, 32)
+        if entropy_size == 16:
+            self._require_atleast(semver.VersionInfo(9, 6, 0))
+
         # pylint: disable=no-member
         request = hww.Request()
-        request.set_password.entropy = os.urandom(32)
+        request.set_password.entropy = os.urandom(entropy_size)
         try:
             self._msg_query(request, expected_response="success")
         except Bitbox02Exception as err:

--- a/src/keystore.c
+++ b/src/keystore.c
@@ -257,8 +257,14 @@ bool keystore_encrypt_and_store_seed(
     return true;
 }
 
-bool keystore_create_and_store_seed(const char* password, const uint8_t* host_entropy)
+bool keystore_create_and_store_seed(
+    const char* password,
+    const uint8_t* host_entropy,
+    size_t host_entropy_size)
 {
+    if (host_entropy_size != 16 && host_entropy_size != 32) {
+        return false;
+    }
     if (KEYSTORE_MAX_SEED_LENGTH != RANDOM_NUM_SIZE) {
         Abort("keystore create: size mismatch");
     }
@@ -267,7 +273,7 @@ bool keystore_create_and_store_seed(const char* password, const uint8_t* host_en
     random_32_bytes(seed);
 
     // Mix in Host entropy.
-    for (size_t i = 0; i < KEYSTORE_MAX_SEED_LENGTH; i++) {
+    for (size_t i = 0; i < host_entropy_size; i++) {
         seed[i] ^= host_entropy[i];
     }
 
@@ -282,10 +288,10 @@ bool keystore_create_and_store_seed(const char* password, const uint8_t* host_en
         return false;
     }
 
-    for (size_t i = 0; i < KEYSTORE_MAX_SEED_LENGTH; i++) {
+    for (size_t i = 0; i < host_entropy_size; i++) {
         seed[i] ^= password_salted_hashed[i];
     }
-    return keystore_encrypt_and_store_seed(seed, KEYSTORE_MAX_SEED_LENGTH, password);
+    return keystore_encrypt_and_store_seed(seed, host_entropy_size, password);
 }
 
 static void _free_string(char** str)

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -68,11 +68,16 @@ USE_RESULT bool keystore_encrypt_and_store_seed(
     const char* password);
 
 /**
-   Generates 32 bytes of entropy, mixes it with host_entropy, and stores it encrypted with the
-   password.
-   @param[in] host_entropy 32 bytes of entropy to be mixed in.
+   Generates the seed, mixes it with host_entropy, and stores it encrypted with the
+   password. The size of the host entropy determines the size of the seed. Can be either 16 or 32
+   bytes, resulting in 12 or 24 BIP39 recovery words.
+   @param[in] host_entropy bytes of entropy to be mixed in.
+   @param[in] host_entropy_size must be 16 or 32.
 */
-USE_RESULT bool keystore_create_and_store_seed(const char* password, const uint8_t* host_entropy);
+USE_RESULT bool keystore_create_and_store_seed(
+    const char* password,
+    const uint8_t* host_entropy,
+    size_t host_entropy_size);
 
 /** Unlocks the keystore seed or checks the password:
  * If the keystore is locked, it decrypts and loads the seed, unlocking the keystore:

--- a/src/rust/bitbox02/src/keystore.rs
+++ b/src/rust/bitbox02/src/keystore.rs
@@ -62,9 +62,13 @@ pub fn unlock_bip39(mnemonic_passphrase: &SafeInputString) -> Result<(), Error> 
     }
 }
 
-pub fn create_and_store_seed(password: &SafeInputString, host_entropy: &[u8; 32]) -> bool {
+pub fn create_and_store_seed(password: &SafeInputString, host_entropy: &[u8]) -> bool {
     unsafe {
-        bitbox02_sys::keystore_create_and_store_seed(password.as_cstr(), host_entropy.as_ptr())
+        bitbox02_sys::keystore_create_and_store_seed(
+            password.as_cstr(),
+            host_entropy.as_ptr(),
+            host_entropy.len() as _,
+        )
     }
 }
 

--- a/test/device-test/src/test_backup.c
+++ b/test/device-test/src/test_backup.c
@@ -126,7 +126,8 @@ int main(void)
 
     screen_print_debug("Creating initial backup...", 1000);
 
-    if (!keystore_create_and_store_seed("device-test", "host-entropy")) {
+    uint8_t host_entropy[32] = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    if (!keystore_create_and_store_seed("device-test", host_entropy, sizeof(host_entropy))) {
         Abort("Failed to create keystore");
     }
     uint8_t remaining_attempts;

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -221,7 +221,7 @@ set(TEST_LIST
    hww
    "-Wl,--wrap=random_32_bytes,--wrap=workflow_confirm_dismiss"
    keystore
-   "-Wl,--wrap=secp256k1_anti_klepto_sign,--wrap=memory_is_initialized,--wrap=memory_is_seeded,--wrap=memory_get_failed_unlock_attempts,--wrap=memory_reset_failed_unlock_attempts,--wrap=memory_increment_failed_unlock_attempts,--wrap=memory_set_encrypted_seed_and_hmac,--wrap=memory_get_encrypted_seed_and_hmac,--wrap=reset_reset,--wrap=salt_hash_data,--wrap=cipher_aes_hmac_encrypt"
+   "-Wl,--wrap=secp256k1_anti_klepto_sign,--wrap=memory_is_initialized,--wrap=memory_is_seeded,--wrap=memory_get_failed_unlock_attempts,--wrap=memory_reset_failed_unlock_attempts,--wrap=memory_increment_failed_unlock_attempts,--wrap=memory_set_encrypted_seed_and_hmac,--wrap=memory_get_encrypted_seed_and_hmac,--wrap=reset_reset,--wrap=salt_hash_data,--wrap=cipher_aes_hmac_encrypt,--wrap=random_32_bytes"
    keystore_antiklepto
    "-Wl,--wrap=keystore_secp256k1_nonce_commit,--wrap=keystore_secp256k1_sign"
    keystore_functional


### PR DESCRIPTION
Corresponds to 12 recovery words / 128 bits.