### PR TITLE
scripts/format-python: fix exception related to encodings

### DIFF
--- a/scripts/format-python
+++ b/scripts/format-python
@@ -19,4 +19,4 @@ if [ $# -eq 0 ] ; then
 	ARGS=($(find py -name '*.py' | grep -v -e generated -e old))
 fi
 
-${BLACK} "${ARGS[@]}"
+LC_ALL=C.UTF-8 ${BLACK} "${ARGS[@]}"


### PR DESCRIPTION
Out of nowhere this exception appears when running `./scripts/docker_exec.sh ./scripts/format-python --check --fast py/`:

```
./scripts/docker_exec.sh ./scripts/format-python --check --fast py/
Traceback (most recent call last):
  File "/usr/local/bin/black", line 8, in <module>
    sys.exit(patched_main())
  File "/usr/local/lib/python3.6/dist-packages/black.py", line 3754, in patched_main
    main()
  File "/usr/local/lib/python3.6/dist-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.6/dist-packages/click/core.py", line 1034, in main
    _verify_python_env()
  File "/usr/local/lib/python3.6/dist-packages/click/_unicodefun.py", line 100, in _verify_python_env
    raise RuntimeError("\n\n".join(extra))
RuntimeError: Click will abort further execution because Python was configured to use ASCII as encoding for the environment. Consult https://click.palletsprojects.com/unicode-support/ for mitigation steps.

This system supports the C.UTF-8 locale which is recommended. You might be able to resolve your issue by exporting the following environment variables:

    export LC_ALL=C.UTF-8
    export LANG=C.UTF-8
```

Following the advise in the error message fixes it. I have no clue
where this is coming from - maybe a new Python version after a recent
Docker image rebuild?