### PR TITLE
btc: rename output `hash` to `payload`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ customers cannot upgrade their bootloader, its changes are recorded separately.
 ### [Unreleased]
 - ListBackups: ported to Rust
 - Cardano: allow transactions with a zero TTL value
+- Protobuf: rename BTCSignOutputRequest.hash to BTCSignOutputRequest.payload
 
 ### 9.8.0 [released 2021-10-21]
 - Multi edition: add Cardano support.

--- a/messages/btc.options
+++ b/messages/btc.options
@@ -26,7 +26,7 @@ BTCSignInputRequest.prevOutHash fixed_length:true max_size:32
 BTCSignInputRequest.keypath max_count:10
 // provide the `has_host_nonce_commitment` field.
 BTCSignInputRequest.host_nonce_commitment proto3_singular_msgs:false
-BTCSignOutputRequest.hash max_size:32
+BTCSignOutputRequest.payload max_size:32
 BTCSignOutputRequest.keypath max_count:10
 BTCSignNextResponse.signature fixed_length:true max_size:64
 // provide the `has_anti_klepto_signer_commitment` field.

--- a/messages/btc.proto
+++ b/messages/btc.proto
@@ -143,7 +143,7 @@ message BTCSignOutputRequest {
   BTCOutputType type = 2; // if ours is false
   // 20 bytes for p2pkh, p2sh, pw2wpkh. 32 bytes for p2wsh.
   uint64 value = 3;
-  bytes hash = 4; // if ours is false
+  bytes payload = 4; // if ours is false. Renamed from `hash`.
   repeated uint32 keypath = 5; // if ours is true
   // If ours is true. References a script config from BTCSignInitRequest
   uint32 script_config_index = 6;

--- a/py/bitbox02/CHANGELOG.md
+++ b/py/bitbox02/CHANGELOG.md
@@ -2,3 +2,4 @@
 
 ## 6.0.0
 - Offset the recoverable ID by 27 in the signature returned by `eth_sign_msg()`.
+- Rename `BTCOutputExternal.hash` to `BTCOutputExternal.payload`.

--- a/py/bitbox02/bitbox02/bitbox02/bitbox02.py
+++ b/py/bitbox02/bitbox02/bitbox02/bitbox02.py
@@ -112,9 +112,9 @@ class BTCOutputInternal:
 class BTCOutputExternal:
     # TODO: Use NamedTuple, but not playing well with protobuf types.
 
-    def __init__(self, output_type: "btc.BTCOutputType.V", output_hash: bytes, value: int):
+    def __init__(self, output_type: "btc.BTCOutputType.V", output_payload: bytes, value: int):
         self.type = output_type
-        self.hash = output_hash
+        self.payload = output_payload
         self.value = value
 
 
@@ -535,7 +535,7 @@ class BitBox02(BitBoxCommonAPI):
                         btc.BTCSignOutputRequest(
                             ours=False,
                             type=tx_output.type,
-                            hash=tx_output.hash,
+                            payload=tx_output.payload,
                             value=tx_output.value,
                         )
                     )

--- a/py/bitbox02/bitbox02/communication/generated/btc_pb2.py
+++ b/py/bitbox02/bitbox02/communication/generated/btc_pb2.py
@@ -22,7 +22,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='btc.proto',
   package='shiftcrypto.bitbox02',
   syntax='proto3',
-  serialized_pb=_b('\n\tbtc.proto\x12\x14shiftcrypto.bitbox02\x1a\x0c\x63ommon.proto\x1a\x10\x61ntiklepto.proto\"\xaf\x03\n\x0f\x42TCScriptConfig\x12G\n\x0bsimple_type\x18\x01 \x01(\x0e\x32\x30.shiftcrypto.bitbox02.BTCScriptConfig.SimpleTypeH\x00\x12\x42\n\x08multisig\x18\x02 \x01(\x0b\x32..shiftcrypto.bitbox02.BTCScriptConfig.MultisigH\x00\x1a\xd9\x01\n\x08Multisig\x12\x11\n\tthreshold\x18\x01 \x01(\r\x12)\n\x05xpubs\x18\x02 \x03(\x0b\x32\x1a.shiftcrypto.bitbox02.XPub\x12\x16\n\x0eour_xpub_index\x18\x03 \x01(\r\x12N\n\x0bscript_type\x18\x04 \x01(\x0e\x32\x39.shiftcrypto.bitbox02.BTCScriptConfig.Multisig.ScriptType\"\'\n\nScriptType\x12\t\n\x05P2WSH\x10\x00\x12\x0e\n\nP2WSH_P2SH\x10\x01\")\n\nSimpleType\x12\x0f\n\x0bP2WPKH_P2SH\x10\x00\x12\n\n\x06P2WPKH\x10\x01\x42\x08\n\x06\x63onfig\"\xfc\x02\n\rBTCPubRequest\x12+\n\x04\x63oin\x18\x01 \x01(\x0e\x32\x1d.shiftcrypto.bitbox02.BTCCoin\x12\x0f\n\x07keypath\x18\x02 \x03(\r\x12\x41\n\txpub_type\x18\x03 \x01(\x0e\x32,.shiftcrypto.bitbox02.BTCPubRequest.XPubTypeH\x00\x12>\n\rscript_config\x18\x04 \x01(\x0b\x32%.shiftcrypto.bitbox02.BTCScriptConfigH\x00\x12\x0f\n\x07\x64isplay\x18\x05 \x01(\x08\"\x8e\x01\n\x08XPubType\x12\x08\n\x04TPUB\x10\x00\x12\x08\n\x04XPUB\x10\x01\x12\x08\n\x04YPUB\x10\x02\x12\x08\n\x04ZPUB\x10\x03\x12\x08\n\x04VPUB\x10\x04\x12\x08\n\x04UPUB\x10\x05\x12\x10\n\x0c\x43\x41PITAL_VPUB\x10\x06\x12\x10\n\x0c\x43\x41PITAL_ZPUB\x10\x07\x12\x10\n\x0c\x43\x41PITAL_UPUB\x10\x08\x12\x10\n\x0c\x43\x41PITAL_YPUB\x10\tB\x08\n\x06output\"k\n\x1a\x42TCScriptConfigWithKeypath\x12<\n\rscript_config\x18\x02 \x01(\x0b\x32%.shiftcrypto.bitbox02.BTCScriptConfig\x12\x0f\n\x07keypath\x18\x03 \x03(\r\"\xd7\x01\n\x12\x42TCSignInitRequest\x12+\n\x04\x63oin\x18\x01 \x01(\x0e\x32\x1d.shiftcrypto.bitbox02.BTCCoin\x12H\n\x0escript_configs\x18\x02 \x03(\x0b\x32\x30.shiftcrypto.bitbox02.BTCScriptConfigWithKeypath\x12\x0f\n\x07version\x18\x04 \x01(\r\x12\x12\n\nnum_inputs\x18\x05 \x01(\r\x12\x13\n\x0bnum_outputs\x18\x06 \x01(\r\x12\x10\n\x08locktime\x18\x07 \x01(\r\"\xe8\x02\n\x13\x42TCSignNextResponse\x12<\n\x04type\x18\x01 \x01(\x0e\x32..shiftcrypto.bitbox02.BTCSignNextResponse.Type\x12\r\n\x05index\x18\x02 \x01(\r\x12\x15\n\rhas_signature\x18\x03 \x01(\x08\x12\x11\n\tsignature\x18\x04 \x01(\x0c\x12\x12\n\nprev_index\x18\x05 \x01(\r\x12W\n\x1d\x61nti_klepto_signer_commitment\x18\x06 \x01(\x0b\x32\x30.shiftcrypto.bitbox02.AntiKleptoSignerCommitment\"m\n\x04Type\x12\t\n\x05INPUT\x10\x00\x12\n\n\x06OUTPUT\x10\x01\x12\x08\n\x04\x44ONE\x10\x02\x12\x0f\n\x0bPREVTX_INIT\x10\x03\x12\x10\n\x0cPREVTX_INPUT\x10\x04\x12\x11\n\rPREVTX_OUTPUT\x10\x05\x12\x0e\n\nHOST_NONCE\x10\x06\"\xea\x01\n\x13\x42TCSignInputRequest\x12\x13\n\x0bprevOutHash\x18\x01 \x01(\x0c\x12\x14\n\x0cprevOutIndex\x18\x02 \x01(\r\x12\x14\n\x0cprevOutValue\x18\x03 \x01(\x04\x12\x10\n\x08sequence\x18\x04 \x01(\r\x12\x0f\n\x07keypath\x18\x06 \x03(\r\x12\x1b\n\x13script_config_index\x18\x07 \x01(\r\x12R\n\x15host_nonce_commitment\x18\x08 \x01(\x0b\x32\x33.shiftcrypto.bitbox02.AntiKleptoHostNonceCommitment\"\xa2\x01\n\x14\x42TCSignOutputRequest\x12\x0c\n\x04ours\x18\x01 \x01(\x08\x12\x31\n\x04type\x18\x02 \x01(\x0e\x32#.shiftcrypto.bitbox02.BTCOutputType\x12\r\n\x05value\x18\x03 \x01(\x04\x12\x0c\n\x04hash\x18\x04 \x01(\x0c\x12\x0f\n\x07keypath\x18\x05 \x03(\r\x12\x1b\n\x13script_config_index\x18\x06 \x01(\r\"\x99\x01\n\x1b\x42TCScriptConfigRegistration\x12+\n\x04\x63oin\x18\x01 \x01(\x0e\x32\x1d.shiftcrypto.bitbox02.BTCCoin\x12<\n\rscript_config\x18\x02 \x01(\x0b\x32%.shiftcrypto.bitbox02.BTCScriptConfig\x12\x0f\n\x07keypath\x18\x03 \x03(\r\"\x0c\n\nBTCSuccess\"m\n\"BTCIsScriptConfigRegisteredRequest\x12G\n\x0cregistration\x18\x01 \x01(\x0b\x32\x31.shiftcrypto.bitbox02.BTCScriptConfigRegistration\"<\n#BTCIsScriptConfigRegisteredResponse\x12\x15\n\ris_registered\x18\x01 \x01(\x08\"\xfc\x01\n\x1e\x42TCRegisterScriptConfigRequest\x12G\n\x0cregistration\x18\x01 \x01(\x0b\x32\x31.shiftcrypto.bitbox02.BTCScriptConfigRegistration\x12\x0c\n\x04name\x18\x02 \x01(\t\x12P\n\txpub_type\x18\x03 \x01(\x0e\x32=.shiftcrypto.bitbox02.BTCRegisterScriptConfigRequest.XPubType\"1\n\x08XPubType\x12\x11\n\rAUTO_ELECTRUM\x10\x00\x12\x12\n\x0e\x41UTO_XPUB_TPUB\x10\x01\"b\n\x14\x42TCPrevTxInitRequest\x12\x0f\n\x07version\x18\x01 \x01(\r\x12\x12\n\nnum_inputs\x18\x02 \x01(\r\x12\x13\n\x0bnum_outputs\x18\x03 \x01(\r\x12\x10\n\x08locktime\x18\x04 \x01(\r\"r\n\x15\x42TCPrevTxInputRequest\x12\x15\n\rprev_out_hash\x18\x01 \x01(\x0c\x12\x16\n\x0eprev_out_index\x18\x02 \x01(\r\x12\x18\n\x10signature_script\x18\x03 \x01(\x0c\x12\x10\n\x08sequence\x18\x04 \x01(\r\">\n\x16\x42TCPrevTxOutputRequest\x12\r\n\x05value\x18\x01 \x01(\x04\x12\x15\n\rpubkey_script\x18\x02 \x01(\x0c\"\xee\x01\n\x15\x42TCSignMessageRequest\x12+\n\x04\x63oin\x18\x01 \x01(\x0e\x32\x1d.shiftcrypto.bitbox02.BTCCoin\x12G\n\rscript_config\x18\x02 \x01(\x0b\x32\x30.shiftcrypto.bitbox02.BTCScriptConfigWithKeypath\x12\x0b\n\x03msg\x18\x03 \x01(\x0c\x12R\n\x15host_nonce_commitment\x18\x04 \x01(\x0b\x32\x33.shiftcrypto.bitbox02.AntiKleptoHostNonceCommitment\"+\n\x16\x42TCSignMessageResponse\x12\x11\n\tsignature\x18\x01 \x01(\x0c\"\xb6\x04\n\nBTCRequest\x12_\n\x1bis_script_config_registered\x18\x01 \x01(\x0b\x32\x38.shiftcrypto.bitbox02.BTCIsScriptConfigRegisteredRequestH\x00\x12V\n\x16register_script_config\x18\x02 \x01(\x0b\x32\x34.shiftcrypto.bitbox02.BTCRegisterScriptConfigRequestH\x00\x12\x41\n\x0bprevtx_init\x18\x03 \x01(\x0b\x32*.shiftcrypto.bitbox02.BTCPrevTxInitRequestH\x00\x12\x43\n\x0cprevtx_input\x18\x04 \x01(\x0b\x32+.shiftcrypto.bitbox02.BTCPrevTxInputRequestH\x00\x12\x45\n\rprevtx_output\x18\x05 \x01(\x0b\x32,.shiftcrypto.bitbox02.BTCPrevTxOutputRequestH\x00\x12\x43\n\x0csign_message\x18\x06 \x01(\x0b\x32+.shiftcrypto.bitbox02.BTCSignMessageRequestH\x00\x12P\n\x14\x61ntiklepto_signature\x18\x07 \x01(\x0b\x32\x30.shiftcrypto.bitbox02.AntiKleptoSignatureRequestH\x00\x42\t\n\x07request\"\x90\x03\n\x0b\x42TCResponse\x12\x33\n\x07success\x18\x01 \x01(\x0b\x32 .shiftcrypto.bitbox02.BTCSuccessH\x00\x12`\n\x1bis_script_config_registered\x18\x02 \x01(\x0b\x32\x39.shiftcrypto.bitbox02.BTCIsScriptConfigRegisteredResponseH\x00\x12>\n\tsign_next\x18\x03 \x01(\x0b\x32).shiftcrypto.bitbox02.BTCSignNextResponseH\x00\x12\x44\n\x0csign_message\x18\x04 \x01(\x0b\x32,.shiftcrypto.bitbox02.BTCSignMessageResponseH\x00\x12X\n\x1c\x61ntiklepto_signer_commitment\x18\x05 \x01(\x0b\x32\x30.shiftcrypto.bitbox02.AntiKleptoSignerCommitmentH\x00\x42\n\n\x08response*/\n\x07\x42TCCoin\x12\x07\n\x03\x42TC\x10\x00\x12\x08\n\x04TBTC\x10\x01\x12\x07\n\x03LTC\x10\x02\x12\x08\n\x04TLTC\x10\x03*H\n\rBTCOutputType\x12\x0b\n\x07UNKNOWN\x10\x00\x12\t\n\x05P2PKH\x10\x01\x12\x08\n\x04P2SH\x10\x02\x12\n\n\x06P2WPKH\x10\x03\x12\t\n\x05P2WSH\x10\x04\x62\x06proto3')
+  serialized_pb=_b('\n\tbtc.proto\x12\x14shiftcrypto.bitbox02\x1a\x0c\x63ommon.proto\x1a\x10\x61ntiklepto.proto\"\xaf\x03\n\x0f\x42TCScriptConfig\x12G\n\x0bsimple_type\x18\x01 \x01(\x0e\x32\x30.shiftcrypto.bitbox02.BTCScriptConfig.SimpleTypeH\x00\x12\x42\n\x08multisig\x18\x02 \x01(\x0b\x32..shiftcrypto.bitbox02.BTCScriptConfig.MultisigH\x00\x1a\xd9\x01\n\x08Multisig\x12\x11\n\tthreshold\x18\x01 \x01(\r\x12)\n\x05xpubs\x18\x02 \x03(\x0b\x32\x1a.shiftcrypto.bitbox02.XPub\x12\x16\n\x0eour_xpub_index\x18\x03 \x01(\r\x12N\n\x0bscript_type\x18\x04 \x01(\x0e\x32\x39.shiftcrypto.bitbox02.BTCScriptConfig.Multisig.ScriptType\"\'\n\nScriptType\x12\t\n\x05P2WSH\x10\x00\x12\x0e\n\nP2WSH_P2SH\x10\x01\")\n\nSimpleType\x12\x0f\n\x0bP2WPKH_P2SH\x10\x00\x12\n\n\x06P2WPKH\x10\x01\x42\x08\n\x06\x63onfig\"\xfc\x02\n\rBTCPubRequest\x12+\n\x04\x63oin\x18\x01 \x01(\x0e\x32\x1d.shiftcrypto.bitbox02.BTCCoin\x12\x0f\n\x07keypath\x18\x02 \x03(\r\x12\x41\n\txpub_type\x18\x03 \x01(\x0e\x32,.shiftcrypto.bitbox02.BTCPubRequest.XPubTypeH\x00\x12>\n\rscript_config\x18\x04 \x01(\x0b\x32%.shiftcrypto.bitbox02.BTCScriptConfigH\x00\x12\x0f\n\x07\x64isplay\x18\x05 \x01(\x08\"\x8e\x01\n\x08XPubType\x12\x08\n\x04TPUB\x10\x00\x12\x08\n\x04XPUB\x10\x01\x12\x08\n\x04YPUB\x10\x02\x12\x08\n\x04ZPUB\x10\x03\x12\x08\n\x04VPUB\x10\x04\x12\x08\n\x04UPUB\x10\x05\x12\x10\n\x0c\x43\x41PITAL_VPUB\x10\x06\x12\x10\n\x0c\x43\x41PITAL_ZPUB\x10\x07\x12\x10\n\x0c\x43\x41PITAL_UPUB\x10\x08\x12\x10\n\x0c\x43\x41PITAL_YPUB\x10\tB\x08\n\x06output\"k\n\x1a\x42TCScriptConfigWithKeypath\x12<\n\rscript_config\x18\x02 \x01(\x0b\x32%.shiftcrypto.bitbox02.BTCScriptConfig\x12\x0f\n\x07keypath\x18\x03 \x03(\r\"\xd7\x01\n\x12\x42TCSignInitRequest\x12+\n\x04\x63oin\x18\x01 \x01(\x0e\x32\x1d.shiftcrypto.bitbox02.BTCCoin\x12H\n\x0escript_configs\x18\x02 \x03(\x0b\x32\x30.shiftcrypto.bitbox02.BTCScriptConfigWithKeypath\x12\x0f\n\x07version\x18\x04 \x01(\r\x12\x12\n\nnum_inputs\x18\x05 \x01(\r\x12\x13\n\x0bnum_outputs\x18\x06 \x01(\r\x12\x10\n\x08locktime\x18\x07 \x01(\r\"\xe8\x02\n\x13\x42TCSignNextResponse\x12<\n\x04type\x18\x01 \x01(\x0e\x32..shiftcrypto.bitbox02.BTCSignNextResponse.Type\x12\r\n\x05index\x18\x02 \x01(\r\x12\x15\n\rhas_signature\x18\x03 \x01(\x08\x12\x11\n\tsignature\x18\x04 \x01(\x0c\x12\x12\n\nprev_index\x18\x05 \x01(\r\x12W\n\x1d\x61nti_klepto_signer_commitment\x18\x06 \x01(\x0b\x32\x30.shiftcrypto.bitbox02.AntiKleptoSignerCommitment\"m\n\x04Type\x12\t\n\x05INPUT\x10\x00\x12\n\n\x06OUTPUT\x10\x01\x12\x08\n\x04\x44ONE\x10\x02\x12\x0f\n\x0bPREVTX_INIT\x10\x03\x12\x10\n\x0cPREVTX_INPUT\x10\x04\x12\x11\n\rPREVTX_OUTPUT\x10\x05\x12\x0e\n\nHOST_NONCE\x10\x06\"\xea\x01\n\x13\x42TCSignInputRequest\x12\x13\n\x0bprevOutHash\x18\x01 \x01(\x0c\x12\x14\n\x0cprevOutIndex\x18\x02 \x01(\r\x12\x14\n\x0cprevOutValue\x18\x03 \x01(\x04\x12\x10\n\x08sequence\x18\x04 \x01(\r\x12\x0f\n\x07keypath\x18\x06 \x03(\r\x12\x1b\n\x13script_config_index\x18\x07 \x01(\r\x12R\n\x15host_nonce_commitment\x18\x08 \x01(\x0b\x32\x33.shiftcrypto.bitbox02.AntiKleptoHostNonceCommitment\"\xa5\x01\n\x14\x42TCSignOutputRequest\x12\x0c\n\x04ours\x18\x01 \x01(\x08\x12\x31\n\x04type\x18\x02 \x01(\x0e\x32#.shiftcrypto.bitbox02.BTCOutputType\x12\r\n\x05value\x18\x03 \x01(\x04\x12\x0f\n\x07payload\x18\x04 \x01(\x0c\x12\x0f\n\x07keypath\x18\x05 \x03(\r\x12\x1b\n\x13script_config_index\x18\x06 \x01(\r\"\x99\x01\n\x1b\x42TCScriptConfigRegistration\x12+\n\x04\x63oin\x18\x01 \x01(\x0e\x32\x1d.shiftcrypto.bitbox02.BTCCoin\x12<\n\rscript_config\x18\x02 \x01(\x0b\x32%.shiftcrypto.bitbox02.BTCScriptConfig\x12\x0f\n\x07keypath\x18\x03 \x03(\r\"\x0c\n\nBTCSuccess\"m\n\"BTCIsScriptConfigRegisteredRequest\x12G\n\x0cregistration\x18\x01 \x01(\x0b\x32\x31.shiftcrypto.bitbox02.BTCScriptConfigRegistration\"<\n#BTCIsScriptConfigRegisteredResponse\x12\x15\n\ris_registered\x18\x01 \x01(\x08\"\xfc\x01\n\x1e\x42TCRegisterScriptConfigRequest\x12G\n\x0cregistration\x18\x01 \x01(\x0b\x32\x31.shiftcrypto.bitbox02.BTCScriptConfigRegistration\x12\x0c\n\x04name\x18\x02 \x01(\t\x12P\n\txpub_type\x18\x03 \x01(\x0e\x32=.shiftcrypto.bitbox02.BTCRegisterScriptConfigRequest.XPubType\"1\n\x08XPubType\x12\x11\n\rAUTO_ELECTRUM\x10\x00\x12\x12\n\x0e\x41UTO_XPUB_TPUB\x10\x01\"b\n\x14\x42TCPrevTxInitRequest\x12\x0f\n\x07version\x18\x01 \x01(\r\x12\x12\n\nnum_inputs\x18\x02 \x01(\r\x12\x13\n\x0bnum_outputs\x18\x03 \x01(\r\x12\x10\n\x08locktime\x18\x04 \x01(\r\"r\n\x15\x42TCPrevTxInputRequest\x12\x15\n\rprev_out_hash\x18\x01 \x01(\x0c\x12\x16\n\x0eprev_out_index\x18\x02 \x01(\r\x12\x18\n\x10signature_script\x18\x03 \x01(\x0c\x12\x10\n\x08sequence\x18\x04 \x01(\r\">\n\x16\x42TCPrevTxOutputRequest\x12\r\n\x05value\x18\x01 \x01(\x04\x12\x15\n\rpubkey_script\x18\x02 \x01(\x0c\"\xee\x01\n\x15\x42TCSignMessageRequest\x12+\n\x04\x63oin\x18\x01 \x01(\x0e\x32\x1d.shiftcrypto.bitbox02.BTCCoin\x12G\n\rscript_config\x18\x02 \x01(\x0b\x32\x30.shiftcrypto.bitbox02.BTCScriptConfigWithKeypath\x12\x0b\n\x03msg\x18\x03 \x01(\x0c\x12R\n\x15host_nonce_commitment\x18\x04 \x01(\x0b\x32\x33.shiftcrypto.bitbox02.AntiKleptoHostNonceCommitment\"+\n\x16\x42TCSignMessageResponse\x12\x11\n\tsignature\x18\x01 \x01(\x0c\"\xb6\x04\n\nBTCRequest\x12_\n\x1bis_script_config_registered\x18\x01 \x01(\x0b\x32\x38.shiftcrypto.bitbox02.BTCIsScriptConfigRegisteredRequestH\x00\x12V\n\x16register_script_config\x18\x02 \x01(\x0b\x32\x34.shiftcrypto.bitbox02.BTCRegisterScriptConfigRequestH\x00\x12\x41\n\x0bprevtx_init\x18\x03 \x01(\x0b\x32*.shiftcrypto.bitbox02.BTCPrevTxInitRequestH\x00\x12\x43\n\x0cprevtx_input\x18\x04 \x01(\x0b\x32+.shiftcrypto.bitbox02.BTCPrevTxInputRequestH\x00\x12\x45\n\rprevtx_output\x18\x05 \x01(\x0b\x32,.shiftcrypto.bitbox02.BTCPrevTxOutputRequestH\x00\x12\x43\n\x0csign_message\x18\x06 \x01(\x0b\x32+.shiftcrypto.bitbox02.BTCSignMessageRequestH\x00\x12P\n\x14\x61ntiklepto_signature\x18\x07 \x01(\x0b\x32\x30.shiftcrypto.bitbox02.AntiKleptoSignatureRequestH\x00\x42\t\n\x07request\"\x90\x03\n\x0b\x42TCResponse\x12\x33\n\x07success\x18\x01 \x01(\x0b\x32 .shiftcrypto.bitbox02.BTCSuccessH\x00\x12`\n\x1bis_script_config_registered\x18\x02 \x01(\x0b\x32\x39.shiftcrypto.bitbox02.BTCIsScriptConfigRegisteredResponseH\x00\x12>\n\tsign_next\x18\x03 \x01(\x0b\x32).shiftcrypto.bitbox02.BTCSignNextResponseH\x00\x12\x44\n\x0csign_message\x18\x04 \x01(\x0b\x32,.shiftcrypto.bitbox02.BTCSignMessageResponseH\x00\x12X\n\x1c\x61ntiklepto_signer_commitment\x18\x05 \x01(\x0b\x32\x30.shiftcrypto.bitbox02.AntiKleptoSignerCommitmentH\x00\x42\n\n\x08response*/\n\x07\x42TCCoin\x12\x07\n\x03\x42TC\x10\x00\x12\x08\n\x04TBTC\x10\x01\x12\x07\n\x03LTC\x10\x02\x12\x08\n\x04TLTC\x10\x03*H\n\rBTCOutputType\x12\x0b\n\x07UNKNOWN\x10\x00\x12\t\n\x05P2PKH\x10\x01\x12\x08\n\x04P2SH\x10\x02\x12\n\n\x06P2WPKH\x10\x03\x12\t\n\x05P2WSH\x10\x04\x62\x06proto3')
   ,
   dependencies=[common__pb2.DESCRIPTOR,antiklepto__pb2.DESCRIPTOR,])
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
@@ -52,8 +52,8 @@ _BTCCOIN = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=4112,
-  serialized_end=4159,
+  serialized_start=4115,
+  serialized_end=4162,
 )
 _sym_db.RegisterEnumDescriptor(_BTCCOIN)
 
@@ -87,8 +87,8 @@ _BTCOUTPUTTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=4161,
-  serialized_end=4233,
+  serialized_start=4164,
+  serialized_end=4236,
 )
 _sym_db.RegisterEnumDescriptor(_BTCOUTPUTTYPE)
 
@@ -261,8 +261,8 @@ _BTCREGISTERSCRIPTCONFIGREQUEST_XPUBTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=2523,
-  serialized_end=2572,
+  serialized_start=2526,
+  serialized_end=2575,
 )
 _sym_db.RegisterEnumDescriptor(_BTCREGISTERSCRIPTCONFIGREQUEST_XPUBTYPE)
 
@@ -697,7 +697,7 @@ _BTCSIGNOUTPUTREQUEST = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='hash', full_name='shiftcrypto.bitbox02.BTCSignOutputRequest.hash', index=3,
+      name='payload', full_name='shiftcrypto.bitbox02.BTCSignOutputRequest.payload', index=3,
       number=4, type=12, cpp_type=9, label=1,
       has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
@@ -730,7 +730,7 @@ _BTCSIGNOUTPUTREQUEST = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=1812,
-  serialized_end=1974,
+  serialized_end=1977,
 )
 
 
@@ -774,8 +774,8 @@ _BTCSCRIPTCONFIGREGISTRATION = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1977,
-  serialized_end=2130,
+  serialized_start=1980,
+  serialized_end=2133,
 )
 
 
@@ -798,8 +798,8 @@ _BTCSUCCESS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2132,
-  serialized_end=2144,
+  serialized_start=2135,
+  serialized_end=2147,
 )
 
 
@@ -829,8 +829,8 @@ _BTCISSCRIPTCONFIGREGISTEREDREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2146,
-  serialized_end=2255,
+  serialized_start=2149,
+  serialized_end=2258,
 )
 
 
@@ -860,8 +860,8 @@ _BTCISSCRIPTCONFIGREGISTEREDRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2257,
-  serialized_end=2317,
+  serialized_start=2260,
+  serialized_end=2320,
 )
 
 
@@ -906,8 +906,8 @@ _BTCREGISTERSCRIPTCONFIGREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2320,
-  serialized_end=2572,
+  serialized_start=2323,
+  serialized_end=2575,
 )
 
 
@@ -958,8 +958,8 @@ _BTCPREVTXINITREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2574,
-  serialized_end=2672,
+  serialized_start=2577,
+  serialized_end=2675,
 )
 
 
@@ -1010,8 +1010,8 @@ _BTCPREVTXINPUTREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2674,
-  serialized_end=2788,
+  serialized_start=2677,
+  serialized_end=2791,
 )
 
 
@@ -1048,8 +1048,8 @@ _BTCPREVTXOUTPUTREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2790,
-  serialized_end=2852,
+  serialized_start=2793,
+  serialized_end=2855,
 )
 
 
@@ -1100,8 +1100,8 @@ _BTCSIGNMESSAGEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2855,
-  serialized_end=3093,
+  serialized_start=2858,
+  serialized_end=3096,
 )
 
 
@@ -1131,8 +1131,8 @@ _BTCSIGNMESSAGERESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3095,
-  serialized_end=3138,
+  serialized_start=3098,
+  serialized_end=3141,
 )
 
 
@@ -1207,8 +1207,8 @@ _BTCREQUEST = _descriptor.Descriptor(
       name='request', full_name='shiftcrypto.bitbox02.BTCRequest.request',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=3141,
-  serialized_end=3707,
+  serialized_start=3144,
+  serialized_end=3710,
 )
 
 
@@ -1269,8 +1269,8 @@ _BTCRESPONSE = _descriptor.Descriptor(
       name='response', full_name='shiftcrypto.bitbox02.BTCResponse.response',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=3710,
-  serialized_end=4110,
+  serialized_start=3713,
+  serialized_end=4113,
 )
 
 _BTCSCRIPTCONFIG_MULTISIG.fields_by_name['xpubs'].message_type = common__pb2._XPUB

--- a/py/bitbox02/bitbox02/communication/generated/btc_pb2.pyi
+++ b/py/bitbox02/bitbox02/communication/generated/btc_pb2.pyi
@@ -364,7 +364,7 @@ class BTCSignOutputRequest(google.protobuf.message.Message):
     OURS_FIELD_NUMBER: builtins.int
     TYPE_FIELD_NUMBER: builtins.int
     VALUE_FIELD_NUMBER: builtins.int
-    HASH_FIELD_NUMBER: builtins.int
+    PAYLOAD_FIELD_NUMBER: builtins.int
     KEYPATH_FIELD_NUMBER: builtins.int
     SCRIPT_CONFIG_INDEX_FIELD_NUMBER: builtins.int
     ours: builtins.bool = ...
@@ -374,8 +374,8 @@ class BTCSignOutputRequest(google.protobuf.message.Message):
     value: builtins.int = ...
     """20 bytes for p2pkh, p2sh, pw2wpkh. 32 bytes for p2wsh."""
 
-    hash: builtins.bytes = ...
-    """if ours is false"""
+    payload: builtins.bytes = ...
+    """if ours is false. Renamed from `hash`."""
 
     @property
     def keypath(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.int]:
@@ -389,11 +389,11 @@ class BTCSignOutputRequest(google.protobuf.message.Message):
         ours : builtins.bool = ...,
         type : global___BTCOutputType.V = ...,
         value : builtins.int = ...,
-        hash : builtins.bytes = ...,
+        payload : builtins.bytes = ...,
         keypath : typing.Optional[typing.Iterable[builtins.int]] = ...,
         script_config_index : builtins.int = ...,
         ) -> None: ...
-    def ClearField(self, field_name: typing_extensions.Literal["hash",b"hash","keypath",b"keypath","ours",b"ours","script_config_index",b"script_config_index","type",b"type","value",b"value"]) -> None: ...
+    def ClearField(self, field_name: typing_extensions.Literal["keypath",b"keypath","ours",b"ours","payload",b"payload","script_config_index",b"script_config_index","type",b"type","value",b"value"]) -> None: ...
 global___BTCSignOutputRequest = BTCSignOutputRequest
 
 class BTCScriptConfigRegistration(google.protobuf.message.Message):

--- a/py/send_message.py
+++ b/py/send_message.py
@@ -146,7 +146,7 @@ def _btc_demo_inputs_outputs(
         ),
         bitbox02.BTCOutputExternal(
             output_type=bitbox02.btc.P2WSH,
-            output_hash=b"11111111111111111111111111111111",
+            output_payload=b"11111111111111111111111111111111",
             value=int(1e8 * 0.2),
         ),
     ]
@@ -501,7 +501,7 @@ class SendMessage:
                 bitbox02.BTCOutputExternal(
                     # TODO: parse pubkey script
                     output_type=bitbox02.btc.P2WSH,
-                    output_hash=b"11111111111111111111111111111111",
+                    output_payload=b"11111111111111111111111111111111",
                     value=outp["value"],
                 )
             )

--- a/src/apps/btc/btc.c
+++ b/src/apps/btc/btc.c
@@ -49,13 +49,19 @@ bool app_btc_address_simple(
         return false;
     }
 
-    uint8_t hash[32] = {0};
-    size_t hash_size_out = 0;
-    if (!btc_common_outputhash_from_pubkeyhash(script_type, pubkey_hash160, hash, &hash_size_out)) {
+    uint8_t payload[32] = {0};
+    size_t payload_size_out = 0;
+    if (!btc_common_payload_from_pubkeyhash(
+            script_type, pubkey_hash160, payload, &payload_size_out)) {
         return false;
     }
-    return btc_common_address_from_outputhash(
-        params, btc_common_determine_output_type(script_type), hash, hash_size_out, out, out_len);
+    return btc_common_address_from_payload(
+        params,
+        btc_common_determine_output_type(script_type),
+        payload,
+        payload_size_out,
+        out,
+        out_len);
 }
 
 app_btc_result_t app_btc_address_multisig(
@@ -94,17 +100,17 @@ app_btc_result_t app_btc_address_multisig(
         return APP_BTC_ERR_USER_ABORT;
     }
 
-    uint8_t hash[SHA256_LEN] = {0};
+    uint8_t payload[SHA256_LEN] = {0};
     size_t written = 0;
-    if (!btc_common_outputhash_from_multisig(
-            multisig, keypath[keypath_len - 2], keypath[keypath_len - 1], hash, &written)) {
+    if (!btc_common_payload_from_multisig(
+            multisig, keypath[keypath_len - 2], keypath[keypath_len - 1], payload, &written)) {
         return APP_BTC_ERR_UNKNOWN;
     }
 
-    if (!btc_common_address_from_outputhash(
+    if (!btc_common_address_from_payload(
             params,
             btc_common_determine_output_type_multisig(multisig),
-            hash,
+            payload,
             written,
             out,
             out_len)) {

--- a/src/apps/btc/btc_common.h
+++ b/src/apps/btc/btc_common.h
@@ -70,20 +70,20 @@ USE_RESULT bool btc_common_is_valid_keypath_address_multisig(
     uint32_t expected_coin);
 
 /**
- * Converts a pubkeyhash to a hash used in an output script, e.g. pubkeyhash or script hash.
+ * Converts a pubkeyhash to a payload used in an output script, e.g. pubkeyhash or script hash.
  * The pkScript to be hashed is created based on the script type (output type).
  * @param[in] script_type script type defining the pkScript.
  * @param[in] pubkey_hash hash160 of a public key. Must be of size HASH160_LEN.
- * @param[out] output_hash will have the resulting hash. Must be of size 32.
- * @param[out] output_hash_size will be 32 for p2wsh scripts, HASH160_LEN for
+ * @param[out] output_payload will have the resulting payload. Must be of size 32.
+ * @param[out] output_payload_size will be 32 for p2wsh scripts, HASH160_LEN for
  * all others.
  * return true on succes, false on failure.
  */
-USE_RESULT bool btc_common_outputhash_from_pubkeyhash(
+USE_RESULT bool btc_common_payload_from_pubkeyhash(
     BTCScriptConfig_SimpleType script_type,
     const uint8_t* pubkey_hash,
-    uint8_t* output_hash,
-    size_t* output_hash_size);
+    uint8_t* output_payload,
+    size_t* output_payload_size);
 
 /**
  * Converts a pubkeyhash to the subscript/scriptCode used in the sighash algo.
@@ -112,14 +112,14 @@ USE_RESULT BTCOutputType
 btc_common_determine_output_type_multisig(const BTCScriptConfig_Multisig* multisig);
 
 /**
- * Converts an output script or publickey hash to an address.
- * hash, hash_size can be obtained from btc_common_outputhash_from_pubkeyhash().
+ * Converts a payload to an address.
+ * payload, payload_size can be obtained from btc_common_payload_from_pubkeyhash().
  */
-USE_RESULT bool btc_common_address_from_outputhash(
+USE_RESULT bool btc_common_address_from_payload(
     const app_btc_coin_params_t* params,
     BTCOutputType output_type,
-    const uint8_t* hash,
-    size_t hash_size,
+    const uint8_t* payload,
+    size_t payload_size,
     char* out,
     size_t out_len);
 
@@ -127,13 +127,13 @@ USE_RESULT bool btc_common_address_from_outputhash(
  * Computes the pkScript from a pubkey or script hash depending on the output
  * type.
  * @param[in] output_type type of pkScript.
- * @param[in] hash pubkey hash or script hash
+ * @param[in] payload pubkey hash or script hash.
  * @param[inout] pk_script_len: size of pk_script IN, size of the resulting pk_script OUT.
  */
-USE_RESULT bool btc_common_pkscript_from_outputhash(
+USE_RESULT bool btc_common_pkscript_from_payload(
     BTCOutputType output_type,
-    const uint8_t* hash,
-    size_t hash_size,
+    const uint8_t* payload,
+    size_t payload_size,
     uint8_t* pk_script,
     size_t* pk_script_len);
 
@@ -162,16 +162,16 @@ USE_RESULT bool btc_common_pkscript_from_multisig(
  * xpubs.
  * @param[in] keypath_change 0 for receive addresses, 1 for change addresses.
  * @param[in] keypath_address receive address index.
- * @param[out] output_hash result, must be at least `SHA256_LEN` bytes.
- * @param[out] size of the output hash. Will be `SHA256_LEN` for P2WSH and `HASH160_LEN` for
- * P2WSH-P2SH.
+ * @param[out] output_payload result, must be at least `SHA256_LEN` bytes.
+ * @param[out] output_payload_size of the output hash. Will be `SHA256_LEN` for P2WSH and
+ * `HASH160_LEN` for P2WSH-P2SH.
  */
-USE_RESULT bool btc_common_outputhash_from_multisig(
+USE_RESULT bool btc_common_payload_from_multisig(
     const BTCScriptConfig_Multisig* multisig,
     uint32_t keypath_change,
     uint32_t keypath_address,
-    uint8_t* output_hash,
-    size_t* output_hash_size);
+    uint8_t* output_payload,
+    size_t* output_payload_size);
 
 /**
  * Validate a m-of-n multisig account. This includes checking that:

--- a/src/rust/bitbox02-rust/src/shiftcrypto.bitbox02.rs
+++ b/src/rust/bitbox02-rust/src/shiftcrypto.bitbox02.rs
@@ -329,9 +329,9 @@ pub struct BtcSignOutputRequest {
     /// 20 bytes for p2pkh, p2sh, pw2wpkh. 32 bytes for p2wsh.
     #[prost(uint64, tag="3")]
     pub value: u64,
-    /// if ours is false
+    /// if ours is false. Renamed from `hash`.
     #[prost(bytes="vec", tag="4")]
-    pub hash: ::prost::alloc::vec::Vec<u8>,
+    pub payload: ::prost::alloc::vec::Vec<u8>,
     /// if ours is true
     #[prost(uint32, repeated, tag="5")]
     pub keypath: ::prost::alloc::vec::Vec<u32>,

--- a/test/unit-test/test_app_btc_sign_multisig.c
+++ b/test/unit-test/test_app_btc_sign_multisig.c
@@ -217,7 +217,7 @@ static _tx _make_test_tx(void)
                     .ours = false,
                     .type = BTCOutputType_P2WSH,
                     .value = 90000, // btc 0.0009
-                    .hash =
+                    .payload =
                         {.size = 32,
                          .bytes =
                              "\x59\x88\x02\x4d\x26\x74\x2c\x74\xd1\x1c\x3b\x28\x83\xe7\x57\x84\x67"

--- a/test/unit-test/test_btc_sign.c
+++ b/test/unit-test/test_btc_sign.c
@@ -661,7 +661,7 @@ static void _sign(const _modification_t* mod)
             .ours = false,
             .type = BTCOutputType_P2PKH,
             .value = 100000000, // btc 1
-            .hash =
+            .payload =
                 {
                     .size = 20,
                     .bytes =
@@ -675,7 +675,7 @@ static void _sign(const _modification_t* mod)
             .ours = false,
             .type = BTCOutputType_P2SH,
             .value = 1234567890, // btc 12.3456789
-            .hash =
+            .payload =
                 {
                     .size = 20,
                     .bytes =
@@ -689,7 +689,7 @@ static void _sign(const _modification_t* mod)
             .ours = false,
             .type = BTCOutputType_P2WPKH,
             .value = 6000, // btc .00006
-            .hash =
+            .payload =
                 {
                     .size = 20,
                     .bytes =
@@ -703,7 +703,7 @@ static void _sign(const _modification_t* mod)
             .ours = false,
             .type = BTCOutputType_P2WSH,
             .value = 7000, // btc .00007
-            .hash =
+            .payload =
                 {
                     .size = 32,
                     .bytes =


### PR DESCRIPTION
When confirming a tx, the recipient address is reconstructed from the
payload provided in the protobuf `BTCSignOutputRequest` type and
displayed for confirmation.

We previously named the payload `hash` as it always was a hash: either
a pubkey hash in case of P2WPKH (pay to witness pubkey hash), or a
script hash in case of P2SH (pay to scripthash) or P2WSH (pay to
witness script hash).

With the Taproot softfork that recently activated on Bitcoin, the
payload is no longer a hash of something but a 32 byte public key. See
https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki ("Why
is the public key directly included in the output?").

"Payload" as a term is also used in other Bitcoin libraries for the
decoded address input, e.g. in rust-bitcoin. We apply the same rename
to the relevant helper functions in btc_common.h.

This is not a breaking change for the BitBox02 API, as the protobuf
names are not present in the binary serialization, so existing
downstream integrations are not affected.

Projects that update to the changed protobuf file will have to rename
`hash` to `payload` in the code generated from the protobuf files.

Alternatives considered:

- Keep `hash` as is, add another field `pubkey`. This puts as much
  burden on the client libraries as renaming to payload, but adds
  complexity to the firmware code.
- Add `encoded_address`, and let the firmware decode it into the
  payload and validate it. This would be a new way of showing
  recipient addresses, but we'd need to keep supporting the old way
  for backwards compatibility. In some inputs, e.g. PSBT, there is no
  address string to provide, so it does not even make it easier for
  downstream projects in all cases.

It seems that the rename was the easiest solution.
