### PR TITLE
sd: use right types for length_out

### DIFF
--- a/src/sd.c
+++ b/src/sd.c
@@ -269,7 +269,10 @@ bool sd_load_bin(const char* fn, const char* dir, uint8_t* buffer, size_t* lengt
         _unmount();
         return false;
     }
-    FRESULT result = f_read(&file_object, buffer, f_size(&file_object), (unsigned int*)length_out);
+    UINT len = 0;
+    FRESULT result = f_read(&file_object, buffer, f_size(&file_object), &len);
+    // UINT and size_t can have different sizes but both are at least 4 bytes.
+    *length_out = (size_t)len;
     f_close(&file_object);
     _unmount();
     return result == FR_OK;


### PR DESCRIPTION
The out length param defined in f_read is of type UINT (typedef of
unsigned int).

The sd_load_bin function uses size_t for the out length param.

On the BitBox02 they are both 4 bytes so it works out. On x86, size_t
is 8 bytes while unsigned int is only 4 bytes, which leads to a
corrupt value due to the invalid cast.