### PR TITLE
prost: Pre-compile the tool

### DIFF
--- a/.ci/run-container-ci
+++ b/.ci/run-container-ci
@@ -25,7 +25,7 @@
 set -e
 set -x
 
-CONTAINER=shiftcrypto/firmware_v2:21
+CONTAINER=shiftcrypto/firmware_v2:22
 
 if [ "$1" == "pull" ] ; then
 	docker pull "$CONTAINER"

--- a/Dockerfile
+++ b/Dockerfile
@@ -129,5 +129,8 @@ RUN rustup component add clippy
 RUN CARGO_HOME=/opt/cargo cargo install cbindgen --version 0.20.0
 RUN CARGO_HOME=/opt/cargo cargo install bindgen --version 0.59.1
 
+COPY tools/prost-build prost-build
+RUN CARGO_HOME=/opt/cargo cargo install --path prost-build --locked
+
 # Clean temporary files to reduce image size
 RUN rm -rf /var/lib/apt/lists/*

--- a/messages/CMakeLists.txt
+++ b/messages/CMakeLists.txt
@@ -42,6 +42,8 @@ foreach(i ${PROTO_FILES})
   endif()
 endforeach()
 
+find_program(PROST_BUILD prost-build)
+
 add_custom_command(
   OUTPUT ${OUTPUT_SOURCES} ${OUTPUT_HEADERS}
   DEPENDS ${PROTO_FILES} ${PROTO_OPTION_FILES}
@@ -56,8 +58,7 @@ add_custom_command(
   # Using prost-build the normal way as part of build.rs does not work due to a cargo bug:
   # https://github.com/danburkert/prost/issues/344#issuecomment-650721245
   COMMAND
-  ${CMAKE_COMMAND} -E env
-    cargo run --manifest-path=${CMAKE_SOURCE_DIR}/tools/prost-build/Cargo.toml -- --messages-dir=${CMAKE_CURRENT_SOURCE_DIR} --out-dir=${CMAKE_SOURCE_DIR}/src/rust/bitbox02-rust/src/
+    ${PROST_BUILD} --messages-dir=${CMAKE_CURRENT_SOURCE_DIR} --out-dir=${CMAKE_SOURCE_DIR}/src/rust/bitbox02-rust/src/
 )
 
 add_custom_target(


### PR DESCRIPTION
Compiling the tool at build time increases build time and complicates
things when we want to support "cargo test" in the rust libraries.