### PR TITLE
protogen: align source messages with python and rust gen files

### DIFF
--- a/py/bitbox02/bitbox02/communication/generated/cardano_pb2.pyi
+++ b/py/bitbox02/bitbox02/communication/generated/cardano_pb2.pyi
@@ -135,6 +135,8 @@ class CardanoSignTransactionRequest(google.protobuf.message.Message):
             VALUE_FIELD_NUMBER: builtins.int
             asset_name: builtins.bytes = ...
             value: builtins.int = ...
+            """Number of tokens transacted of this asset."""
+
             def __init__(self,
                 *,
                 asset_name : builtins.bytes = ...,

--- a/src/rust/bitbox02-rust/src/shiftcrypto.bitbox02.rs
+++ b/src/rust/bitbox02-rust/src/shiftcrypto.bitbox02.rs
@@ -592,6 +592,7 @@ pub mod cardano_sign_transaction_request {
         pub struct Token {
             #[prost(bytes="vec", tag="1")]
             pub asset_name: ::prost::alloc::vec::Vec<u8>,
+            /// Number of tokens transacted of this asset.
             #[prost(uint64, tag="2")]
             pub value: u64,
         }


### PR DESCRIPTION
One proto comment didn't make it in 778bc9ee4, it seems, which added
support for Cardano tokens.
