### PR TITLE
binary: strip /home/<user> prefix to restore reproducible builds

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -239,7 +239,8 @@ if(CMAKE_BUILD_TYPE STREQUAL "DEBUG")
 else()
   set(RUST_PROFILE "release")
   set(RUST_CARGO_FLAG "--release")
-  set(RUSTFLAGS --remap-path-prefix=${CMAKE_CURRENT_SOURCE_DIR}/rust=src)
+  # For binary reproducibility, strip path prefixes that can be different depending on environment (e.g. /home/<user>, etc.).
+  set(RUSTFLAGS "--remap-path-prefix=${CMAKE_CURRENT_SOURCE_DIR}/rust=src --remap-path-prefix=$ENV{HOME}=")
 endif()
 
 if(CMAKE_CROSSCOMPILING)


### PR DESCRIPTION
We added the bip32-ed25519 dependency from git.

This added the string `/home/dockeruser/.cargo/git/checkouts/...` to
the binary. Verified using `arm-none-eabi-strings firmware.bin | grep /home`.

We strip the home prefix completely. The already existing remap exists
for the same reason. We keep it b/c simply stripping the home folder
here is not sufficient (the whole repo path can be different).