### PR TITLE
Docker: remove protoc-gen-doc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -333,8 +333,6 @@ find_program(PROTOC protoc)
 if (PROTOC STREQUAL "PROTOC-NOTFOUND")
   message(FATAL_ERROR "Could not find 'protoc'.")
 endif()
-# used when generating docs from proto files
-find_program(PROTOC_GEN_DOC protoc-gen-doc)
 
 #-----------------------------------------------------------------------------
 # Build
@@ -370,10 +368,6 @@ if(DOXYGEN_FOUND)
   add_dependencies(doc doxygen-docs)
 else()
   message("Doxygen: doxygen not found - docs disabled")
-endif()
-
-if(NOT PROTOC_GEN_DOC STREQUAL "PROTOC_GEN_DOC-NOTFOUND")
-  add_dependencies(doc protobuf-docs)
 endif()
 
 if(CMAKE_CROSSCOMPILING)

--- a/Dockerfile
+++ b/Dockerfile
@@ -116,8 +116,6 @@ ENV PATH $GOROOT/bin:$GOPATH/bin:$PATH
 RUN mkdir -p /opt/go_dist && \
     curl https://dl.google.com/go/go1.14.4.linux-amd64.tar.gz | tar -xz -C /opt/go_dist
 
-RUN go get -v -u github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc
-
 # Install lcov from release (the one from the repos is too old).
 RUN cd /opt && wget https://github.com/linux-test-project/lcov/releases/download/v1.14/lcov-1.14.tar.gz && tar -xf lcov-1.14.tar.gz
 ENV PATH /opt/lcov-1.14/bin:$PATH

--- a/messages/CMakeLists.txt
+++ b/messages/CMakeLists.txt
@@ -64,19 +64,3 @@ add_custom_target(
   generate-protobufs
   DEPENDS ${OUTPUT_SOURCES} ${OUTPUT_HEADERS}
 )
-
-set(PB_DOCS_DIR ${CMAKE_BINARY_DIR}/docs-pb)
-
-if(NOT PROTOC_GEN_DOC STREQUAL "PROTOC_GEN_DOC-NOTFOUND")
-  add_custom_command(
-    OUTPUT ${PB_DOCS_DIR}/index.html
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${PB_DOCS_DIR}
-    COMMAND ${PROTOC} "--proto_path=${CMAKE_CURRENT_SOURCE_DIR}" "--doc_out=${PB_DOCS_DIR}" ${PROTO_FILES_ABSOLUTE}
-    COMMAND ${CMAKE_COMMAND} -E echo Find the protobuf docs here ${PB_DOCS_DIR}/index.html
-    DEPENDS ${PROTO_FILES}
-  )
-  add_custom_target(
-    protobuf-docs
-    DEPENDS ${PB_DOCS_DIR}/index.html
-  )
-endif()


### PR DESCRIPTION
We installed the Go tool from master, which recently had a change
requiring Go 1.17.

Instead of fixing it, we remove the doc generation from Docker/CMake,
as we don't actively use it.