### PR TITLE
py/bitbox02: add offset of 27 when signing an ETH message

### DIFF
--- a/py/bitbox02/CHANGELOG.md
+++ b/py/bitbox02/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## 6.0.0
+- Offset the recoverable ID by 27 in the signature returned by `eth_sign_msg()`.

--- a/py/bitbox02/bitbox02/bitbox02/__init__.py
+++ b/py/bitbox02/bitbox02/bitbox02/__init__.py
@@ -16,7 +16,7 @@
 from __future__ import print_function
 import sys
 
-__version__ = "5.3.0"
+__version__ = "6.0.0"
 
 if sys.version_info.major != 3 or sys.version_info.minor < 6:
     print(


### PR DESCRIPTION
The use of this offset for uncompressed pubkeys started in Bitcoin,
and in Ethereum, usage is inconsistent.

MyEtherWallet supports both when verifying:

https://github.com/MyEtherWallet/MyEtherWallet/blob/052f697f3b269db4378f331dbb89d24b406bb7c7/src/components/VerifyMessageInput/VerifyMessageInput.vue#L118

Trezor adds this offset as well.

The testing.aopp.group AOPP demo site requires the offset.