### PR TITLE
cardano/signtx: disallow duplicate token keys in an output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ customers cannot upgrade their bootloader, its changes are recorded separately.
 
 ### [Unreleased]
 - Cardano: support sending to legacy Byron addresses
+- Cardano: disallow duplicate token keys in an output
 
 ### 9.9.0 [released 2022-01-10]
 - Support sending to taproot addresses


### PR DESCRIPTION
Token key being: (policy id, asset name).

A duplicate token in an output would be confirmed multiple times by
the user. The resulting tx is valid at the protocol level, but only
the last token with the same key is used when there are duplicates.

