### PR TITLE
keystore: add seed_len to mock_state()

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -343,7 +343,7 @@ add_custom_target(rust-bindgen
     --whitelist-function keystore_secp256k1_sign
     --whitelist-function keystore_bip39_mnemonic_to_seed
     --whitelist-function keystore_get_root_fingerprint
-    --whitelist-function mock_state
+    --whitelist-function keystore_mock_unlocked
     --whitelist-var EC_PUBLIC_KEY_UNCOMPRESSED_LEN
     --whitelist-var EC_PUBLIC_KEY_LEN
     --whitelist-function keystore_encode_xpub_at_keypath

--- a/src/keystore.c
+++ b/src/keystore.c
@@ -44,16 +44,16 @@ static bool _is_unlocked_bip39 = false;
 static uint8_t _retained_bip39_seed[64] = {0};
 
 #ifdef TESTING
-void mock_state(const uint8_t* retained_seed, const uint8_t* retained_bip39_seed)
+void mock_state(const uint8_t* seed, size_t seed_len, const uint8_t* bip39_seed)
 {
-    _is_unlocked_device = retained_seed != NULL;
-    if (retained_seed != NULL) {
-        _seed_length = KEYSTORE_MAX_SEED_LENGTH;
-        memcpy(_retained_seed, retained_seed, sizeof(_retained_seed));
+    _is_unlocked_device = seed != NULL;
+    if (seed != NULL) {
+        _seed_length = seed_len;
+        memcpy(_retained_seed, seed, seed_len);
     }
-    _is_unlocked_bip39 = retained_bip39_seed != NULL;
-    if (retained_bip39_seed != NULL) {
-        memcpy(_retained_bip39_seed, retained_bip39_seed, sizeof(_retained_bip39_seed));
+    _is_unlocked_bip39 = bip39_seed != NULL;
+    if (bip39_seed != NULL) {
+        memcpy(_retained_bip39_seed, bip39_seed, sizeof(_retained_bip39_seed));
     }
 }
 #endif

--- a/src/keystore.c
+++ b/src/keystore.c
@@ -31,16 +31,17 @@
 // password.
 #define KDF_NUM_ITERATIONS (2)
 
-// change this ONLY via keystore_unlock() or keystore_lock()
+// Change this ONLY via keystore_unlock() or keystore_lock()
 static bool _is_unlocked_device = false;
-// seed length defaults to 32 bytes, but we could accept smaller seeds in the future.
-static uint8_t _seed_length = KEYSTORE_MAX_SEED_LENGTH;
-// must be defined if is_unlocked is true. ONLY ACCESS THIS WITH _get_seed()
+// Must be defined if is_unlocked is true. Length of the seed store in `_retained_seed`. See also:
+// `_validate_seed_length()`.
+static uint8_t _seed_length = 0;
+// Must be defined if is_unlocked is true. ONLY ACCESS THIS WITH _get_seed()
 static uint8_t _retained_seed[KEYSTORE_MAX_SEED_LENGTH] = {0};
 
-// change this ONLY via keystore_unlock_bip39().
+// Change this ONLY via keystore_unlock_bip39().
 static bool _is_unlocked_bip39 = false;
-// must be defined if _is_unlocked is true. ONLY ACCESS THIS WITH _get_bip39_seed().
+// Must be defined if _is_unlocked is true. ONLY ACCESS THIS WITH _get_bip39_seed().
 static uint8_t _retained_bip39_seed[64] = {0};
 
 #ifdef TESTING
@@ -399,7 +400,7 @@ void keystore_lock(void)
 {
     _is_unlocked_device = false;
     _is_unlocked_bip39 = false;
-    _seed_length = KEYSTORE_MAX_SEED_LENGTH;
+    _seed_length = 0;
     util_zero(_retained_seed, sizeof(_retained_seed));
     util_zero(_retained_bip39_seed, sizeof(_retained_bip39_seed));
 }

--- a/src/keystore.c
+++ b/src/keystore.c
@@ -45,7 +45,7 @@ static bool _is_unlocked_bip39 = false;
 static uint8_t _retained_bip39_seed[64] = {0};
 
 #ifdef TESTING
-void mock_state(const uint8_t* seed, size_t seed_len, const uint8_t* bip39_seed)
+void keystore_mock_unlocked(const uint8_t* seed, size_t seed_len, const uint8_t* bip39_seed)
 {
     _is_unlocked_device = seed != NULL;
     if (seed != NULL) {

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -48,7 +48,7 @@ typedef enum {
 /**
  * convenience to mock the keystore state (locked, seed) in tests.
  */
-void mock_state(const uint8_t* retained_seed, const uint8_t* retained_bip39_seed);
+void mock_state(const uint8_t* seed, size_t seed_len, const uint8_t* bip39_seed);
 #endif
 
 /**

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -48,7 +48,7 @@ typedef enum {
 /**
  * convenience to mock the keystore state (locked, seed) in tests.
  */
-void mock_state(const uint8_t* seed, size_t seed_len, const uint8_t* bip39_seed);
+void keystore_mock_unlocked(const uint8_t* seed, size_t seed_len, const uint8_t* bip39_seed);
 #endif
 
 /**

--- a/src/rust/bitbox02/src/testing.rs
+++ b/src/rust/bitbox02/src/testing.rs
@@ -21,8 +21,6 @@ use std::boxed::Box;
 
 use crate::keystore;
 
-use core::convert::TryInto;
-
 #[derive(Default)]
 pub struct Data {
     pub ui_confirm_create: Option<Box<dyn Fn(&super::ui::ConfirmParams) -> bool>>,
@@ -51,12 +49,8 @@ pub fn mock(data: Data) {
 
 /// This mocks an unlocked keystore with the given bip39 recovery words.
 pub fn mock_unlocked_using_mnemonic(mnemonic: &str) {
-    let seed: [u8; 32] = keystore::bip39_mnemonic_to_seed(mnemonic)
-        .unwrap()
-        .as_slice()
-        .try_into()
-        .unwrap();
-    unsafe { bitbox02_sys::mock_state(seed.as_ptr(), core::ptr::null()) }
+    let seed = keystore::bip39_mnemonic_to_seed(mnemonic).unwrap();
+    unsafe { bitbox02_sys::mock_state(seed.as_ptr(), seed.len() as _, core::ptr::null()) }
     keystore::unlock_bip39(&crate::input::SafeInputString::new()).unwrap();
 }
 

--- a/src/rust/bitbox02/src/testing.rs
+++ b/src/rust/bitbox02/src/testing.rs
@@ -50,7 +50,9 @@ pub fn mock(data: Data) {
 /// This mocks an unlocked keystore with the given bip39 recovery words.
 pub fn mock_unlocked_using_mnemonic(mnemonic: &str) {
     let seed = keystore::bip39_mnemonic_to_seed(mnemonic).unwrap();
-    unsafe { bitbox02_sys::mock_state(seed.as_ptr(), seed.len() as _, core::ptr::null()) }
+    unsafe {
+        bitbox02_sys::keystore_mock_unlocked(seed.as_ptr(), seed.len() as _, core::ptr::null())
+    }
     keystore::unlock_bip39(&crate::input::SafeInputString::new()).unwrap();
 }
 

--- a/test/unit-test/test_app_btc_common.c
+++ b/test/unit-test/test_app_btc_common.c
@@ -264,7 +264,7 @@ static XPub _derive_our_xpub(const uint32_t* keypath, size_t keypath_len)
 
 static void _test_btc_common_multisig_is_valid(void** state)
 {
-    mock_state(_mock_seed, _mock_bip39_seed);
+    mock_state(_mock_seed, sizeof(_mock_seed), _mock_bip39_seed);
 
     const uint32_t expected_coin = 1 + BIP32_INITIAL_HARDENED_CHILD;
     const uint32_t keypath[4] = {
@@ -288,11 +288,11 @@ static void _test_btc_common_multisig_is_valid(void** state)
         "CugjeksHSbyZT7rq38VQF";
     multisig.xpubs[multisig.our_xpub_index] = btc_util_parse_xpub(our_xpub);
 
-    mock_state(_mock_seed, NULL);
+    mock_state(_mock_seed, sizeof(_mock_seed), NULL);
     assert_false(btc_common_multisig_is_valid(
         &multisig, keypath, sizeof(keypath) / sizeof(uint32_t), expected_coin));
 
-    mock_state(_mock_seed, _mock_bip39_seed);
+    mock_state(_mock_seed, sizeof(_mock_seed), _mock_bip39_seed);
 
     // ok
     assert_true(btc_common_multisig_is_valid(

--- a/test/unit-test/test_app_btc_common.c
+++ b/test/unit-test/test_app_btc_common.c
@@ -264,7 +264,7 @@ static XPub _derive_our_xpub(const uint32_t* keypath, size_t keypath_len)
 
 static void _test_btc_common_multisig_is_valid(void** state)
 {
-    mock_state(_mock_seed, sizeof(_mock_seed), _mock_bip39_seed);
+    keystore_mock_unlocked(_mock_seed, sizeof(_mock_seed), _mock_bip39_seed);
 
     const uint32_t expected_coin = 1 + BIP32_INITIAL_HARDENED_CHILD;
     const uint32_t keypath[4] = {
@@ -288,11 +288,11 @@ static void _test_btc_common_multisig_is_valid(void** state)
         "CugjeksHSbyZT7rq38VQF";
     multisig.xpubs[multisig.our_xpub_index] = btc_util_parse_xpub(our_xpub);
 
-    mock_state(_mock_seed, sizeof(_mock_seed), NULL);
+    keystore_mock_unlocked(_mock_seed, sizeof(_mock_seed), NULL);
     assert_false(btc_common_multisig_is_valid(
         &multisig, keypath, sizeof(keypath) / sizeof(uint32_t), expected_coin));
 
-    mock_state(_mock_seed, sizeof(_mock_seed), _mock_bip39_seed);
+    keystore_mock_unlocked(_mock_seed, sizeof(_mock_seed), _mock_bip39_seed);
 
     // ok
     assert_true(btc_common_multisig_is_valid(

--- a/test/unit-test/test_app_btc_multisig.c
+++ b/test/unit-test/test_app_btc_multisig.c
@@ -220,7 +220,7 @@ static testcase_t _tests[] = {
 
 static void _test_app_btc_address_multisig(void** state)
 {
-    mock_state(_mock_seed, _mock_bip39_seed);
+    mock_state(_mock_seed, sizeof(_mock_seed), _mock_bip39_seed);
 
     for (size_t test_case_index = 0; test_case_index < sizeof(_tests) / sizeof(testcase_t);
          test_case_index++) {

--- a/test/unit-test/test_app_btc_multisig.c
+++ b/test/unit-test/test_app_btc_multisig.c
@@ -220,7 +220,7 @@ static testcase_t _tests[] = {
 
 static void _test_app_btc_address_multisig(void** state)
 {
-    mock_state(_mock_seed, sizeof(_mock_seed), _mock_bip39_seed);
+    keystore_mock_unlocked(_mock_seed, sizeof(_mock_seed), _mock_bip39_seed);
 
     for (size_t test_case_index = 0; test_case_index < sizeof(_tests) / sizeof(testcase_t);
          test_case_index++) {

--- a/test/unit-test/test_app_btc_sign_multisig.c
+++ b/test/unit-test/test_app_btc_sign_multisig.c
@@ -241,7 +241,7 @@ static _tx _make_test_tx(void)
 
 static void _test_tx(const _tx* tx, const uint8_t* expected_signature)
 {
-    mock_state(_mock_seed, sizeof(_mock_seed), _mock_bip39_seed);
+    keystore_mock_unlocked(_mock_seed, sizeof(_mock_seed), _mock_bip39_seed);
 
     BTCSignNextResponse next = {0};
 

--- a/test/unit-test/test_app_btc_sign_multisig.c
+++ b/test/unit-test/test_app_btc_sign_multisig.c
@@ -241,7 +241,7 @@ static _tx _make_test_tx(void)
 
 static void _test_tx(const _tx* tx, const uint8_t* expected_signature)
 {
-    mock_state(_mock_seed, _mock_bip39_seed);
+    mock_state(_mock_seed, sizeof(_mock_seed), _mock_bip39_seed);
 
     BTCSignNextResponse next = {0};
 

--- a/test/unit-test/test_btc_sign.c
+++ b/test/unit-test/test_btc_sign.c
@@ -417,7 +417,8 @@ static bool _stream_prevtx(
 static void _sign(const _modification_t* mod)
 {
     // Need keystore to derive change and input scripts
-    mock_state(mod->seeded ? _mock_seed : NULL, mod->seeded ? _mock_bip39_seed : NULL);
+    mock_state(
+        mod->seeded ? _mock_seed : NULL, sizeof(_mock_seed), mod->seeded ? _mock_bip39_seed : NULL);
 
     uint32_t purpose;
     switch (mod->script_type) {

--- a/test/unit-test/test_btc_sign.c
+++ b/test/unit-test/test_btc_sign.c
@@ -417,7 +417,7 @@ static bool _stream_prevtx(
 static void _sign(const _modification_t* mod)
 {
     // Need keystore to derive change and input scripts
-    mock_state(
+    keystore_mock_unlocked(
         mod->seeded ? _mock_seed : NULL, sizeof(_mock_seed), mod->seeded ? _mock_bip39_seed : NULL);
 
     uint32_t purpose;

--- a/test/unit-test/test_keystore.c
+++ b/test/unit-test/test_keystore.c
@@ -204,11 +204,11 @@ static void _test_keystore_get_xpub(void** state)
 
     struct ext_key xpub = {0};
 
-    mock_state(NULL, NULL);
+    mock_state(NULL, 0, NULL);
     // fails because keystore is locked
     assert_false(keystore_get_xpub(_keypath, sizeof(_keypath) / sizeof(uint32_t), &xpub));
 
-    mock_state(_mock_seed, _mock_bip39_seed);
+    mock_state(_mock_seed, sizeof(_mock_seed), _mock_bip39_seed);
     assert_true(keystore_get_xpub(_keypath, sizeof(_keypath) / sizeof(uint32_t), &xpub));
 
     secp256k1_pubkey expected_pubkey;
@@ -232,7 +232,7 @@ static void _test_keystore_get_xpub(void** state)
 
 static void _test_keystore_get_root_fingerprint(void** state)
 {
-    mock_state(_mock_seed, _mock_bip39_seed);
+    mock_state(_mock_seed, sizeof(_mock_seed), _mock_bip39_seed);
     uint8_t fingerprint[4];
     assert_true(keystore_get_root_fingerprint(fingerprint));
     uint8_t expected_fingerprint[4] = {0x9e, 0x1b, 0x2d, 0x1e};
@@ -248,13 +248,13 @@ static void _test_keystore_secp256k1_nonce_commit(void** state)
     memset(host_nonce_commitment, 0xAB, sizeof(host_nonce_commitment));
 
     {
-        mock_state(NULL, NULL);
+        mock_state(NULL, 0, NULL);
         // fails because keystore is locked
         assert_false(keystore_secp256k1_nonce_commit(
             _keypath, sizeof(_keypath) / sizeof(uint32_t), msg, host_nonce_commitment, commitment));
     }
     {
-        mock_state(_mock_seed, _mock_bip39_seed);
+        mock_state(_mock_seed, sizeof(_mock_seed), _mock_bip39_seed);
         assert_true(keystore_secp256k1_nonce_commit(
             _keypath, sizeof(_keypath) / sizeof(uint32_t), msg, host_nonce_commitment, commitment));
         const uint8_t expected_commitment[EC_PUBLIC_KEY_LEN] =
@@ -279,13 +279,13 @@ static void _test_keystore_secp256k1_sign(void** state)
     memset(host_nonce, 0x56, sizeof(host_nonce));
 
     {
-        mock_state(NULL, NULL);
+        mock_state(NULL, 0, NULL);
         // fails because keystore is locked
         assert_false(keystore_secp256k1_sign(
             _keypath, sizeof(_keypath) / sizeof(uint32_t), msg, host_nonce, sig, NULL));
     }
     {
-        mock_state(_mock_seed, _mock_bip39_seed);
+        mock_state(_mock_seed, sizeof(_mock_seed), _mock_bip39_seed);
 
         _sign_expected_seckey = _expected_seckey;
         _sign_expected_msg = msg;
@@ -412,7 +412,7 @@ static void _perform_some_unlocks(void)
 static void _test_keystore_unlock(void** state)
 {
     _smarteeprom_reset();
-    mock_state(NULL, NULL); // reset to locked
+    mock_state(NULL, 0, NULL); // reset to locked
 
     uint8_t remaining_attempts;
 
@@ -451,11 +451,11 @@ static void _test_keystore_unlock(void** state)
 
 static void _test_keystore_lock(void** state)
 {
-    mock_state(NULL, NULL);
+    mock_state(NULL, 0, NULL);
     assert_true(keystore_is_locked());
-    mock_state(_mock_seed, NULL);
+    mock_state(_mock_seed, sizeof(_mock_seed), NULL);
     assert_true(keystore_is_locked());
-    mock_state(_mock_seed, _mock_bip39_seed);
+    mock_state(_mock_seed, sizeof(_mock_seed), _mock_bip39_seed);
     assert_false(keystore_is_locked());
     keystore_lock();
     assert_true(keystore_is_locked());
@@ -464,13 +464,13 @@ static void _test_keystore_lock(void** state)
 static void _test_keystore_get_bip39_mnemonic(void** state)
 {
     char mnemonic[300];
-    mock_state(NULL, NULL);
+    mock_state(NULL, 0, NULL);
     assert_false(keystore_get_bip39_mnemonic(mnemonic, sizeof(mnemonic)));
 
-    mock_state(_mock_seed, NULL);
+    mock_state(_mock_seed, sizeof(_mock_seed), NULL);
     assert_false(keystore_get_bip39_mnemonic(mnemonic, sizeof(mnemonic)));
 
-    mock_state(_mock_seed, _mock_bip39_seed);
+    mock_state(_mock_seed, sizeof(_mock_seed), _mock_bip39_seed);
     assert_true(keystore_get_bip39_mnemonic(mnemonic, sizeof(mnemonic)));
     const char* expected_mnemonic =
         "baby mass dust captain baby mass mass dust captain baby mass dutch creek office smoke "
@@ -603,7 +603,7 @@ static void _mock_with_mnemonic(const char* mnemonic, const char* passphrase)
     size_t seed_len;
     assert_true(keystore_bip39_mnemonic_to_seed(mnemonic, seed, &seed_len));
 
-    mock_state(seed, NULL);
+    mock_state(seed, seed_len, NULL);
     assert_true(keystore_unlock_bip39(passphrase));
 }
 

--- a/test/unit-test/test_keystore.c
+++ b/test/unit-test/test_keystore.c
@@ -204,11 +204,11 @@ static void _test_keystore_get_xpub(void** state)
 
     struct ext_key xpub = {0};
 
-    mock_state(NULL, 0, NULL);
+    keystore_mock_unlocked(NULL, 0, NULL);
     // fails because keystore is locked
     assert_false(keystore_get_xpub(_keypath, sizeof(_keypath) / sizeof(uint32_t), &xpub));
 
-    mock_state(_mock_seed, sizeof(_mock_seed), _mock_bip39_seed);
+    keystore_mock_unlocked(_mock_seed, sizeof(_mock_seed), _mock_bip39_seed);
     assert_true(keystore_get_xpub(_keypath, sizeof(_keypath) / sizeof(uint32_t), &xpub));
 
     secp256k1_pubkey expected_pubkey;
@@ -232,7 +232,7 @@ static void _test_keystore_get_xpub(void** state)
 
 static void _test_keystore_get_root_fingerprint(void** state)
 {
-    mock_state(_mock_seed, sizeof(_mock_seed), _mock_bip39_seed);
+    keystore_mock_unlocked(_mock_seed, sizeof(_mock_seed), _mock_bip39_seed);
     uint8_t fingerprint[4];
     assert_true(keystore_get_root_fingerprint(fingerprint));
     uint8_t expected_fingerprint[4] = {0x9e, 0x1b, 0x2d, 0x1e};
@@ -248,13 +248,13 @@ static void _test_keystore_secp256k1_nonce_commit(void** state)
     memset(host_nonce_commitment, 0xAB, sizeof(host_nonce_commitment));
 
     {
-        mock_state(NULL, 0, NULL);
+        keystore_mock_unlocked(NULL, 0, NULL);
         // fails because keystore is locked
         assert_false(keystore_secp256k1_nonce_commit(
             _keypath, sizeof(_keypath) / sizeof(uint32_t), msg, host_nonce_commitment, commitment));
     }
     {
-        mock_state(_mock_seed, sizeof(_mock_seed), _mock_bip39_seed);
+        keystore_mock_unlocked(_mock_seed, sizeof(_mock_seed), _mock_bip39_seed);
         assert_true(keystore_secp256k1_nonce_commit(
             _keypath, sizeof(_keypath) / sizeof(uint32_t), msg, host_nonce_commitment, commitment));
         const uint8_t expected_commitment[EC_PUBLIC_KEY_LEN] =
@@ -279,13 +279,13 @@ static void _test_keystore_secp256k1_sign(void** state)
     memset(host_nonce, 0x56, sizeof(host_nonce));
 
     {
-        mock_state(NULL, 0, NULL);
+        keystore_mock_unlocked(NULL, 0, NULL);
         // fails because keystore is locked
         assert_false(keystore_secp256k1_sign(
             _keypath, sizeof(_keypath) / sizeof(uint32_t), msg, host_nonce, sig, NULL));
     }
     {
-        mock_state(_mock_seed, sizeof(_mock_seed), _mock_bip39_seed);
+        keystore_mock_unlocked(_mock_seed, sizeof(_mock_seed), _mock_bip39_seed);
 
         _sign_expected_seckey = _expected_seckey;
         _sign_expected_msg = msg;
@@ -412,7 +412,7 @@ static void _perform_some_unlocks(void)
 static void _test_keystore_unlock(void** state)
 {
     _smarteeprom_reset();
-    mock_state(NULL, 0, NULL); // reset to locked
+    keystore_mock_unlocked(NULL, 0, NULL); // reset to locked
 
     uint8_t remaining_attempts;
 
@@ -451,11 +451,11 @@ static void _test_keystore_unlock(void** state)
 
 static void _test_keystore_lock(void** state)
 {
-    mock_state(NULL, 0, NULL);
+    keystore_mock_unlocked(NULL, 0, NULL);
     assert_true(keystore_is_locked());
-    mock_state(_mock_seed, sizeof(_mock_seed), NULL);
+    keystore_mock_unlocked(_mock_seed, sizeof(_mock_seed), NULL);
     assert_true(keystore_is_locked());
-    mock_state(_mock_seed, sizeof(_mock_seed), _mock_bip39_seed);
+    keystore_mock_unlocked(_mock_seed, sizeof(_mock_seed), _mock_bip39_seed);
     assert_false(keystore_is_locked());
     keystore_lock();
     assert_true(keystore_is_locked());
@@ -464,13 +464,13 @@ static void _test_keystore_lock(void** state)
 static void _test_keystore_get_bip39_mnemonic(void** state)
 {
     char mnemonic[300];
-    mock_state(NULL, 0, NULL);
+    keystore_mock_unlocked(NULL, 0, NULL);
     assert_false(keystore_get_bip39_mnemonic(mnemonic, sizeof(mnemonic)));
 
-    mock_state(_mock_seed, sizeof(_mock_seed), NULL);
+    keystore_mock_unlocked(_mock_seed, sizeof(_mock_seed), NULL);
     assert_false(keystore_get_bip39_mnemonic(mnemonic, sizeof(mnemonic)));
 
-    mock_state(_mock_seed, sizeof(_mock_seed), _mock_bip39_seed);
+    keystore_mock_unlocked(_mock_seed, sizeof(_mock_seed), _mock_bip39_seed);
     assert_true(keystore_get_bip39_mnemonic(mnemonic, sizeof(mnemonic)));
     const char* expected_mnemonic =
         "baby mass dust captain baby mass mass dust captain baby mass dutch creek office smoke "
@@ -603,7 +603,7 @@ static void _mock_with_mnemonic(const char* mnemonic, const char* passphrase)
     size_t seed_len;
     assert_true(keystore_bip39_mnemonic_to_seed(mnemonic, seed, &seed_len));
 
-    mock_state(seed, seed_len, NULL);
+    keystore_mock_unlocked(seed, seed_len, NULL);
     assert_true(keystore_unlock_bip39(passphrase));
 }
 

--- a/test/unit-test/test_keystore_antiklepto.c
+++ b/test/unit-test/test_keystore_antiklepto.c
@@ -80,7 +80,7 @@ bool __wrap_keystore_secp256k1_nonce_commit(
 
 static void _test_keystore_antiklepto(void** state)
 {
-    mock_state(_mock_seed, sizeof(_mock_seed), _mock_bip39_seed);
+    keystore_mock_unlocked(_mock_seed, sizeof(_mock_seed), _mock_bip39_seed);
 
     uint32_t keypath[] = {
         84 + BIP32_INITIAL_HARDENED_CHILD,

--- a/test/unit-test/test_keystore_antiklepto.c
+++ b/test/unit-test/test_keystore_antiklepto.c
@@ -80,7 +80,7 @@ bool __wrap_keystore_secp256k1_nonce_commit(
 
 static void _test_keystore_antiklepto(void** state)
 {
-    mock_state(_mock_seed, _mock_bip39_seed);
+    mock_state(_mock_seed, sizeof(_mock_seed), _mock_bip39_seed);
 
     uint32_t keypath[] = {
         84 + BIP32_INITIAL_HARDENED_CHILD,


### PR DESCRIPTION
So we can test with seeds of 16 bytes too (12 words), not just 32
bytes (24 words).