### PR TITLE
memory: increase max number of allowed multisig registrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add securechip_model to DeviceInfo: ATECCC608A or ATECC608B.
 - Added reboot purpose for clearer UX: "Proceed to upgrade?" vs. "Go to startup settings?"
 - Allow creation of 128 bit seeds (12 BIP39 recovery words)
+- Increase maximum number of registered multisig accounts from 10 to 25.
 
 ## 9.5.0 [released 2021-03-10]
 - RestoreFrommnemonic: ported to Rust. Will now return UserAbortError on user abort instead of GenericError.

--- a/src/memory/memory.h
+++ b/src/memory/memory.h
@@ -27,7 +27,7 @@
 #define MEMORY_MULTISIG_NAME_MAX_LEN (31)
 
 // How many multisig configurations (accounts) can be registered.
-#define MEMORY_MULTISIG_NUM_ENTRIES 10
+#define MEMORY_MULTISIG_NUM_ENTRIES 25
 
 typedef struct {
     void (*const random_32_bytes)(uint8_t* buf_out);

--- a/test/unit-test/test_memory_functional.c
+++ b/test/unit-test/test_memory_functional.c
@@ -104,38 +104,19 @@ static void _test_memory_multisig_invalid(void** state)
 static void _test_memory_multisig_full(void** state)
 {
     _reset_memory();
-    const uint8_t hashes[][32] = {
-        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-        "cccccccccccccccccccccccccccccccc",
-        "dddddddddddddddddddddddddddddddd",
-        "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
-        "ffffffffffffffffffffffffffffffff",
-        "gggggggggggggggggggggggggggggggg",
-        "hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh",
-        "iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii",
-        "jjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjj",
-        "kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk",
-    };
-    const char* names[] = {
-        "name1",
-        "name2",
-        "name3",
-        "name4",
-        "name5",
-        "name6",
-        "name7",
-        "name8",
-        "name9",
-        "name10",
-        "name11",
-    };
+    // Only 25 slots available.
+    const size_t limit = 25;
+    uint8_t hashes[limit + 1][32];
+    char names[limit + 1][10];
+    for (size_t i = 0; i < limit + 1; i++) {
+        memset(hashes[i], i + i, 32);
+        snprintf(names[i], sizeof(names[i]), "name%ld", i);
+    }
 
-    // Only 5 slots available.
-    for (int i = 0; i < 10; i++) {
+    for (size_t i = 0; i < limit; i++) {
         assert_int_equal(MEMORY_OK, memory_multisig_set_by_hash(hashes[i], names[i]));
     }
-    assert_int_equal(MEMORY_ERR_FULL, memory_multisig_set_by_hash(hashes[10], names[10]));
+    assert_int_equal(MEMORY_ERR_FULL, memory_multisig_set_by_hash(hashes[limit], names[limit]));
 }
 
 int main(void)


### PR DESCRIPTION
The previous limit of 10 was not enough for a user. While we want keep
as much space reserved for future use as possible, this change should
be okay and still leaves plenty of space. One multisig registration
takes 64 bytes, so we go from 0.625kB to 1.525kB of occupied memory,
out of 8kB in the chunk, with more chunks available for future use.

We can bump the limit easily now since the the space after the multisigs
is unused, so a migration is not necessary.

An alternative to bumping the limit is to provide a way to delete
previous registrations, which would force a re-registration and
re-verification when that multisig account would be used again. This
is also not ideal - having more space to fit accounts is better
and a simpler solution for now. We can observe if there will be users
than require an even greater number, in which case we might offer a
way to delete entries, or suggest to purchase more devices.