### PR TITLE
api: return Disabled error code if Cardano is disabled

### DIFF
--- a/src/rust/bitbox02-rust/src/hww/api.rs
+++ b/src/rust/bitbox02-rust/src/hww/api.rs
@@ -162,6 +162,8 @@ async fn process_api(request: &Request) -> Option<Result<Response, Error>> {
                 .await
                 .map(|r| Response::Cardano(pb::CardanoResponse { response: Some(r) })),
         ),
+        #[cfg(not(feature = "app-cardano"))]
+        Request::Cardano(_) => Some(Err(Error::Disabled)),
         _ => None,
     }
 }


### PR DESCRIPTION
In the Bitcoin-only target, we should return Disabled, as with
Ethereum, instead of InvalidInput.