### PR TITLE
external: update libwally-core to 0.8.4

### DIFF
--- a/src/keystore.c
+++ b/src/keystore.c
@@ -608,7 +608,7 @@ bool keystore_secp256k1_nonce_commit(
     }
     secp256k1_context* ctx = wally_get_secp_context();
     secp256k1_ecdsa_s2c_opening signer_commitment;
-    if (!secp256k1_ecdsa_anti_klepto_signer_commit(
+    if (!secp256k1_ecdsa_anti_exfil_signer_commit(
             ctx,
             &signer_commitment,
             msg32,
@@ -640,7 +640,7 @@ bool keystore_secp256k1_sign(
     }
     secp256k1_context* ctx = wally_get_secp_context();
     secp256k1_ecdsa_signature secp256k1_sig = {0};
-    if (!secp256k1_anti_klepto_sign(
+    if (!secp256k1_anti_exfil_sign(
             ctx,
             &secp256k1_sig,
             msg32,

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -203,13 +203,13 @@ USE_RESULT bool keystore_secp256k1_pubkey_uncompressed(
 /**
  * Get a commitment to the original nonce before tweaking it with the host nonce. This is part of
  * the ECDSA Anti-Klepto Protocol. For more details, check the docs of
- * `secp256k1_ecdsa_anti_klepto_signer_commit`.
+ * `secp256k1_ecdsa_anti_exfil_signer_commit`.
  * @param[in] keypath derivation keypath
  * @param[in] keypath_len size of keypath buffer
  * @param[in] msg32 32 byte message which will be signed by `keystore_secp256k1_sign`.
  * @param[in] host_commitment must be `sha256(sha256(tag)||shas256(tag)||host_nonce)` where
  * host_nonce is passed to `keystore_secp256k1_sign()`. See
- * `secp256k1_ecdsa_anti_klepto_host_commit()`.
+ * `secp256k1_ecdsa_anti_exfil_host_commit()`.
  * @param[out] client_commitment_out EC_PUBLIC_KEY_LEN bytes compressed signer nonce pubkey.
  */
 USE_RESULT bool keystore_secp256k1_nonce_commit(

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -228,7 +228,7 @@ set(TEST_LIST
    cleanup
    "-Wl,--wrap=util_cleanup_32"
    keystore
-   "-Wl,--wrap=secp256k1_anti_klepto_sign,--wrap=memory_is_initialized,--wrap=memory_is_seeded,--wrap=memory_get_failed_unlock_attempts,--wrap=memory_reset_failed_unlock_attempts,--wrap=memory_increment_failed_unlock_attempts,--wrap=memory_set_encrypted_seed_and_hmac,--wrap=memory_get_encrypted_seed_and_hmac,--wrap=reset_reset,--wrap=salt_hash_data,--wrap=cipher_aes_hmac_encrypt,--wrap=random_32_bytes"
+   "-Wl,--wrap=secp256k1_anti_exfil_sign,--wrap=memory_is_initialized,--wrap=memory_is_seeded,--wrap=memory_get_failed_unlock_attempts,--wrap=memory_reset_failed_unlock_attempts,--wrap=memory_increment_failed_unlock_attempts,--wrap=memory_set_encrypted_seed_and_hmac,--wrap=memory_get_encrypted_seed_and_hmac,--wrap=reset_reset,--wrap=salt_hash_data,--wrap=cipher_aes_hmac_encrypt,--wrap=random_32_bytes"
    keystore_antiklepto
    "-Wl,--wrap=keystore_secp256k1_nonce_commit,--wrap=keystore_secp256k1_sign"
    keystore_functional

--- a/test/unit-test/test_btc_sign.c
+++ b/test/unit-test/test_btc_sign.c
@@ -1147,7 +1147,7 @@ static void _sign(const _modification_t* mod)
 
         inputs[1].input.has_host_nonce_commitment = true;
         // Make host commitment from host_nonce.
-        assert_true(secp256k1_ecdsa_anti_klepto_host_commit(
+        assert_true(secp256k1_ecdsa_anti_exfil_host_commit(
             wally_get_secp_context(),
             inputs[1].input.host_nonce_commitment.commitment,
             host_nonce));
@@ -1184,7 +1184,7 @@ static void _sign(const _modification_t* mod)
             secp256k1_ecdsa_s2c_opening opening;
             assert_true(secp256k1_ecdsa_s2c_opening_parse(
                 wally_get_secp_context(), &opening, next.anti_klepto_signer_commitment.commitment));
-            assert_true(secp256k1_anti_klepto_host_verify(
+            assert_true(secp256k1_anti_exfil_host_verify(
                 wally_get_secp_context(),
                 &parsed_signature,
                 expected_sighash,

--- a/test/unit-test/test_keystore.c
+++ b/test/unit-test/test_keystore.c
@@ -102,7 +102,7 @@ static uint8_t _expected_secret[32] = {
     0x12, 0x12, 0x40, 0x37, 0x7a, 0x79, 0x97, 0x55, 0xd7, 0xcc, 0xe9, 0x26, 0x1e, 0x16, 0x91, 0x71,
 };
 
-int __real_secp256k1_anti_klepto_sign(
+int __real_secp256k1_anti_exfil_sign(
     const secp256k1_context* ctx,
     secp256k1_ecdsa_signature* sig,
     const unsigned char* msg32,
@@ -112,7 +112,7 @@ int __real_secp256k1_anti_klepto_sign(
 
 static const unsigned char* _sign_expected_msg = NULL;
 static const unsigned char* _sign_expected_seckey = NULL;
-int __wrap_secp256k1_anti_klepto_sign(
+int __wrap_secp256k1_anti_exfil_sign(
     const secp256k1_context* ctx,
     secp256k1_ecdsa_signature* sig,
     const unsigned char* msg32,
@@ -128,7 +128,7 @@ int __wrap_secp256k1_anti_klepto_sign(
         assert_memory_equal(_sign_expected_seckey, seckey, 32);
         _sign_expected_seckey = NULL;
     }
-    return __real_secp256k1_anti_klepto_sign(ctx, sig, msg32, seckey, host_data32, recid);
+    return __real_secp256k1_anti_exfil_sign(ctx, sig, msg32, seckey, host_data32, recid);
 }
 
 bool __wrap_salt_hash_data(

--- a/test/unit-test/test_keystore_antiklepto.c
+++ b/test/unit-test/test_keystore_antiklepto.c
@@ -116,7 +116,7 @@ static void _test_keystore_antiklepto(void** state)
         // Anti-Klepto Protocol".
 
         // Protocol step 1.
-        assert_true(secp256k1_ecdsa_anti_klepto_host_commit(
+        assert_true(secp256k1_ecdsa_anti_exfil_host_commit(
             wally_get_secp_context(), host_nonce_commitment, host_nonce));
 
         { // Commit - protocol step 2.
@@ -178,7 +178,7 @@ static void _test_keystore_antiklepto(void** state)
         secp256k1_ecdsa_s2c_opening opening;
         assert_true(secp256k1_ecdsa_s2c_opening_parse(
             wally_get_secp_context(), &opening, signer_commitment));
-        assert_true(secp256k1_anti_klepto_host_verify(
+        assert_true(secp256k1_anti_exfil_host_verify(
             wally_get_secp_context(),
             &parsed_signature,
             msg,


### PR DESCRIPTION
It contains bech32m encoding functionality required for taproot.

anti_klepto was renamed to anti_exfil in
https://github.com/ElementsProject/secp256k1-zkp/commit/e354c5751d670716791778d86c1dcd599f2e1a9c