### PR TITLE
keystore: allow zero seeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ customers cannot upgrade their bootloader, its changes are recorded separately.
 ## Firmware
 
 ### [Unreleased]
+- Allow recovery words that convert to a zero seed, such as the 12 words `abandon abandon .... about`.
 
 ### 9.7.0 [released 2021-09-06]
 - Allow mainnet keypaths (`m/44'/60'/0'/0/*`) Rinkeby and Ropsten, and testnet keypaths (`m/44'/1'/0'/0/*`) for Ethereum mainnet

--- a/src/keystore.c
+++ b/src/keystore.c
@@ -71,12 +71,6 @@ static uint8_t* _get_seed(void)
     if (!_is_unlocked_device) {
         return NULL;
     }
-    // sanity check
-    uint8_t zero[KEYSTORE_MAX_SEED_LENGTH] = {0};
-    util_zero(zero, sizeof(zero));
-    if (MEMEQ(_retained_seed, zero, KEYSTORE_MAX_SEED_LENGTH)) {
-        return NULL;
-    }
     return _retained_seed;
 }
 


### PR DESCRIPTION
Some users test the wallet using these recovery words:

```
abandon abandon abandon abandon abandon abandon abandon abandon
abandon abandon abandon about
```

Which translates to 16 zero bytes. This is a valid seed just like any
other. The BIP39 seed (the stretched seed using the passphrase) which
is used as the root of BIP32 keys is not zero.

Before this patch, users testing with this seed would get BIP39 unlock
errors due to the wrong sanity check.