### PR TITLE
tests: fix compile time warnings

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -36,7 +36,7 @@ set(LIBWALLY_CFLAGS  "\
 set(LIBWALLY_CFLAGS "${LIBWALLY_CFLAGS} -Wno-cast-qual -Wno-cast-align \
   -Wno-missing-prototypes -Wno-redundant-decls \
   -Wno-switch-default -Wno-missing-declarations \
-  -Wno-array-bounds \
+  -Wno-array-bounds -Wno-unused-label -Wno-sign-compare -Wno-type-limits \
 ")
 if(CMAKE_CROSSCOMPILING)
   set(LIBWALLY_LDFLAGS --specs=nosys.specs)
@@ -222,7 +222,7 @@ set_property(TARGET asf4-drivers PROPERTY INTERFACE_LINK_LIBRARIES "")
   set_property(TARGET cryptoauthlib PROPERTY INTERFACE_LINK_LIBRARIES "")
   target_compile_definitions(cryptoauthlib PUBLIC ATCA_HAL_CUSTOM ATCA_NO_POLL)
   target_include_directories(cryptoauthlib SYSTEM PUBLIC cryptoauthlib/lib)
-  target_compile_options(cryptoauthlib PRIVATE -Wno-pedantic -Wno-incompatible-pointer-types -Wno-unused-parameter -Wno-unused-variable)
+  target_compile_options(cryptoauthlib PRIVATE -Wno-pedantic -Wno-incompatible-pointer-types -Wno-unused-parameter -Wno-unused-variable -Wno-cast-qual)
 endif() # CMAKE_CROSSCOMPILING
 
 # fatfs must to be linked together with a diskio middleware:

--- a/src/rust/bitbox02/src/util.rs
+++ b/src/rust/bitbox02/src/util.rs
@@ -44,7 +44,7 @@ pub fn str_from_null_terminated(input: &[u8]) -> Result<&str, ()> {
 /// let name = "sample_string";
 /// let buf = match str_to_cstr!(name, 50) {
 ///     Ok(buf) => buf,
-///     Err(msg) => panic!(msg),
+///     Err(msg) => panic!("{}", msg),
 /// };
 /// ```
 #[macro_export]

--- a/src/ui/components/confirm.c
+++ b/src/ui/components/confirm.c
@@ -105,7 +105,12 @@ component_t* confirm_create(
 
     if (params->display_size) {
         char size_label[20];
+        // Ignore warning, %u works for 32bit but not 64 bit (unit tests). %zu does not work with
+        // our compiler.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat"
         snprintf(size_label, sizeof(size_label), "Size: %uB", params->display_size);
+#pragma GCC diagnostic pop
         ui_util_add_sub_component(
             confirm, label_create(size_label, params->font, LEFT_BOTTOM, confirm));
     }

--- a/src/ui/ugui/ugui.c
+++ b/src/ui/ugui/ugui.c
@@ -619,7 +619,7 @@ void UG_MeasureStringCentered(UG_S16 *xout, UG_S16 *yout, const char *str)
     const char* start = str;
     for (c = str; *c != '\0'; c++) {
         if (*c == '\n') {
-            snprintf(line, sizeof(line), "%.*s", c - start, start);
+            snprintf(line, sizeof(line), "%.*s", (int)(c - start), start);
             _UG_PutString(0, 0, &calc_width_line, &calc_height_line, line, 0, 1, false);
             *yout += calc_height_line;
             *yout += gui->char_v_space;
@@ -627,7 +627,7 @@ void UG_MeasureStringCentered(UG_S16 *xout, UG_S16 *yout, const char *str)
             start = c + 1;
         }
     }
-    snprintf(line, sizeof(line), "%.*s", c - start, start);
+    snprintf(line, sizeof(line), "%.*s", (int)(c - start), start);
     _UG_PutString(0, 0, &calc_width_line, &calc_height_line, line, 0, 1, false);
     *yout += calc_height_line;
     *yout += gui->char_v_space;
@@ -760,12 +760,12 @@ void UG_PutStringCentered( UG_S16 x, UG_S16 y, UG_S16 width, UG_S16 height, cons
     const char* start = str;
     for (c = str; *c != '\0'; c++) {
         if (*c == '\n' && current_line < UG_MAX_LINE_ROWS) {
-            snprintf(lines[current_line], sizeof(lines[current_line]), "%.*s", c - start, start);
+            snprintf(lines[current_line], sizeof(lines[current_line]), "%.*s", (int)(c - start), start);
             current_line++;
             start = c + 1;
         }
     }
-    snprintf(lines[current_line], sizeof(lines[current_line]), "%.*s", c - start, start);
+    snprintf(lines[current_line], sizeof(lines[current_line]), "%.*s", (int)(c - start), start);
 
     // calculate the height of each line
     _UG_PutString(0, 0, NULL, &calc_height, "W", 0, 1, inverted);

--- a/test/unit-test/test_memory_functional.c
+++ b/test/unit-test/test_memory_functional.c
@@ -109,8 +109,8 @@ static void _test_memory_multisig_full(void** state)
     uint8_t hashes[limit + 1][32];
     char names[limit + 1][10];
     for (size_t i = 0; i < limit + 1; i++) {
-        memset(hashes[i], i + i, 32);
-        snprintf(names[i], sizeof(names[i]), "name%ld", i);
+        memset(hashes[i], (int)(i + i), 32);
+        snprintf(names[i], sizeof(names[i]), "name%lu", i);
     }
 
     for (size_t i = 0; i < limit; i++) {


### PR DESCRIPTION
warning: panic message is not a string literal

```
 --> ../src/rust/src/util.rs:47:24
  |
7 |     Err(msg) => panic!(msg),
  |                        ^^^
  |
  = note: `#[warn(non_fmt_panic)]` on by default
  = note: this is no longer accepted in Rust 2021
help: add a "{}" format string to Display the message
  |
7 |     Err(msg) => panic!("{}", msg),
  |                        ^^^^^
help: or use std::panic::panic_any instead
  |
7 |     Err(msg) => std::panic::panic_any(msg),
  |                 ^^^^^^^^^^^^^^^^^^^^^^
```

Also, closes https://github.com/digitalbitbox/bitbox02-firmware/issues/799.