### PR TITLE
wally upgrade fixes

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -14,7 +14,7 @@ string(REPLACE "-mfpu=fpv4-sp-d16" "" MODIFIED_C_FLAGS ${MODIFIED_C_FLAGS_TMP})
 # wally-core
 
 # configure flags for secp256k1 bundled in libwally core, to reduce memory consumption
-set(LIBWALLY_SECP256k1_FLAGS --with-ecmult-window=2 --with-ecmult-gen-precision=2 --enable-ecmult-static-precomputation --enable-module-ecdsa-s2c)
+set(LIBWALLY_SECP256k1_FLAGS --with-ecmult-window=2 --with-ecmult-gen-precision=2 --enable-ecmult-static-precomputation)
 set(LIBWALLY_CONFIGURE_FLAGS --enable-static --disable-shared --disable-tests ${LIBWALLY_SECP256k1_FLAGS})
 if(SANITIZE_ADDRESS)
   set(LIBWALLY_CFLAGS "-fsanitize=address")

--- a/src/common_main.c
+++ b/src/common_main.c
@@ -60,6 +60,7 @@ static void _wally_patched_bzero(void* ptr, size_t len)
 static bool _setup_wally(void)
 {
     static struct wally_operations _ops = {0};
+    _ops.struct_size = sizeof(struct wally_operations);
     if (wally_get_operations(&_ops) != WALLY_OK) {
         return false;
     }


### PR DESCRIPTION
The libwally dep was upgraded in 98822a3db. There was a breaking
change that the previous commit missed.

https://github.com/ElementsProject/libwally-core/blob/e4b62491b6fcc19f53f4cef4919ec11db62f518d/CHANGES.md#version-082

> struct wally_operations has changed to hold the size of the struct and has an additional member to allow overriding the lib secp context used internally. Users must recompile their applications against this version as a result (re-linking or simply upgrading the shared library is insufficient).

This commit updates this to be compatible with the updated libwally.