### PR TITLE
rust: run unit tests serially, drop MUTEX to manually serialize

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -175,6 +175,9 @@ Then you can run the tests by executing
 make run-unit-tests # or make -C build-build test
 ```
 
+Rust unit tests, if not invoked via `make run-rust-unit-tests`, must be run with
+`-- --test-threads 1` due to unsafe concurrent access to `SafeData`, `mock_sd()` and `mock_memory()`.
+
 ### Coverage
 
 gcovr or lcov/genhtml can be used to generate HTML coverage reports using the following commands:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -441,7 +441,8 @@ if(NOT CMAKE_CROSSCOMPILING)
         # see src/rust/bitbox02-rust-c/src/lib.rs.
         # https://github.com/rust-lang/rust/issues/66740
         RUSTC_BOOTSTRAP=1
-        ${CARGO} test $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:-v> --all-features --target-dir ${RUST_BINARY_DIR}/all-features ${RUST_CARGO_FLAG} -- --nocapture
+        # only one test thread because of unsafe concurrent access to `SafeData`, `mock_sd()` and `mock_memory()`. Using mutexes instead leads to mutex poisoning and very messy output in case of a unit test failure.
+        ${CARGO} test $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:-v> --all-features --target-dir ${RUST_BINARY_DIR}/all-features ${RUST_CARGO_FLAG} -- --nocapture --test-threads 1
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/rust/
     )
   add_dependencies(rust-test bitbox_merged)

--- a/src/rust/bitbox02-rust/src/async_usb.rs
+++ b/src/rust/bitbox02-rust/src/async_usb.rs
@@ -241,8 +241,6 @@ mod tests {
     use super::*;
     use std::prelude::v1::*;
 
-    use bitbox02::testing::MUTEX;
-
     fn assert_panics<F: FnOnce() + std::panic::UnwindSafe>(f: F) {
         assert!(std::panic::catch_unwind(f).is_err());
     }
@@ -250,8 +248,6 @@ mod tests {
     /// Test spawning a task, spinning it, and getting the result.
     #[test]
     fn test_full_cycle() {
-        let _guard = MUTEX.lock().unwrap();
-
         async fn task(usb_in: UsbIn) -> UsbOut {
             assert_eq!(usb_in, [1, 2, 3].to_vec());
             [4, 5, 6, 7].to_vec()
@@ -294,8 +290,6 @@ mod tests {
 
     #[test]
     fn test_next_request() {
-        let _guard = MUTEX.lock().unwrap();
-
         async fn task(usb_in: UsbIn) -> UsbOut {
             assert_eq!(&usb_in, &[1, 2, 3]);
             let next_req = next_request([4, 5, 6, 7].to_vec()).await;

--- a/src/rust/bitbox02-rust/src/hww/api/backup.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/backup.rs
@@ -163,14 +163,13 @@ mod tests {
 
     use crate::bb02_async::block_on;
     use bitbox02::testing::{
-        mock, mock_memory, mock_sd, mock_unlocked, mock_unlocked_using_mnemonic, Data, MUTEX,
+        mock, mock_memory, mock_sd, mock_unlocked, mock_unlocked_using_mnemonic, Data,
     };
     use std::boxed::Box;
 
     /// Test backup creation on a uninitialized keystore.
     #[test]
     pub fn test_create_uninitialized() {
-        let _guard = MUTEX.lock().unwrap();
         const EXPECTED_TIMESTMAP: u32 = 1601281809;
 
         // All good.
@@ -197,7 +196,6 @@ mod tests {
 
     #[test]
     pub fn test_list() {
-        let _guard = MUTEX.lock().unwrap();
         const EXPECTED_TIMESTMAP: u32 = 1601281809;
 
         const DEVICE_NAME_1: &str = "test device name";

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin.rs
@@ -202,12 +202,11 @@ mod tests {
     use crate::bb02_async::block_on;
     use alloc::boxed::Box;
     use alloc::vec::Vec;
-    use bitbox02::testing::{mock, mock_unlocked, Data, MUTEX};
+    use bitbox02::testing::{mock, mock_unlocked, Data};
     use util::bip32::HARDENED;
 
     #[test]
     pub fn test_xpub() {
-        let _guard = MUTEX.lock().unwrap();
         struct Test<'a> {
             coin: BtcCoin,
             keypath: &'a [u32],
@@ -398,8 +397,6 @@ mod tests {
 
     #[test]
     pub fn test_address_simple() {
-        let _guard = MUTEX.lock().unwrap();
-
         struct Test<'a> {
             coin: BtcCoin,
             keypath: &'a [u32],

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin/signmsg.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin/signmsg.rs
@@ -131,7 +131,7 @@ mod tests {
     use super::*;
 
     use crate::bb02_async::block_on;
-    use bitbox02::testing::{mock, mock_unlocked, Data, MUTEX};
+    use bitbox02::testing::{mock, mock_unlocked, Data};
     use std::boxed::Box;
     use util::bip32::HARDENED;
 
@@ -142,8 +142,6 @@ mod tests {
 
     #[test]
     pub fn test_process() {
-        let _guard = MUTEX.lock().unwrap();
-
         let request = pb::BtcSignMessageRequest {
             coin: BtcCoin::Btc as _,
             script_config: Some(pb::BtcScriptConfigWithKeypath {
@@ -195,8 +193,6 @@ mod tests {
 
     #[test]
     pub fn test_process_user_aborted() {
-        let _guard = MUTEX.lock().unwrap();
-
         let request = pb::BtcSignMessageRequest {
             coin: BtcCoin::Btc as _,
             script_config: Some(pb::BtcScriptConfigWithKeypath {
@@ -282,8 +278,6 @@ mod tests {
 
     #[test]
     pub fn test_process_failures() {
-        let _guard = MUTEX.lock().unwrap();
-
         // Invalid coin
         assert_eq!(
             block_on(process(&pb::BtcSignMessageRequest {

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin/signtx.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin/signtx.rs
@@ -369,7 +369,7 @@ mod tests {
     use super::*;
     use crate::bb02_async::block_on;
     use alloc::boxed::Box;
-    use bitbox02::testing::{mock, mock_unlocked, Data, MUTEX};
+    use bitbox02::testing::{mock, mock_unlocked, Data};
     use util::bip32::HARDENED;
 
     struct TxInput {
@@ -764,8 +764,6 @@ mod tests {
 
     #[test]
     pub fn test_process() {
-        let _guard = MUTEX.lock().unwrap();
-
         let transaction = alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new()));
 
         let tx = transaction.clone();

--- a/src/rust/bitbox02-rust/src/hww/api/cardano/address.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/cardano/address.rs
@@ -151,7 +151,7 @@ mod tests {
     use super::*;
     use crate::bb02_async::block_on;
     use alloc::boxed::Box;
-    use bitbox02::testing::{mock, mock_unlocked, Data, MUTEX};
+    use bitbox02::testing::{mock, mock_unlocked, Data};
     use util::bip32::HARDENED;
 
     #[test]
@@ -223,7 +223,6 @@ mod tests {
 
     #[test]
     fn test_pubkey_hash_at_keypath() {
-        let _guard = MUTEX.lock().unwrap();
         bitbox02::keystore::lock();
         assert!(
             pubkey_hash_at_keypath(&[1852 + HARDENED, 1815 + HARDENED, HARDENED, 0, 0]).is_err()
@@ -238,8 +237,6 @@ mod tests {
 
     #[test]
     fn test_process_failures() {
-        let _guard = MUTEX.lock().unwrap();
-
         // All good
         mock_unlocked();
         assert_eq!(
@@ -302,8 +299,6 @@ mod tests {
 
     #[test]
     fn test_process_confirm() {
-        let _guard = MUTEX.lock().unwrap();
-
         const EXPECTED: &str = "addr1q90tlskd4mh5kncmul7vx887j30tjtfgvap5n0g0rf9qqc7znmndrdhe7rwvqkw5c7mqnp4a3yflnvu6kff7l5dungvqmvu6hs";
 
         mock(Data {
@@ -333,8 +328,6 @@ mod tests {
 
     #[test]
     fn test_process_table() {
-        let _guard = MUTEX.lock().unwrap();
-
         struct Test<'a> {
             keypath_payment: &'a [u32],
             keypath_stake: &'a [u32],

--- a/src/rust/bitbox02-rust/src/hww/api/cardano/sign_transaction.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/cardano/sign_transaction.rs
@@ -292,7 +292,7 @@ mod tests {
     use super::*;
     use crate::bb02_async::block_on;
     use alloc::boxed::Box;
-    use bitbox02::testing::{mock, mock_unlocked, Data, MUTEX};
+    use bitbox02::testing::{mock, mock_unlocked, Data};
     use util::bip32::HARDENED;
 
     use pb::cardano_sign_transaction_request::{certificate, certificate::Cert, Certificate};
@@ -345,8 +345,6 @@ mod tests {
 
     #[test]
     fn test_sign_normal_tx() {
-        let _guard = MUTEX.lock().unwrap();
-
         let tx = pb::CardanoSignTransactionRequest {
             network: CardanoNetwork::CardanoMainnet as _,
             inputs: vec![pb::cardano_sign_transaction_request::Input {
@@ -437,8 +435,6 @@ mod tests {
 
     #[test]
     fn test_sign_stake_registration() {
-        let _guard = MUTEX.lock().unwrap();
-
         let tx = pb::CardanoSignTransactionRequest {
             network: CardanoNetwork::CardanoMainnet as _,
             inputs: vec![
@@ -556,8 +552,6 @@ mod tests {
 
     #[test]
     fn test_sign_stake_deregistration() {
-        let _guard = MUTEX.lock().unwrap();
-
         let tx = pb::CardanoSignTransactionRequest {
             network: CardanoNetwork::CardanoMainnet as _,
             inputs: vec![
@@ -659,8 +653,6 @@ mod tests {
 
     #[test]
     fn test_sign_withdrawal() {
-        let _guard = MUTEX.lock().unwrap();
-
         let tx = pb::CardanoSignTransactionRequest {
             network: CardanoNetwork::CardanoMainnet as _,
             inputs: vec![
@@ -752,8 +744,6 @@ mod tests {
     /// Test that ttl=0 is not included in the transaction if allow_ttl_zero is false. Up to v9.8.0, ttl was not included if it was zero.
     #[test]
     fn test_sign_tx_no_ttl() {
-        let _guard = MUTEX.lock().unwrap();
-
         let tx = pb::CardanoSignTransactionRequest {
             network: CardanoNetwork::CardanoMainnet as _,
             inputs: vec![pb::cardano_sign_transaction_request::Input {
@@ -813,8 +803,6 @@ mod tests {
     /// Also test other configurations where the transaction cannot be mined.
     #[test]
     fn test_sign_non_mineable_tx() {
-        let _guard = MUTEX.lock().unwrap();
-
         let tx = pb::CardanoSignTransactionRequest {
             network: CardanoNetwork::CardanoMainnet as _,
             inputs: vec![pb::cardano_sign_transaction_request::Input {
@@ -887,8 +875,6 @@ mod tests {
 
     #[test]
     fn test_sign_tx_valid_interval_start() {
-        let _guard = MUTEX.lock().unwrap();
-
         let tx = pb::CardanoSignTransactionRequest {
             network: CardanoNetwork::CardanoMainnet as _,
             inputs: vec![pb::cardano_sign_transaction_request::Input {
@@ -950,8 +936,6 @@ mod tests {
 
     #[test]
     fn test_sign_tx_invalid_interval_start() {
-        let _guard = MUTEX.lock().unwrap();
-
         let tx = pb::CardanoSignTransactionRequest {
             network: CardanoNetwork::CardanoMainnet as _,
             inputs: vec![pb::cardano_sign_transaction_request::Input {
@@ -1013,8 +997,6 @@ mod tests {
 
     #[test]
     fn test_sign_tx_tokens() {
-        let _guard = MUTEX.lock().unwrap();
-
         let tx = pb::CardanoSignTransactionRequest {
             network: CardanoNetwork::CardanoMainnet as _,
             inputs: vec![pb::cardano_sign_transaction_request::Input {

--- a/src/rust/bitbox02-rust/src/hww/api/electrum.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/electrum.rs
@@ -52,13 +52,11 @@ mod tests {
     use super::*;
 
     use crate::bb02_async::block_on;
-    use bitbox02::testing::{mock_unlocked, MUTEX};
+    use bitbox02::testing::mock_unlocked;
     use std::boxed::Box;
 
     #[test]
     pub fn test_process() {
-        let _guard = MUTEX.lock().unwrap();
-
         mock_unlocked();
 
         // All good.

--- a/src/rust/bitbox02-rust/src/hww/api/ethereum/pubrequest.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/ethereum/pubrequest.rs
@@ -98,14 +98,12 @@ mod tests {
     use super::*;
 
     use crate::bb02_async::block_on;
-    use bitbox02::testing::{mock, mock_unlocked, Data, MUTEX};
+    use bitbox02::testing::{mock, mock_unlocked, Data};
     use std::boxed::Box;
     use util::bip32::HARDENED;
 
     #[test]
     pub fn test_process_xpub() {
-        let _guard = MUTEX.lock().unwrap();
-
         const EXPECTED_XPUB: &str = "xpub6FNKHYBc1HTwuwZcj4dz7xiG1kN7Hs3v7efYmgtzu1Gv6wJXxaCnFdQDRodbQpJKwdeVBf1RRNHARa6FsUMTCuRe2gKR7xCkSDdnppUp9oW";
         let request = pb::EthPubRequest {
             output_type: OutputType::Xpub as _,
@@ -155,8 +153,6 @@ mod tests {
 
     #[test]
     pub fn test_process_address() {
-        let _guard = MUTEX.lock().unwrap();
-
         const ADDRESS: &str = "0x773A77b9D32589be03f9132AF759e294f7851be9";
 
         let request = &pb::EthPubRequest {
@@ -296,8 +292,6 @@ mod tests {
 
     #[test]
     pub fn test_process_erc20_address() {
-        let _guard = MUTEX.lock().unwrap();
-
         const ADDRESS: &str = "0x773A77b9D32589be03f9132AF759e294f7851be9";
         const CONTRACT_ADDRESS: [u8; 20] =
             *b"\xda\xc1\x7f\x95\x8d\x2e\xe5\x23\xa2\x20\x62\x06\x99\x45\x97\xc1\x3d\x83\x1e\xc7";

--- a/src/rust/bitbox02-rust/src/hww/api/ethereum/sign.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/ethereum/sign.rs
@@ -280,7 +280,7 @@ mod tests {
     use super::*;
 
     use crate::bb02_async::block_on;
-    use bitbox02::testing::{mock, mock_unlocked, Data, MUTEX};
+    use bitbox02::testing::{mock, mock_unlocked, Data};
     use std::boxed::Box;
     use util::bip32::HARDENED;
 
@@ -349,8 +349,6 @@ mod tests {
     /// Standard ETH transaction with no data field.
     #[test]
     pub fn test_process_standard_transaction() {
-        let _guard = MUTEX.lock().unwrap();
-
         const KEYPATH: &[u32] = &[44 + HARDENED, 60 + HARDENED, 0 + HARDENED, 0, 0];
 
         mock(Data {
@@ -389,8 +387,6 @@ mod tests {
     /// Standard ETH transaction on an unusual keypath (Ropsten on mainnet keypath)
     #[test]
     pub fn test_process_warn_unusual_keypath() {
-        let _guard = MUTEX.lock().unwrap();
-
         const KEYPATH: &[u32] = &[44 + HARDENED, 60 + HARDENED, 0 + HARDENED, 0, 0];
 
         static mut CONFIRM_COUNTER: u32 = 0;
@@ -442,8 +438,6 @@ mod tests {
     /// Standard ETH transaction with an unknown data field.
     #[test]
     pub fn test_process_standard_transaction_with_data() {
-        let _guard = MUTEX.lock().unwrap();
-
         const KEYPATH: &[u32] = &[44 + HARDENED, 60 + HARDENED, 0 + HARDENED, 0, 0];
         static mut CONFIRM_COUNTER: u32 = 0;
         mock(Data {
@@ -498,8 +492,6 @@ mod tests {
     /// the data field contains an ERC20 transfer method invocation.
     #[test]
     pub fn test_process_standard_erc20_transaction() {
-        let _guard = MUTEX.lock().unwrap();
-
         const KEYPATH: &[u32] = &[44 + HARDENED, 60 + HARDENED, 0 + HARDENED, 0, 0];
 
         mock(Data {
@@ -538,8 +530,6 @@ mod tests {
     /// An ERC20 transaction which is not in our list of supported ERC20 tokens.
     #[test]
     pub fn test_process_standard_unknown_erc20_transaction() {
-        let _guard = MUTEX.lock().unwrap();
-
         const KEYPATH: &[u32] = &[44 + HARDENED, 60 + HARDENED, 0 + HARDENED, 0, 0];
 
         mock(Data {
@@ -577,8 +567,6 @@ mod tests {
 
     #[test]
     pub fn test_process_unhappy() {
-        let _guard = MUTEX.lock().unwrap();
-
         let valid_request = pb::EthSignRequest {
             coin: pb::EthCoin::Eth as _,
             keypath: vec![44 + HARDENED, 60 + HARDENED, 0 + HARDENED, 0, 0],

--- a/src/rust/bitbox02-rust/src/hww/api/ethereum/signmsg.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/ethereum/signmsg.rs
@@ -92,7 +92,7 @@ mod tests {
     use super::*;
 
     use crate::bb02_async::block_on;
-    use bitbox02::testing::{mock, mock_unlocked, Data, MUTEX};
+    use bitbox02::testing::{mock, mock_unlocked, Data};
     use std::boxed::Box;
     use util::bip32::HARDENED;
 
@@ -102,8 +102,6 @@ mod tests {
 
     #[test]
     pub fn test_process() {
-        let _guard = MUTEX.lock().unwrap();
-
         const SIGNATURE: [u8; 64] = [b'1'; 64];
 
         static mut CONFIRM_COUNTER: u32 = 0;
@@ -146,8 +144,6 @@ mod tests {
 
     #[test]
     pub fn test_process_warn_unusual_keypath() {
-        let _guard = MUTEX.lock().unwrap();
-
         const SIGNATURE: [u8; 64] = [b'1'; 64];
 
         static mut CONFIRM_COUNTER: u32 = 0;
@@ -191,8 +187,6 @@ mod tests {
 
     #[test]
     pub fn test_process_user_aborted() {
-        let _guard = MUTEX.lock().unwrap();
-
         let request = pb::EthSignMessageRequest {
             coin: pb::EthCoin::Eth as _,
             keypath: KEYPATH.to_vec(),
@@ -249,8 +243,6 @@ mod tests {
 
     #[test]
     pub fn test_process_failures() {
-        let _guard = MUTEX.lock().unwrap();
-
         const KEYPATH: &[u32] = &[44 + HARDENED, 60 + HARDENED, 0 + HARDENED, 0, 0];
 
         // Message too long

--- a/src/rust/bitbox02-rust/src/hww/api/reset.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/reset.rs
@@ -40,13 +40,11 @@ mod tests {
     use super::*;
 
     use crate::bb02_async::block_on;
-    use bitbox02::testing::{mock, Data, MUTEX};
+    use bitbox02::testing::{mock, Data};
     use std::boxed::Box;
 
     #[test]
     pub fn test_reset() {
-        let _guard = MUTEX.lock().unwrap();
-
         // All good.
         mock(Data {
             ui_confirm_create: Some(Box::new(|params| {

--- a/src/rust/bitbox02-rust/src/hww/api/sdcard.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/sdcard.rs
@@ -44,13 +44,11 @@ mod tests {
     use super::*;
 
     use crate::bb02_async::block_on;
-    use bitbox02::testing::{mock, Data, MUTEX};
+    use bitbox02::testing::{mock, Data};
     use std::boxed::Box;
 
     #[test]
     pub fn test_reset() {
-        let _guard = MUTEX.lock().unwrap();
-
         // already inserted.
         mock(Data {
             sdcard_inserted: Some(true),

--- a/src/rust/bitbox02-rust/src/hww/api/set_device_name.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/set_device_name.rs
@@ -46,13 +46,11 @@ mod tests {
     use super::*;
 
     use crate::bb02_async::block_on;
-    use bitbox02::testing::{mock, mock_memory, Data, MUTEX};
+    use bitbox02::testing::{mock, mock_memory, Data};
     use std::boxed::Box;
 
     #[test]
     pub fn test_set_device_name() {
-        let _guard = MUTEX.lock().unwrap();
-
         static SOME_NAME: &str = "foo";
 
         // All good.

--- a/src/rust/bitbox02-rust/src/hww/api/set_mnemonic_passphrase_enabled.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/set_mnemonic_passphrase_enabled.rs
@@ -44,13 +44,11 @@ mod tests {
     use super::*;
 
     use crate::bb02_async::block_on;
-    use bitbox02::testing::{mock, mock_memory, Data, MUTEX};
+    use bitbox02::testing::{mock, mock_memory, Data};
     use std::boxed::Box;
 
     #[test]
     pub fn test_mnemonic_passphrase_enabled() {
-        let _guard = MUTEX.lock().unwrap();
-
         // All good.
         mock(Data {
             ui_confirm_create: Some(Box::new(|params| {

--- a/src/rust/bitbox02-rust/src/hww/api/system.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/system.rs
@@ -42,13 +42,11 @@ mod tests {
     use super::*;
 
     use crate::bb02_async::block_on;
-    use bitbox02::testing::{mock, Data, MUTEX};
+    use bitbox02::testing::{mock, Data};
     use std::boxed::Box;
 
     #[test]
     pub fn test_reboot() {
-        let _guard = MUTEX.lock().unwrap();
-
         mock(Data {
             ui_confirm_create: Some(Box::new(|_| true)),
             ..Default::default()
@@ -67,8 +65,6 @@ mod tests {
 
     #[test]
     pub fn test_reboot_aborted() {
-        let _guard = MUTEX.lock().unwrap();
-
         mock(Data {
             ui_confirm_create: Some(Box::new(|_| false)),
             ..Default::default()

--- a/src/rust/bitbox02-rust/src/keystore/ed25519.rs
+++ b/src/rust/bitbox02-rust/src/keystore/ed25519.rs
@@ -48,12 +48,10 @@ mod tests {
     use super::*;
 
     use bip32_ed25519::HARDENED_OFFSET;
-    use bitbox02::testing::{mock_unlocked, MUTEX};
+    use bitbox02::testing::mock_unlocked;
 
     #[test]
     fn test_get_xpub() {
-        let _guard = MUTEX.lock().unwrap();
-
         assert!(get_xpub(&[]).is_err());
 
         mock_unlocked();

--- a/src/rust/bitbox02-rust/src/workflow/mnemonic.rs
+++ b/src/rust/bitbox02-rust/src/workflow/mnemonic.rs
@@ -262,7 +262,7 @@ mod tests {
     extern crate std;
     use super::*;
 
-    use bitbox02::testing::{mock, Data, MUTEX};
+    use bitbox02::testing::{mock, Data};
     use std::boxed::Box;
 
     fn bruteforce_lastword(mnemonic: &[&str]) -> Vec<zeroize::Zeroizing<String>> {
@@ -280,8 +280,6 @@ mod tests {
 
     #[test]
     fn test_lastword_choices() {
-        let _guard = MUTEX.lock().unwrap();
-
         assert_eq!(
             &as_str_vec(&bruteforce_lastword(&["violin"; 23])),
             &["boss", "coyote", "dry", "habit", "panel", "regular", "speed", "winter"]

--- a/src/rust/bitbox02/src/backup.rs
+++ b/src/rust/bitbox02/src/backup.rs
@@ -104,12 +104,10 @@ pub fn restore_from_directory(dir: &str) -> Result<RestoreData, RestoreError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::testing::{mock_memory, mock_sd, mock_unlocked, MUTEX};
+    use crate::testing::{mock_memory, mock_sd, mock_unlocked};
 
     #[test]
     pub fn test_restore_from_backup() {
-        let _guard = MUTEX.lock().unwrap();
-
         mock_memory();
         mock_sd();
         mock_unlocked();

--- a/src/rust/bitbox02/src/keystore.rs
+++ b/src/rust/bitbox02/src/keystore.rs
@@ -302,7 +302,7 @@ pub fn get_ed25519_seed() -> Result<zeroize::Zeroizing<Vec<u8>>, ()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::testing::{mock_unlocked, MUTEX, TEST_MNEMONIC};
+    use crate::testing::{mock_unlocked, TEST_MNEMONIC};
 
     #[test]
     fn test_bip39_mnemonic_to_seed() {
@@ -339,8 +339,6 @@ mod tests {
 
     #[test]
     fn test_get_bip39_mnemonic() {
-        let _guard = MUTEX.lock().unwrap();
-
         lock();
         assert!(get_bip39_mnemonic().is_err());
 
@@ -363,8 +361,6 @@ mod tests {
 
     #[test]
     fn test_get_ed25519_seed() {
-        let _guard = MUTEX.lock().unwrap();
-
         // No seed on a locked keystore.
         lock();
         assert!(get_ed25519_seed().is_err());

--- a/src/rust/bitbox02/src/testing.rs
+++ b/src/rust/bitbox02/src/testing.rs
@@ -33,12 +33,11 @@ pub struct Data {
 
 pub struct SafeData(pub RefCell<Data>);
 
-// Safety: must hold MUTEX lock before accessing.
+// Safety: must not be accessed concurrently.
 unsafe impl Sync for SafeData {}
 
 lazy_static! {
     pub static ref DATA: SafeData = SafeData(RefCell::new(Default::default()));
-    pub static ref MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
 }
 
 /// Provide mock implementations and data. This also locks the keystore - use `mock_unlocked()` to mock a seeded and unlocked keystore.
@@ -64,14 +63,14 @@ pub fn mock_unlocked() {
     mock_unlocked_using_mnemonic(TEST_MNEMONIC)
 }
 
-/// This mounts a new FAT32 volume in RAM for use in unit tests. As there is only one volume, access only when holding `MUTEX`.
+/// This mounts a new FAT32 volume in RAM for use in unit tests. As there is only one volume, access only serially.
 pub fn mock_sd() {
     unsafe {
         bitbox02_sys::sd_format();
     }
 }
 
-/// This sets up memory in RAM for use in unit tests. As there is only one RAM volume, access only when holding `MUTEX`.
+/// This sets up memory in RAM for use in unit tests. As there is only one RAM volume, access only serially.
 /// The memory is initialized to be like after factory setup, i.e. 0xFF everywhere followed by `memory_setup()`.
 pub fn mock_memory() {
     unsafe {


### PR DESCRIPTION
Before, if a unit test panicked with a mutex guard, all other unit
tests waiting for the mutex panic as well due to being poisoned. This
leads to very verbose and messy output if a unit tests
fails. Furthermore, the actual unit test error is sometimes mangled up
with the other output.

By running the tests serially, we can drop the mutex and avoid all
these problems.

Alternative considered: use into_inner() on the PoisonError, as
described in

- https://doc.rust-lang.org/std/sync/struct.PoisonError.html
- https://doc.rust-lang.org/nomicon/poisoning.html

It is not clear if this would always lead to correct unit test
behavior, and handling the locks becomes even less ergonomic.