### PR TITLE
main: autoenter into bootloader when Aborting during boot

### DIFF
--- a/src/common_main.c
+++ b/src/common_main.c
@@ -67,10 +67,7 @@ static bool _setup_wally(void)
     return wally_set_operations(&_ops) == WALLY_OK;
 }
 
-// Go into bootloader if there was an error during startup, so a firmware update can be
-// applied. Otherwise, if there is an Abort() during startup, there would no way to reboot into the
-// bootloader and the device would be bricked.
-static void _bootloader_autoenter(void)
+void common_main_bootloader_autoenter(void)
 {
     auto_enter_t auto_enter = {
         .value = sectrue_u8,
@@ -88,12 +85,12 @@ void common_main(void)
     mpu_bitbox02_init();
     if (!memory_setup(&_memory_interface_functions)) {
         // If memory setup failed, this also might fail, but can't hurt to try.
-        _bootloader_autoenter();
+        common_main_bootloader_autoenter();
         Abort("memory_setup failed");
     }
 
     if (!_setup_wally()) {
-        _bootloader_autoenter();
+        common_main_bootloader_autoenter();
         Abort("_setup_wally failed");
     }
 
@@ -104,7 +101,7 @@ void common_main(void)
     // used are already initialized.
     int securechip_result = securechip_setup(&_securechip_interface_functions);
     if (securechip_result) {
-        _bootloader_autoenter();
+        common_main_bootloader_autoenter();
         char errmsg[100] = {0};
         snprintf(
             errmsg,

--- a/src/common_main.h
+++ b/src/common_main.h
@@ -20,6 +20,13 @@
 uint32_t common_stack_chk_guard(void);
 
 /**
+ * Go into bootloader on next reboot. This should be called before any Abort during boot, so a
+ * firmware update can be applied. Otherwise, if there is an Abort() during startup, there would no
+ * way to reboot into the bootloader and the device would be bricked.
+ */
+void common_main_bootloader_autoenter(void);
+
+/**
  * This performs common setup at boot of the firmware/factorysetup.
  */
 void common_main(void);

--- a/src/firmware.c
+++ b/src/firmware.c
@@ -38,7 +38,15 @@ int main(void)
     screen_splash();
     qtouch_init();
     common_main();
-    bitbox02_smarteeprom_init();
+    if (!bitbox02_smarteeprom_init()) {
+        /*
+         * Incorrect version!
+         * Something has gone terribly wrong.
+         * Maybe reset the whole device?
+         */
+        common_main_bootloader_autoenter();
+        Abort("Unrecognized SmartEEPROM version.");
+    }
     traceln("%s", "Device initialized");
     orientation_screen_blocking();
     idle_workflow_blocking();

--- a/src/memory/bitbox02_smarteeprom.c
+++ b/src/memory/bitbox02_smarteeprom.c
@@ -89,11 +89,11 @@ static void _init_v1(void)
     _set_data_version(0x01);
 }
 
-void bitbox02_smarteeprom_init(void)
+bool bitbox02_smarteeprom_init(void)
 {
     uint8_t current_version = _get_data_version();
     if (current_version == BITBOX02_SMARTEEPROM_DATA_VERSION) {
-        return;
+        return true;
     }
     /*
      * Migrate from old versions.
@@ -102,14 +102,9 @@ void bitbox02_smarteeprom_init(void)
      */
     if (current_version == BITBOX02_SMARTEEPROM_UNINITIALIZED_VERSION) {
         _init_v1();
-    } else {
-        /*
-         * Incorrect version!
-         * Something has gone terribly wrong.
-         * Maybe reset the whole device?
-         */
-        Abort("Unrecognized SmartEEPROM version.");
+        return true;
     }
+    return false;
 }
 
 uint8_t bitbox02_smarteeprom_get_unlock_attempts(void)

--- a/src/memory/bitbox02_smarteeprom.h
+++ b/src/memory/bitbox02_smarteeprom.h
@@ -15,7 +15,10 @@
 #ifndef _BITBOX02_SMARTEEPROM_H
 #define _BITBOX02_SMARTEEPROM_H
 
+#include <stdbool.h>
 #include <stdint.h>
+
+#include <compiler_util.h>
 
 /**
  * After this many failed unlock attempts, the keystore becomes locked until a
@@ -48,6 +51,6 @@ void bitbox02_smarteeprom_reset_unlock_attempts(void);
  * Makes sure that the contents of the SmartEEPROM in the BitBox02
  * are up-to-date with the latest struct definition.
  */
-void bitbox02_smarteeprom_init(void);
+USE_RESULT bool bitbox02_smarteeprom_init(void);
 
 #endif // _BITBOX02_SMARTEEPROM_H


### PR DESCRIPTION
To not brick a device permanently with a panic/Abort during boot, we
set the device to boot into the bootloader during the next boot.

We missed one instance: bitbox02_smarteeprom_init() can also Abort()
with a critical error.