### PR TITLE
keystore: add keystore_secp256k1_schnorr_bip86_[pubkey|sign] funcs

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -14,7 +14,7 @@ string(REPLACE "-mfpu=fpv4-sp-d16" "" MODIFIED_C_FLAGS ${MODIFIED_C_FLAGS_TMP})
 # wally-core
 
 # configure flags for secp256k1 bundled in libwally core, to reduce memory consumption
-set(LIBWALLY_SECP256k1_FLAGS --with-ecmult-window=2 --with-ecmult-gen-precision=2 --enable-ecmult-static-precomputation)
+set(LIBWALLY_SECP256k1_FLAGS --with-ecmult-window=2 --with-ecmult-gen-precision=2 --enable-ecmult-static-precomputation --enable-module-schnorrsig)
 set(LIBWALLY_CONFIGURE_FLAGS --enable-static --disable-shared --disable-tests ${LIBWALLY_SECP256k1_FLAGS})
 if(SANITIZE_ADDRESS)
   set(LIBWALLY_CFLAGS "-fsanitize=address")

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -239,7 +239,7 @@ USE_RESULT bool keystore_secp256k1_nonce_commit(
  * @param[in] msg32 32 byte message to sign
  * @param[in] host_nonce32 32 byte nonce contribution. Cannot be NULL.
  * Intended to be a contribution by the host. If there is none available, use 32 zero bytes.
- * @param[out] sig resulting signature in compact format. Must be 64 bytes.
+ * @param[out] sig_compact_out resulting signature in compact format. Must be 64 bytes.
  * @param[out] recid recoverable id. Can be NULL if not needed.
  * Parse with secp256k1_ecdsa_signature_serialize_compact().
  * @return true on success, false if the keystore is locked.
@@ -308,5 +308,38 @@ USE_RESULT bool keystore_encode_xpub_at_keypath(
     xpub_type_t xpub_type,
     char* out,
     size_t out_len);
+
+/**
+ * Return the tweaked taproot pubkey at the given keypath.
+ *
+ * Instead of returning the original pubkey at the keypath directly, it is tweaked with the hash of
+ * the pubkey.
+ *
+ * See
+ * https://github.com/bitcoin/bips/blob/edffe529056f6dfd33d8f716fb871467c3c09263/bip-0086.mediawiki#address-derivation
+ *
+ * @param[in] keypath derivation keypath
+ * @param[in] keypath_len number of elements in keypath
+ * @param[out] pubkey_out 32 byte x-only pubkey (see BIP-340 for details).
+ */
+USE_RESULT bool keystore_secp256k1_schnorr_bip86_pubkey(
+    const uint32_t* keypath,
+    size_t keypath_len,
+    uint8_t* pubkey_out);
+
+/**
+ * Sign a message that verifies against the pubkey returned by
+ * `keystore_secp256k1_schnorr_bip86_pubkey()`.
+ *
+ * @param[in] keypath derivation keypath
+ * @param[in] keypath_len number of elements in keypath
+ * @param[in] msg32 32 byte message to sign
+ * @param[out] sig64_out resulting 64 byte signature
+ */
+USE_RESULT bool keystore_secp256k1_schnorr_bip86_sign(
+    const uint32_t* keypath,
+    size_t keypath_len,
+    const uint8_t* msg32,
+    uint8_t* sig64_out);
 
 #endif


### PR DESCRIPTION
Needed to to generate taproot receive addresses and sign taproot
inputs in transactions.

A taproot output contains a 32 byte x-only pubkey (see BIP-340), which
may or may not be tweaked with the root of a merkle tree containing
execution scripts as leafs.

In a normal single-sig with no extra scripts, BIP-86 specifies:

> BIP 341 states: "If the spending conditions do not require a script
path, the output key should commit to an unspendable script path
instead of having no script path. This can be achieved by computing
the output key point as Q = P + int(hashTapTweak(bytes(P)))G.".

https://github.com/bitcoin/bips/blob/4c6389f8431f677847b115538a47ce8c826c6be8/bip-0086.mediawiki

This commit adds keystore functions to get such tweaked
pubkey (original pubkey tweaked with the hash of the original pubkey)
and to sign for it.

We put this functionality directly into keystore.c instead of
performing the tweaking outside of it so we only have to derive the
pubkey at the keypath once. The alternative would have been to add a
32 bytes tweak argument to the pubkey/sign functions and have the
caller compute the correct tweak, or to perform the tweaking at the
callsite altogether.