### PR TITLE
dockerenv.sh: set non-unique GID flag in groupadd

### DIFF
--- a/scripts/dockerenv.sh
+++ b/scripts/dockerenv.sh
@@ -58,7 +58,7 @@ dockerdev () {
 
     # Use same user/group id as on the host, so that files are not created as root in the mounted
     # volume.
-    docker exec -it "$CONTAINER_NAME" groupadd -g "$(id -g)" dockergroup
+    docker exec -it "$CONTAINER_NAME" groupadd -o -g "$(id -g)" dockergroup
     docker exec -it "$CONTAINER_NAME" useradd -u "$(id -u)" -m -g dockergroup dockeruser
 
     # Call a second time to enter the container.


### PR DESCRIPTION
This is a bugfix for running the Docker script on Mac. The script was aborting with a "groupadd: GID '20' already exists" error message even though the script comment specifically says it will use an already existing GID.

Solved by adding the `-o` option to `groupadd`. 
```
-o, --non-unique
    This option permits to add a group with a non-unique GID. 
```