### PR TITLE
api/restore: confirm restore and backup name/ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ customers cannot upgrade their bootloader, its changes are recorded separately.
 ### [Unreleased]
 - Support sending to taproot addresses
 - ListBackups: ported to Rust
+- Confirm restore from microSD before setting a device password
 - Cardano: allow transactions with a zero TTL value
 - Cardano: add support for sending tokens
 - Protobuf: rename BTCSignOutputRequest.hash to BTCSignOutputRequest.payload


### PR DESCRIPTION
The ID is shown to disambiguate in case there are multiple backups
with the same name.