### PR TITLE
py/bitbox02: lower version number that was erroneously bumped

### DIFF
--- a/py/bitbox02/bitbox02/bitbox02/__init__.py
+++ b/py/bitbox02/bitbox02/bitbox02/__init__.py
@@ -16,7 +16,7 @@
 from __future__ import print_function
 import sys
 
-__version__ = "7.0.0"
+__version__ = "6.0.0"
 
 if sys.version_info.major != 3 or sys.version_info.minor < 6:
     print(


### PR DESCRIPTION
The last tagged and released version is 5.3.0. We accidentally bumped
the major version twice. The next version is going to be 6.0.0.