### PR TITLE
main: autoenter into bootloader when Aborting during boot

### DIFF
--- a/src/hardfault.c
+++ b/src/hardfault.c
@@ -14,6 +14,7 @@
 
 #include "hardfault.h"
 #include "util.h"
+#include <memory/memory.h>
 #include <platform_config.h>
 #include <screen.h>
 #include <usb/usb.h>
@@ -45,4 +46,18 @@ void Abort(const char* msg)
 #endif
     while (1) {
     }
+}
+
+void AbortAutoenter(const char* msg)
+{
+    auto_enter_t auto_enter = {
+        .value = sectrue_u8,
+    };
+    upside_down_t upside_down = {
+        .value = screen_is_upside_down(),
+    };
+    if (!memory_bootloader_set_flags(auto_enter, upside_down)) {
+        // If this failed, we might not be able to reboot into the bootloader.
+    }
+    Abort(msg);
 }

--- a/src/hardfault.h
+++ b/src/hardfault.h
@@ -26,4 +26,11 @@ void HardFault_Handler(void) __attribute__((weak));
 // debugging.
 __attribute__((noreturn)) void Abort(const char* msg);
 
+// Abort is for manual calls to stop execution, providing a message for debugging. It also sets
+// autoenter to true, making sure that the device boots into the bootloader after reconnecting it.
+// This should be called for any Abort during firmware startup, so a firmware update can be
+// applied. Otherwise, if there is an Abort() during startup, there would no way to reboot into the
+// bootloader and the device would be bricked.
+__attribute__((noreturn)) void AbortAutoenter(const char* msg);
+
 #endif

--- a/src/memory/bitbox02_smarteeprom.c
+++ b/src/memory/bitbox02_smarteeprom.c
@@ -19,6 +19,7 @@
 #include "memory/smarteeprom.h"
 
 #include <stddef.h>
+#include <stdio.h>
 #include <string.h>
 
 /**
@@ -108,7 +109,9 @@ void bitbox02_smarteeprom_init(void)
          * Something has gone terribly wrong.
          * Maybe reset the whole device?
          */
-        Abort("Unrecognized SmartEEPROM version.");
+        char msg[200] = {0};
+        snprintf(msg, sizeof(msg), "Unrecognized SmartEEPROM version.\nGot %d", current_version);
+        AbortAutoenter(msg);
     }
 }
 


### PR DESCRIPTION
To not brick a device permanently with a panic/Abort during boot, we
set the device to boot into the bootloader during the next boot.

We missed one instance: bitbox02_smarteeprom_init() can also Abort()
with a critical error.