### PR TITLE
cardano: allow ttl=0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ customers cannot upgrade their bootloader, its changes are recorded separately.
 
 ### [Unreleased]
 - ListBackups: ported to Rust
+- Cardano: allow transactions with a zero TTL value
 
 ### 9.8.0 [released 2021-10-21]
 - Multi edition: add Cardano support.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,8 +89,8 @@ endif()
 #
 # Versions MUST contain three parts and start with lowercase 'v'.
 # Example 'v1.0.0'. They MUST not contain a pre-release label such as '-beta'.
-set(FIRMWARE_VERSION "v9.8.0")
-set(FIRMWARE_BTC_ONLY_VERSION "v9.8.0")
+set(FIRMWARE_VERSION "v9.9.0")
+set(FIRMWARE_BTC_ONLY_VERSION "v9.9.0")
 set(BOOTLOADER_VERSION "v1.0.4")
 
 find_package(PythonInterp 3.6 REQUIRED)

--- a/messages/cardano.proto
+++ b/messages/cardano.proto
@@ -97,6 +97,7 @@ message CardanoSignTransactionRequest {
   repeated Certificate certificates = 6;
   repeated Withdrawal withdrawals = 7;
   uint64 validity_interval_start = 8;
+  bool allow_zero_ttl = 9; // include ttl even if it is zero
 }
 
 message CardanoSignTransactionResponse {

--- a/py/bitbox02/bitbox02/communication/generated/cardano_pb2.py
+++ b/py/bitbox02/bitbox02/communication/generated/cardano_pb2.py
@@ -21,7 +21,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='cardano.proto',
   package='shiftcrypto.bitbox02',
   syntax='proto3',
-  serialized_pb=_b('\n\rcardano.proto\x12\x14shiftcrypto.bitbox02\x1a\x0c\x63ommon.proto\"F\n\x13\x43\x61rdanoXpubsRequest\x12/\n\x08keypaths\x18\x01 \x03(\x0b\x32\x1d.shiftcrypto.bitbox02.Keypath\"%\n\x14\x43\x61rdanoXpubsResponse\x12\r\n\x05xpubs\x18\x01 \x03(\x0c\"\x9e\x01\n\x13\x43\x61rdanoScriptConfig\x12\x43\n\x07pkh_skh\x18\x01 \x01(\x0b\x32\x30.shiftcrypto.bitbox02.CardanoScriptConfig.PkhSkhH\x00\x1a\x38\n\x06PkhSkh\x12\x17\n\x0fkeypath_payment\x18\x01 \x03(\r\x12\x15\n\rkeypath_stake\x18\x02 \x03(\rB\x08\n\x06\x63onfig\"\xa1\x01\n\x15\x43\x61rdanoAddressRequest\x12\x35\n\x07network\x18\x01 \x01(\x0e\x32$.shiftcrypto.bitbox02.CardanoNetwork\x12\x0f\n\x07\x64isplay\x18\x02 \x01(\x08\x12@\n\rscript_config\x18\x03 \x01(\x0b\x32).shiftcrypto.bitbox02.CardanoScriptConfig\"\xfb\x07\n\x1d\x43\x61rdanoSignTransactionRequest\x12\x35\n\x07network\x18\x01 \x01(\x0e\x32$.shiftcrypto.bitbox02.CardanoNetwork\x12I\n\x06inputs\x18\x02 \x03(\x0b\x32\x39.shiftcrypto.bitbox02.CardanoSignTransactionRequest.Input\x12K\n\x07outputs\x18\x03 \x03(\x0b\x32:.shiftcrypto.bitbox02.CardanoSignTransactionRequest.Output\x12\x0b\n\x03\x66\x65\x65\x18\x04 \x01(\x04\x12\x0b\n\x03ttl\x18\x05 \x01(\x04\x12U\n\x0c\x63\x65rtificates\x18\x06 \x03(\x0b\x32?.shiftcrypto.bitbox02.CardanoSignTransactionRequest.Certificate\x12S\n\x0bwithdrawals\x18\x07 \x03(\x0b\x32>.shiftcrypto.bitbox02.CardanoSignTransactionRequest.Withdrawal\x12\x1f\n\x17validity_interval_start\x18\x08 \x01(\x04\x1aG\n\x05Input\x12\x0f\n\x07keypath\x18\x01 \x03(\r\x12\x15\n\rprev_out_hash\x18\x02 \x01(\x0c\x12\x16\n\x0eprev_out_index\x18\x03 \x01(\r\x1ar\n\x06Output\x12\x17\n\x0f\x65ncoded_address\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x04\x12@\n\rscript_config\x18\x03 \x01(\x0b\x32).shiftcrypto.bitbox02.CardanoScriptConfig\x1a\xb8\x02\n\x0b\x43\x65rtificate\x12;\n\x12stake_registration\x18\x01 \x01(\x0b\x32\x1d.shiftcrypto.bitbox02.KeypathH\x00\x12=\n\x14stake_deregistration\x18\x02 \x01(\x0b\x32\x1d.shiftcrypto.bitbox02.KeypathH\x00\x12k\n\x10stake_delegation\x18\x03 \x01(\x0b\x32O.shiftcrypto.bitbox02.CardanoSignTransactionRequest.Certificate.StakeDelegationH\x00\x1a\x38\n\x0fStakeDelegation\x12\x0f\n\x07keypath\x18\x01 \x03(\r\x12\x14\n\x0cpool_keyhash\x18\x02 \x01(\x0c\x42\x06\n\x04\x63\x65rt\x1a,\n\nWithdrawal\x12\x0f\n\x07keypath\x18\x01 \x03(\r\x12\r\n\x05value\x18\x02 \x01(\x04\"\xb9\x01\n\x1e\x43\x61rdanoSignTransactionResponse\x12^\n\x11shelley_witnesses\x18\x01 \x03(\x0b\x32\x43.shiftcrypto.bitbox02.CardanoSignTransactionResponse.ShelleyWitness\x1a\x37\n\x0eShelleyWitness\x12\x12\n\npublic_key\x18\x01 \x01(\x0c\x12\x11\n\tsignature\x18\x02 \x01(\x0c\"\xe8\x01\n\x0e\x43\x61rdanoRequest\x12:\n\x05xpubs\x18\x01 \x01(\x0b\x32).shiftcrypto.bitbox02.CardanoXpubsRequestH\x00\x12>\n\x07\x61\x64\x64ress\x18\x02 \x01(\x0b\x32+.shiftcrypto.bitbox02.CardanoAddressRequestH\x00\x12O\n\x10sign_transaction\x18\x03 \x01(\x0b\x32\x33.shiftcrypto.bitbox02.CardanoSignTransactionRequestH\x00\x42\t\n\x07request\"\xde\x01\n\x0f\x43\x61rdanoResponse\x12;\n\x05xpubs\x18\x01 \x01(\x0b\x32*.shiftcrypto.bitbox02.CardanoXpubsResponseH\x00\x12\x30\n\x03pub\x18\x02 \x01(\x0b\x32!.shiftcrypto.bitbox02.PubResponseH\x00\x12P\n\x10sign_transaction\x18\x03 \x01(\x0b\x32\x34.shiftcrypto.bitbox02.CardanoSignTransactionResponseH\x00\x42\n\n\x08response*8\n\x0e\x43\x61rdanoNetwork\x12\x12\n\x0e\x43\x61rdanoMainnet\x10\x00\x12\x12\n\x0e\x43\x61rdanoTestnet\x10\x01\x62\x06proto3')
+  serialized_pb=_b('\n\rcardano.proto\x12\x14shiftcrypto.bitbox02\x1a\x0c\x63ommon.proto\"F\n\x13\x43\x61rdanoXpubsRequest\x12/\n\x08keypaths\x18\x01 \x03(\x0b\x32\x1d.shiftcrypto.bitbox02.Keypath\"%\n\x14\x43\x61rdanoXpubsResponse\x12\r\n\x05xpubs\x18\x01 \x03(\x0c\"\x9e\x01\n\x13\x43\x61rdanoScriptConfig\x12\x43\n\x07pkh_skh\x18\x01 \x01(\x0b\x32\x30.shiftcrypto.bitbox02.CardanoScriptConfig.PkhSkhH\x00\x1a\x38\n\x06PkhSkh\x12\x17\n\x0fkeypath_payment\x18\x01 \x03(\r\x12\x15\n\rkeypath_stake\x18\x02 \x03(\rB\x08\n\x06\x63onfig\"\xa1\x01\n\x15\x43\x61rdanoAddressRequest\x12\x35\n\x07network\x18\x01 \x01(\x0e\x32$.shiftcrypto.bitbox02.CardanoNetwork\x12\x0f\n\x07\x64isplay\x18\x02 \x01(\x08\x12@\n\rscript_config\x18\x03 \x01(\x0b\x32).shiftcrypto.bitbox02.CardanoScriptConfig\"\x93\x08\n\x1d\x43\x61rdanoSignTransactionRequest\x12\x35\n\x07network\x18\x01 \x01(\x0e\x32$.shiftcrypto.bitbox02.CardanoNetwork\x12I\n\x06inputs\x18\x02 \x03(\x0b\x32\x39.shiftcrypto.bitbox02.CardanoSignTransactionRequest.Input\x12K\n\x07outputs\x18\x03 \x03(\x0b\x32:.shiftcrypto.bitbox02.CardanoSignTransactionRequest.Output\x12\x0b\n\x03\x66\x65\x65\x18\x04 \x01(\x04\x12\x0b\n\x03ttl\x18\x05 \x01(\x04\x12U\n\x0c\x63\x65rtificates\x18\x06 \x03(\x0b\x32?.shiftcrypto.bitbox02.CardanoSignTransactionRequest.Certificate\x12S\n\x0bwithdrawals\x18\x07 \x03(\x0b\x32>.shiftcrypto.bitbox02.CardanoSignTransactionRequest.Withdrawal\x12\x1f\n\x17validity_interval_start\x18\x08 \x01(\x04\x12\x16\n\x0e\x61llow_zero_ttl\x18\t \x01(\x08\x1aG\n\x05Input\x12\x0f\n\x07keypath\x18\x01 \x03(\r\x12\x15\n\rprev_out_hash\x18\x02 \x01(\x0c\x12\x16\n\x0eprev_out_index\x18\x03 \x01(\r\x1ar\n\x06Output\x12\x17\n\x0f\x65ncoded_address\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x04\x12@\n\rscript_config\x18\x03 \x01(\x0b\x32).shiftcrypto.bitbox02.CardanoScriptConfig\x1a\xb8\x02\n\x0b\x43\x65rtificate\x12;\n\x12stake_registration\x18\x01 \x01(\x0b\x32\x1d.shiftcrypto.bitbox02.KeypathH\x00\x12=\n\x14stake_deregistration\x18\x02 \x01(\x0b\x32\x1d.shiftcrypto.bitbox02.KeypathH\x00\x12k\n\x10stake_delegation\x18\x03 \x01(\x0b\x32O.shiftcrypto.bitbox02.CardanoSignTransactionRequest.Certificate.StakeDelegationH\x00\x1a\x38\n\x0fStakeDelegation\x12\x0f\n\x07keypath\x18\x01 \x03(\r\x12\x14\n\x0cpool_keyhash\x18\x02 \x01(\x0c\x42\x06\n\x04\x63\x65rt\x1a,\n\nWithdrawal\x12\x0f\n\x07keypath\x18\x01 \x03(\r\x12\r\n\x05value\x18\x02 \x01(\x04\"\xb9\x01\n\x1e\x43\x61rdanoSignTransactionResponse\x12^\n\x11shelley_witnesses\x18\x01 \x03(\x0b\x32\x43.shiftcrypto.bitbox02.CardanoSignTransactionResponse.ShelleyWitness\x1a\x37\n\x0eShelleyWitness\x12\x12\n\npublic_key\x18\x01 \x01(\x0c\x12\x11\n\tsignature\x18\x02 \x01(\x0c\"\xe8\x01\n\x0e\x43\x61rdanoRequest\x12:\n\x05xpubs\x18\x01 \x01(\x0b\x32).shiftcrypto.bitbox02.CardanoXpubsRequestH\x00\x12>\n\x07\x61\x64\x64ress\x18\x02 \x01(\x0b\x32+.shiftcrypto.bitbox02.CardanoAddressRequestH\x00\x12O\n\x10sign_transaction\x18\x03 \x01(\x0b\x32\x33.shiftcrypto.bitbox02.CardanoSignTransactionRequestH\x00\x42\t\n\x07request\"\xde\x01\n\x0f\x43\x61rdanoResponse\x12;\n\x05xpubs\x18\x01 \x01(\x0b\x32*.shiftcrypto.bitbox02.CardanoXpubsResponseH\x00\x12\x30\n\x03pub\x18\x02 \x01(\x0b\x32!.shiftcrypto.bitbox02.PubResponseH\x00\x12P\n\x10sign_transaction\x18\x03 \x01(\x0b\x32\x34.shiftcrypto.bitbox02.CardanoSignTransactionResponseH\x00\x42\n\n\x08response*8\n\x0e\x43\x61rdanoNetwork\x12\x12\n\x0e\x43\x61rdanoMainnet\x10\x00\x12\x12\n\x0e\x43\x61rdanoTestnet\x10\x01\x62\x06proto3')
   ,
   dependencies=[common__pb2.DESCRIPTOR,])
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
@@ -43,8 +43,8 @@ _CARDANONETWORK = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=2159,
-  serialized_end=2215,
+  serialized_start=2183,
+  serialized_end=2239,
 )
 _sym_db.RegisterEnumDescriptor(_CARDANONETWORK)
 
@@ -272,8 +272,8 @@ _CARDANOSIGNTRANSACTIONREQUEST_INPUT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=961,
-  serialized_end=1032,
+  serialized_start=985,
+  serialized_end=1056,
 )
 
 _CARDANOSIGNTRANSACTIONREQUEST_OUTPUT = _descriptor.Descriptor(
@@ -316,8 +316,8 @@ _CARDANOSIGNTRANSACTIONREQUEST_OUTPUT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1034,
-  serialized_end=1148,
+  serialized_start=1058,
+  serialized_end=1172,
 )
 
 _CARDANOSIGNTRANSACTIONREQUEST_CERTIFICATE_STAKEDELEGATION = _descriptor.Descriptor(
@@ -353,8 +353,8 @@ _CARDANOSIGNTRANSACTIONREQUEST_CERTIFICATE_STAKEDELEGATION = _descriptor.Descrip
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1399,
-  serialized_end=1455,
+  serialized_start=1423,
+  serialized_end=1479,
 )
 
 _CARDANOSIGNTRANSACTIONREQUEST_CERTIFICATE = _descriptor.Descriptor(
@@ -400,8 +400,8 @@ _CARDANOSIGNTRANSACTIONREQUEST_CERTIFICATE = _descriptor.Descriptor(
       name='cert', full_name='shiftcrypto.bitbox02.CardanoSignTransactionRequest.Certificate.cert',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=1151,
-  serialized_end=1463,
+  serialized_start=1175,
+  serialized_end=1487,
 )
 
 _CARDANOSIGNTRANSACTIONREQUEST_WITHDRAWAL = _descriptor.Descriptor(
@@ -437,8 +437,8 @@ _CARDANOSIGNTRANSACTIONREQUEST_WITHDRAWAL = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1465,
-  serialized_end=1509,
+  serialized_start=1489,
+  serialized_end=1533,
 )
 
 _CARDANOSIGNTRANSACTIONREQUEST = _descriptor.Descriptor(
@@ -504,6 +504,13 @@ _CARDANOSIGNTRANSACTIONREQUEST = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
+    _descriptor.FieldDescriptor(
+      name='allow_zero_ttl', full_name='shiftcrypto.bitbox02.CardanoSignTransactionRequest.allow_zero_ttl', index=8,
+      number=9, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
   ],
   extensions=[
   ],
@@ -517,7 +524,7 @@ _CARDANOSIGNTRANSACTIONREQUEST = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=490,
-  serialized_end=1509,
+  serialized_end=1533,
 )
 
 
@@ -554,8 +561,8 @@ _CARDANOSIGNTRANSACTIONRESPONSE_SHELLEYWITNESS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1642,
-  serialized_end=1697,
+  serialized_start=1666,
+  serialized_end=1721,
 )
 
 _CARDANOSIGNTRANSACTIONRESPONSE = _descriptor.Descriptor(
@@ -584,8 +591,8 @@ _CARDANOSIGNTRANSACTIONRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1512,
-  serialized_end=1697,
+  serialized_start=1536,
+  serialized_end=1721,
 )
 
 
@@ -632,8 +639,8 @@ _CARDANOREQUEST = _descriptor.Descriptor(
       name='request', full_name='shiftcrypto.bitbox02.CardanoRequest.request',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=1700,
-  serialized_end=1932,
+  serialized_start=1724,
+  serialized_end=1956,
 )
 
 
@@ -680,8 +687,8 @@ _CARDANORESPONSE = _descriptor.Descriptor(
       name='response', full_name='shiftcrypto.bitbox02.CardanoResponse.response',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=1935,
-  serialized_end=2157,
+  serialized_start=1959,
+  serialized_end=2181,
 )
 
 _CARDANOXPUBSREQUEST.fields_by_name['keypaths'].message_type = common__pb2._KEYPATH

--- a/py/bitbox02/bitbox02/communication/generated/cardano_pb2.pyi
+++ b/py/bitbox02/bitbox02/communication/generated/cardano_pb2.pyi
@@ -204,6 +204,7 @@ class CardanoSignTransactionRequest(google.protobuf.message.Message):
     CERTIFICATES_FIELD_NUMBER: builtins.int
     WITHDRAWALS_FIELD_NUMBER: builtins.int
     VALIDITY_INTERVAL_START_FIELD_NUMBER: builtins.int
+    ALLOW_ZERO_TTL_FIELD_NUMBER: builtins.int
     network: global___CardanoNetwork.V = ...
     @property
     def inputs(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___CardanoSignTransactionRequest.Input]: ...
@@ -216,6 +217,9 @@ class CardanoSignTransactionRequest(google.protobuf.message.Message):
     @property
     def withdrawals(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___CardanoSignTransactionRequest.Withdrawal]: ...
     validity_interval_start: builtins.int = ...
+    allow_zero_ttl: builtins.bool = ...
+    """include ttl even if it is zero"""
+
     def __init__(self,
         *,
         network : global___CardanoNetwork.V = ...,
@@ -226,8 +230,9 @@ class CardanoSignTransactionRequest(google.protobuf.message.Message):
         certificates : typing.Optional[typing.Iterable[global___CardanoSignTransactionRequest.Certificate]] = ...,
         withdrawals : typing.Optional[typing.Iterable[global___CardanoSignTransactionRequest.Withdrawal]] = ...,
         validity_interval_start : builtins.int = ...,
+        allow_zero_ttl : builtins.bool = ...,
         ) -> None: ...
-    def ClearField(self, field_name: typing_extensions.Literal["certificates",b"certificates","fee",b"fee","inputs",b"inputs","network",b"network","outputs",b"outputs","ttl",b"ttl","validity_interval_start",b"validity_interval_start","withdrawals",b"withdrawals"]) -> None: ...
+    def ClearField(self, field_name: typing_extensions.Literal["allow_zero_ttl",b"allow_zero_ttl","certificates",b"certificates","fee",b"fee","inputs",b"inputs","network",b"network","outputs",b"outputs","ttl",b"ttl","validity_interval_start",b"validity_interval_start","withdrawals",b"withdrawals"]) -> None: ...
 global___CardanoSignTransactionRequest = CardanoSignTransactionRequest
 
 class CardanoSignTransactionResponse(google.protobuf.message.Message):

--- a/py/send_message.py
+++ b/py/send_message.py
@@ -775,6 +775,39 @@ class SendMessage:
             )
             print(response)
 
+        def sign_zero_ttl() -> None:
+            response = self._device.cardano_sign_transaction(
+                transaction=bitbox02.cardano.CardanoSignTransactionRequest(
+                    network=bitbox02.cardano.CardanoMainnet,
+                    inputs=[
+                        bitbox02.cardano.CardanoSignTransactionRequest.Input(
+                            keypath=[2147485500, 2147485463, 2147483648, 0, 0],
+                            prev_out_hash=bytes.fromhex(
+                                "59864ee73ca5d91098a32b3ce9811bac1996dcbaefa6b6247dcaafb5779c2538"
+                            ),
+                            prev_out_index=0,
+                        )
+                    ],
+                    outputs=[
+                        bitbox02.cardano.CardanoSignTransactionRequest.Output(
+                            encoded_address="addr1q9qfllpxg2vu4lq6rnpel4pvpp5xnv3kvvgtxk6k6wp4ff89xrhu8jnu3p33vnctc9eklee5dtykzyag5penc6dcmakqsqqgpt",
+                            value=1000000,
+                        ),
+                        bitbox02.cardano.CardanoSignTransactionRequest.Output(
+                            encoded_address=get_address(False),
+                            value=4829501,
+                            script_config=script_config,
+                        ),
+                    ],
+                    fee=170499,
+                    ttl=0,
+                    allow_zero_ttl=True,
+                    certificates=[],
+                    validity_interval_start=41110811,
+                )
+            )
+            print(response)
+
         def delegate() -> None:
             response = self._device.cardano_sign_transaction(
                 transaction=bitbox02.cardano.CardanoSignTransactionRequest(
@@ -859,6 +892,7 @@ class SendMessage:
             ("Retrieve account xpubs", xpubs),
             ("Retrieve a Shelley address", address),
             ("Sign a transaction", sign),
+            ("Sign a transaction with TTL=0", sign_zero_ttl),
             ("Delegate staking to a pool", delegate),
             ("Withdraw staking rewards", withdraw),
         )

--- a/src/rust/bitbox02-rust/src/hww/api/cardano/sign_transaction/cbor.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/cardano/sign_transaction/cbor.rs
@@ -84,7 +84,7 @@ pub fn encode_transaction_body<W: Write>(
     let mut encoder = Encoder::new(writer);
 
     let mut num_map_entries = 3; // inputs, outputs, fee
-    if tx.ttl != 0 {
+    if tx.ttl != 0 || tx.allow_zero_ttl {
         num_map_entries += 1;
     }
     if !tx.certificates.is_empty() {
@@ -121,7 +121,7 @@ pub fn encode_transaction_body<W: Write>(
     // Map entry 2 is the fee.
     encoder.u8(2)?.u64(tx.fee)?;
     // Optional map entry 3 is ttl.
-    if tx.ttl != 0 {
+    if tx.ttl != 0 || tx.allow_zero_ttl {
         encoder.u8(3)?.u64(tx.ttl)?;
     }
     // Optional map entry 4 are the certificates:

--- a/src/rust/bitbox02-rust/src/shiftcrypto.bitbox02.rs
+++ b/src/rust/bitbox02-rust/src/shiftcrypto.bitbox02.rs
@@ -562,6 +562,9 @@ pub struct CardanoSignTransactionRequest {
     pub withdrawals: ::prost::alloc::vec::Vec<cardano_sign_transaction_request::Withdrawal>,
     #[prost(uint64, tag="8")]
     pub validity_interval_start: u64,
+    /// include ttl even if it is zero
+    #[prost(bool, tag="9")]
+    pub allow_zero_ttl: bool,
 }
 /// Nested message and enum types in `CardanoSignTransactionRequest`.
 pub mod cardano_sign_transaction_request {


### PR DESCRIPTION
Before, ttl=0 was interpreted as "not provided", which means that it
is not serialized and signed.

According to the spec, zero is a valid value for the TTL. It means
however that the transaction can never be mined, as the current slot
will always be bigger than 0.

According to the Adalite team, this type of transaction is used in
meta protocols:
https://github.com/vacuumlabs/adalite/pull/1212#discussion_r755973295

> But TTL = 0 is in theory a semantically valid TTL the transaction
can have - advanced users may leverage that to sign a transaction and
ensure it won't ever be accepted by the blockchain - it's used
e.g. with Ledger when CLI users need to sign separately voting
registration metadata (but the device allows signing only the full tx)
and therefore want to throw away the rest of the signed
transaction. (of course, they can use ttl=1 which would do as well,
but mapping 0 to null seems worth avoiding for the sake of
predictability of the interface and overall consistency)

To be backwards compatible, we add a new protobuf field
`allow_zero_ttl` and take it into account. "Transaction cannot be
mined" is shown to the user in this case.

Since it touches the same code, I also extended the "Transaction
cannot be mined" case to when the validity start is bigger than the
TTL.