### PR TITLE
keystore: fix unit test race condition

### DIFF
--- a/src/rust/bitbox02/src/keystore.rs
+++ b/src/rust/bitbox02/src/keystore.rs
@@ -334,6 +334,7 @@ mod tests {
     fn test_get_bip39_mnemonic() {
         let _guard = MUTEX.lock().unwrap();
 
+        lock();
         assert!(get_bip39_mnemonic().is_err());
 
         mock_unlocked();


### PR DESCRIPTION
The keystore might have been unlocked from some other test - all are
working on global state.