### PR TITLE
ci: lint all default python files to avoid errors

### DIFF
--- a/.ci/check-pep8
+++ b/.ci/check-pep8
@@ -17,4 +17,6 @@ if [ -z "${FILES}" ] ; then
 fi
 
 ./scripts/format-python --check --fast ${FILES}
-./scripts/lint-python ${FILES}
+# We lint all default Python files, as linting only a subset can lead to errors (e.g. if
+# send_message.py only is linted without the bitbox02 dep).
+./scripts/lint-python

--- a/scripts/lint-python
+++ b/scripts/lint-python
@@ -14,13 +14,8 @@ command -v ${PYLINT} >/dev/null 2>&1 || { echo >&2 "${PYLINT} is missing"; exit 
 MYPY=${MYPY:-mypy}
 command -v ${MYPY} >/dev/null 2>&1 || { echo >&2 "${MYPY} is missing"; exit 1; }
 
-# Store arguments as array in ARGS
-ARGS=("$@")
-
-if [ $# -eq 0 ] ; then
-	# Store default files as array in ARGS
-	ARGS=($(find py releases -name '*.py' | grep -v -e generated -e old))
-fi
+# Store files as array in ARGS
+ARGS=($(find py releases -name '*.py' | grep -v -e generated -e old))
 
 # implicit-reexport: `from foo import bar` re-exports (normal Python3 behavior), otherwise mypy
 # expects `from foo import bar as bar`.


### PR DESCRIPTION
If e.g. only send_message.py is linted without the bitbox02 package
files, import errors can happen.

We still only start linting if any relevant Python file has been
touched, but then we lint all of them.

The reason if sometimes worked before is that the bitbox02 package
installed in the system was used (installed in Docker during Docker
build), but that was linting the wrong package.