### PR TITLE
bootloader: change vars type from uint8_t to bool where makes sense

### DIFF
--- a/src/qtouch/qtouch.c
+++ b/src/qtouch/qtouch.c
@@ -75,7 +75,7 @@ qtm_control_t* p_qtm_control;
 qtm_state_t qstate;
 
 /* Measurement Done Touch Flag  */
-volatile uint8_t measurement_done_touch = 0;
+volatile bool measurement_done_touch = false;
 
 /* Error Handling */
 uint8_t module_error_code = 0;
@@ -372,7 +372,7 @@ static void qtm_post_process_complete(void)
         if (counter == 30 && !measurement_done_touch) {
             for (uint16_t i = 0; i < DEF_NUM_SENSORS; i++) {
                 if (qtouch_get_sensor_node_reference(i) == 0) {
-                    measurement_done_touch = 1;
+                    measurement_done_touch = true;
                     break;
                 }
             }
@@ -383,7 +383,7 @@ static void qtm_post_process_complete(void)
     if ((0U != (qtlib_key_set1.qtm_touch_key_group_data->qtm_keys_status & 0x80U))) {
         p_qtm_control->binding_layer_flags |= (1U << reburst_request);
     } else {
-        measurement_done_touch = 1;
+        measurement_done_touch = true;
     }
 
     if (measurement_done_touch) {

--- a/src/touch/gestures.c
+++ b/src/touch/gestures.c
@@ -43,7 +43,7 @@ static const uint8_t SLIDE_DETECTION_DIFF = MAX_SLIDER_POS * 0.04; // Percent of
  */
 static const uint8_t TAP_SLIDE_TOLERANCE = MAX_SLIDER_POS * 0.1; // Percent of slider range
 
-extern volatile uint8_t measurement_done_touch;
+extern volatile bool measurement_done_touch;
 
 /********************************** STATE **********************************/
 
@@ -259,7 +259,7 @@ static void _emit_continuous_tap_event(void)
 static void _measure_and_emit(void)
 {
     qtouch_process(); // Non blocking
-    if (measurement_done_touch != 1) {
+    if (!measurement_done_touch) {
         return;
     }
 

--- a/test/unit-test/framework/mock_qtouch.c
+++ b/test/unit-test/framework/mock_qtouch.c
@@ -14,12 +14,13 @@
 
 #include <setjmp.h>
 #include <stdarg.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <cmocka.h>
 
 #include "mock_qtouch.h"
 
-volatile uint8_t measurement_done_touch = 1;
+volatile bool measurement_done_touch = true;
 
 uint8_t qtouch_is_scroller_active(uint16_t sensor_node)
 {


### PR DESCRIPTION
Some vars with uint8_t type were actually treated as booleans.
Makes sense to change those to bool so it's easier to read.

Note that this affects qtouch and gestures.

This is a follow up from https://github.com/digitalbitbox/bitbox02-firmware/pull/759#discussion_r653545158.

I haven't actually tried it on a real device yet. Just sending it here so I won't forget.
