### PR TITLE
eth/sign: increase size limit for tx data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ customers cannot upgrade their bootloader, its changes are recorded separately.
 - Cardano: add support for sending tokens
 - Protobuf: rename BTCSignOutputRequest.hash to BTCSignOutputRequest.payload
 - Ethereum: add 807 ERC-20 tokens
+- Ethereum: increase size limit for transaction data to accommodate Opensea transactions
 
 ### 9.8.0 [released 2021-10-21]
 - Multi edition: add Cardano support.

--- a/src/rust/bitbox02-rust/src/hww/api/ethereum/sign.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/ethereum/sign.rs
@@ -196,7 +196,7 @@ pub async fn process(request: &pb::EthSignRequest) -> Result<Response, Error> {
         || request.gas_price.len() > 16
         || request.gas_limit.len() > 16
         || request.value.len() > 32
-        || request.data.len() > 1024
+        || request.data.len() > 6144
     {
         return Err(Error::InvalidInput);
     }
@@ -626,7 +626,7 @@ mod tests {
         {
             // data too long
             let mut invalid_request = valid_request.clone();
-            invalid_request.data = vec![0; 1025];
+            invalid_request.data = vec![0; 6145];
             assert_eq!(
                 block_on(process(&invalid_request)),
                 Err(Error::InvalidInput)


### PR DESCRIPTION
Fixes #843

We previously limited the max. size of contract data to 1024 bytes.

Some smart contract invocations require much larger data,
e.g. transactions involving the Opensea contract. Example tx with a
large data field (~2400 bytes):

https://etherscan.io/tx/0x2db260bf407a246e3bbf57692168238b55b8518ef72c8288e68547e418cf0e08

Ideally, Opensea transactions would be parsed and displayed in a human
readable format instead. The current way to display the raw contract
data is only safe for expert users that know how to verify it, but
that is not feasible for huge contract data fields like with Opensea.

For now, we don't change the data display logic but simply increase
the size limit so transcations with larger data fields don't fail. The
data field is shown in raw hex format, truncated at 320
bytes (`MAX_LABEL_SIZE`) as before this commit.

Our USB packet size is 7609 bytes (`USB_DATA_MAX_LEN`). We bump the
max data limit to a new arbitrary large number, but below the max
packet size so a transaction can still be transmitted to the
device. The other ETH transaction fields combined are less than 200
bytes.