### PR TITLE
cardano: update spec references from Shelley to Alonzo

### DIFF
--- a/messages/cardano.proto
+++ b/messages/cardano.proto
@@ -39,7 +39,7 @@ message CardanoScriptConfig {
   // Entries correspond to address types as described in:
   // https://github.com/cardano-foundation/CIPs/blob/6c249ef48f8f5b32efc0ec768fadf4321f3173f2/CIP-0019/CIP-0019.md
   // See also:
-  // https://github.com/input-output-hk/cardano-ledger-specs/blob/c6c4be1562e23a3dd48282387c4e48ff918fbab0/eras/shelley/test-suite/cddl-files/shelley.cddl#L89
+  // https://github.com/input-output-hk/cardano-ledger-specs/blob/d0aa86ded0b973b09b629e5aa62aa1e71364d088/eras/alonzo/test-suite/cddl-files/alonzo.cddl#L137
   oneof config {
     // Shelley PaymentKeyHash & StakeKeyHash
     PkhSkh pkh_skh = 1;
@@ -69,7 +69,7 @@ message CardanoSignTransactionRequest {
     CardanoScriptConfig script_config = 3;
   }
 
-  // See https://github.com/input-output-hk/cardano-ledger-specs/blob/c6c4be1562e23a3dd48282387c4e48ff918fbab0/eras/shelley/test-suite/cddl-files/shelley.cddl#L102
+  // See https://github.com/input-output-hk/cardano-ledger-specs/blob/d0aa86ded0b973b09b629e5aa62aa1e71364d088/eras/alonzo/test-suite/cddl-files/alonzo.cddl#L150
   message Certificate {
     message StakeDelegation {
       repeated uint32 keypath = 1;

--- a/src/rust/bitbox02-rust/src/hww/api/cardano/address.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/cardano/address.rs
@@ -41,7 +41,7 @@ pub const ADDRESS_HASH_SIZE: usize = 28;
 ///
 /// These address tags are accepted:
 /// https://github.com/cardano-foundation/CIPs/blob/0081c890995ff94618145ae5beb7f288c029a86a/CIP-0019/CIP-0019.md#shelley-addresses
-/// See also: https://github.com/input-output-hk/cardano-ledger-specs/blob/c0a7b02a0fb16849206d9bc0e357583d08d54fae/eras/shelley/test-suite/cddl-files/shelley.cddl#L71-L79
+/// See also: https://github.com/input-output-hk/cardano-ledger-specs/blob/d0aa86ded0b973b09b629e5aa62aa1e71364d088/eras/alonzo/test-suite/cddl-files/alonzo.cddl#L119-L127
 pub fn decode_payment_address(params: &params::Params, address: &str) -> Result<Vec<u8>, Error> {
     let (hrp, data, variant) = bech32::decode(address).or(Err(Error::InvalidInput))?;
     if variant != Variant::Bech32 || hrp != params.bech32_hrp_payment {
@@ -73,7 +73,7 @@ pub fn pubkey_hash_at_keypath(keypath: &[u32]) -> Result<[u8; ADDRESS_HASH_SIZE]
     Ok(out)
 }
 
-/// See https://github.com/input-output-hk/cardano-ledger-specs/blob/c0a7b02a0fb16849206d9bc0e357583d08d54fae/eras/shelley/test-suite/cddl-files/shelley.cddl#L71-L79
+/// See https://github.com/input-output-hk/cardano-ledger-specs/blob/d0aa86ded0b973b09b629e5aa62aa1e71364d088/eras/alonzo/test-suite/cddl-files/alonzo.cddl#L119-L127
 fn address_header(params: &params::Params, script_config: &Config) -> u8 {
     let address_tag: u8 = match script_config {
         Config::PkhSkh(_) => 0,

--- a/src/rust/bitbox02-rust/src/hww/api/cardano/sign_transaction/cbor.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/cardano/sign_transaction/cbor.rs
@@ -43,7 +43,7 @@ impl<'a, U: Update> Write for HashedWriter<'a, U> {
     }
 }
 
-/// See https://github.com/input-output-hk/cardano-ledger-specs/blob/c0a7b02a0fb16849206d9bc0e357583d08d54fae/eras/shelley/test-suite/cddl-files/shelley.cddl#L124
+/// See https://github.com/input-output-hk/cardano-ledger-specs/blob/d0aa86ded0b973b09b629e5aa62aa1e71364d088/eras/alonzo/test-suite/cddl-files/alonzo.cddl#L176
 fn encode_stake_credential<W: Write>(
     encoder: &mut Encoder<W>,
     keypath: &[u32],
@@ -55,7 +55,7 @@ fn encode_stake_credential<W: Write>(
 
 /// Encode a withdrawal/reward address.
 ///
-/// See https://github.com/input-output-hk/cardano-ledger-specs/blob/c0a7b02a0fb16849206d9bc0e357583d08d54fae/eras/shelley/test-suite/cddl-files/shelley.cddl#L82
+/// See https://github.com/input-output-hk/cardano-ledger-specs/blob/d0aa86ded0b973b09b629e5aa62aa1e71364d088/eras/alonzo/test-suite/cddl-files/alonzo.cddl#L130
 pub fn encode_withdrawal_address(
     params: &params::Params,
     keypath: &[u32],
@@ -74,7 +74,7 @@ pub fn encode_withdrawal_address(
 /// The transaction must be verified/validated before calling this function.
 ///
 /// References:
-/// - Transaction body encoding spec: https://github.com/input-output-hk/cardano-ledger-specs/blob/c6c4be1562e23a3dd48282387c4e48ff918fbab0/eras/shelley/test-suite/cddl-files/shelley.cddl#L51
+/// - Transaction body encoding spec: https://github.com/input-output-hk/cardano-ledger-specs/blob/d0aa86ded0b973b09b629e5aa62aa1e71364d088/eras/alonzo/test-suite/cddl-files/alonzo.cddl#L50
 /// - Serialization implementation: https://github.com/input-output-hk/cardano-ledger-specs/blob/c6c4be1562e23a3dd48282387c4e48ff918fbab0/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/TxBody.hs#L208
 pub fn encode_transaction_body<W: Write>(
     tx: &pb::CardanoSignTransactionRequest,

--- a/src/rust/bitbox02-rust/src/shiftcrypto.bitbox02.rs
+++ b/src/rust/bitbox02-rust/src/shiftcrypto.bitbox02.rs
@@ -506,7 +506,7 @@ pub struct CardanoScriptConfig {
     /// Entries correspond to address types as described in:
     /// https://github.com/cardano-foundation/CIPs/blob/6c249ef48f8f5b32efc0ec768fadf4321f3173f2/CIP-0019/CIP-0019.md
     /// See also:
-    /// https://github.com/input-output-hk/cardano-ledger-specs/blob/c6c4be1562e23a3dd48282387c4e48ff918fbab0/eras/shelley/test-suite/cddl-files/shelley.cddl#L89
+    /// https://github.com/input-output-hk/cardano-ledger-specs/blob/d0aa86ded0b973b09b629e5aa62aa1e71364d088/eras/alonzo/test-suite/cddl-files/alonzo.cddl#L137
     #[prost(oneof="cardano_script_config::Config", tags="1")]
     pub config: ::core::option::Option<cardano_script_config::Config>,
 }
@@ -522,7 +522,7 @@ pub mod cardano_script_config {
     /// Entries correspond to address types as described in:
     /// https://github.com/cardano-foundation/CIPs/blob/6c249ef48f8f5b32efc0ec768fadf4321f3173f2/CIP-0019/CIP-0019.md
     /// See also:
-    /// https://github.com/input-output-hk/cardano-ledger-specs/blob/c6c4be1562e23a3dd48282387c4e48ff918fbab0/eras/shelley/test-suite/cddl-files/shelley.cddl#L89
+    /// https://github.com/input-output-hk/cardano-ledger-specs/blob/d0aa86ded0b973b09b629e5aa62aa1e71364d088/eras/alonzo/test-suite/cddl-files/alonzo.cddl#L137
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Config {
         /// Shelley PaymentKeyHash & StakeKeyHash
@@ -580,7 +580,7 @@ pub mod cardano_sign_transaction_request {
         #[prost(message, optional, tag="3")]
         pub script_config: ::core::option::Option<super::CardanoScriptConfig>,
     }
-    /// See https://github.com/input-output-hk/cardano-ledger-specs/blob/c6c4be1562e23a3dd48282387c4e48ff918fbab0/eras/shelley/test-suite/cddl-files/shelley.cddl#L102
+    /// See https://github.com/input-output-hk/cardano-ledger-specs/blob/d0aa86ded0b973b09b629e5aa62aa1e71364d088/eras/alonzo/test-suite/cddl-files/alonzo.cddl#L150
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Certificate {
         #[prost(oneof="certificate::Cert", tags="1, 2, 3")]


### PR DESCRIPTION
Alonzo is the currently newest era and up to date spec.

See: https://github.com/input-output-hk/cardano-ledger-specs/tree/d0aa86ded0b973b09b629e5aa62aa1e71364d088