### PR TITLE
sd: remove _USE_LFN sections

### DIFF
--- a/src/sd.c
+++ b/src/sd.c
@@ -288,12 +288,6 @@ bool sd_list_subdir(sd_list_t* list_out, const char* subdir)
     }
     FILINFO fno;
     DIR dir;
-#ifdef _USE_LFN
-    char c_lfn[_MAX_LFN + 1];
-    fno.lfname = c_lfn;
-    fno.lfsize = sizeof(c_lfn);
-#endif
-
     if (!_mount()) {
         return false;
     }
@@ -315,16 +309,11 @@ bool sd_list_subdir(sd_list_t* list_out, const char* subdir)
         return false;
     }
     for (;;) {
-        char* pc_fn;
         result = f_readdir(&dir, &fno);
         if (result != FR_OK || fno.fname[0] == 0) {
             break;
         }
-#ifdef _USE_LFN
-        pc_fn = *fno.lfname ? fno.lfname : fno.fname;
-#else
-        pc_fn = fno.fname;
-#endif
+        const char* pc_fn = fno.fname;
         if (STREQ(pc_fn, ".") || STREQ(pc_fn, "..")) {
             continue;
         }


### PR DESCRIPTION
_USE_LFN does not exist - FF_USE_LFN does. This code is not active and
can be removed.

LFN stands for long filename format, an extension to FAT32 that allows
filenames longer than what "8.3 filenames" allow (8 chars + 3 char
extension).

From http://elm-chan.org/fsw/ff/doc/readdir.html:

A short name is automatically generated from a long name according to
the FAT32 spec.

```
When LFN is enabled, a member altname[] is defined in the file
information structure to store the short file name of the object. If
the long file name is not accessible due to a reason listed below,
short file name is stored to the fname[] and the altname[] has a null
string.
```

I assume that in an old version of FatFs, the long filename was stored
in `lfname` and the short name in `fname`, while now the long name is
stored in `fname` and the short name is stored in `altname`.