### PR TITLE
memory: move shared data to new file memory_shared.h

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,6 +29,7 @@ set(DBB-FIRMWARE-SOURCES
   ${CMAKE_SOURCE_DIR}/src/hww.c
   ${CMAKE_SOURCE_DIR}/src/memory/bitbox02_smarteeprom.c
   ${CMAKE_SOURCE_DIR}/src/memory/memory.c
+  ${CMAKE_SOURCE_DIR}/src/memory/memory_shared.c
   ${CMAKE_SOURCE_DIR}/src/memory/mpu.c
   ${CMAKE_SOURCE_DIR}/src/memory/nvmctrl.c
   ${CMAKE_SOURCE_DIR}/src/memory/smarteeprom.c
@@ -123,6 +124,7 @@ set(DBB-BOOTLOADER-SOURCES
   ${CMAKE_SOURCE_DIR}/src/bootloader/bootloader.c
   ${CMAKE_SOURCE_DIR}/src/bootloader/startup.c
   ${CMAKE_SOURCE_DIR}/src/bootloader/mpu_regions.c
+  ${CMAKE_SOURCE_DIR}/src/memory/memory_shared.c
   ${CMAKE_SOURCE_DIR}/src/memory/mpu.c
   ${CMAKE_SOURCE_DIR}/src/memory/nvmctrl.c
   ${CMAKE_SOURCE_DIR}/src/queue.c

--- a/src/flags.h
+++ b/src/flags.h
@@ -70,6 +70,8 @@
 #define FLASH_APP_VERSION_LEN (4) // 4 byte big endian unsigned int
 #define FLASH_APP_VERSION_START (FLASH_APP_START + FLASH_APP_LEN - FLASH_APP_VERSION_LEN)
 
+#define CHUNK_SIZE (FLASH_ERASE_MIN_LEN) // 8kB; minimum erase granularity
+
 // SmartEEPROM reserved memory start
 #define FLASH_SMARTEEPROM_START (FLASH_END - SMARTEEPROM_RESERVED_FLASH_PAGES * FLASH_PAGE_SIZE)
 

--- a/src/memory/memory.c
+++ b/src/memory/memory.c
@@ -12,13 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include "flags.h"
 #include "hardfault.h"
-#include "memory/memory.h"
+#include "memory.h"
+#include "memory_shared.h"
 #include "random.h"
 #include "util.h"
 #include <rust/rust.h>
@@ -39,15 +41,11 @@
 
 // Everything defaults to 0xFF (erased state).
 
-#define CHUNK_SIZE (FLASH_ERASE_MIN_LEN) // 8kB; minimum erase granularity
 #if (FLASH_APPDATA_START % CHUNK_SIZE)
 #error "Chunk start not aligned with erase granularity"
 #endif
 #if (FLASH_APPDATA_LEN % CHUNK_SIZE)
 #error "Chunk end not aligned with erase granularity"
-#endif
-#if (FLASH_SHARED_DATA_LEN != CHUNK_SIZE)
-#error "Shared data chunk not correct length"
 #endif
 
 #pragma GCC diagnostic push
@@ -113,28 +111,6 @@ typedef union {
     } fields;
     uint8_t bytes[CHUNK_SIZE];
 } chunk_2_t;
-
-// CHUNK_SHARED: Shared data between the bootloader and firmware.
-//    auto_enter: if sectrue_u8, bootloader mode is entered on reboot
-//    upside_down: passes screen orientation to the bootloader
-//
-// ** DO NOT CHANGE MEMBER ORDER OR MEMORY LOCATION **
-//
-// Because the bootloader is fixed, changes may break the bootloader!
-//
-typedef union {
-    struct __attribute__((__packed__)) {
-        // Shared flags - do not change order!
-        uint8_t auto_enter;
-        uint8_t upside_down;
-        // Following are used by firmware only
-        uint8_t reserved[2];
-        uint8_t io_protection_key_split[32];
-        uint8_t authorization_key_split[32];
-        uint8_t encryption_key_split[32];
-    } fields;
-    uint8_t bytes[CHUNK_SIZE];
-} chunk_shared_t;
 #pragma GCC diagnostic pop
 
 #define BITMASK_SEEDED ((uint8_t)(1u << 0u))
@@ -227,15 +203,6 @@ static void _read_chunk(uint32_t chunk_num, uint8_t* chunk_out)
 #endif
 }
 
-static void _read_shared_bootdata(uint8_t* chunk_out)
-{
-#ifdef TESTING
-    memory_read_shared_bootdata_mock(chunk_out);
-#else
-    memcpy(chunk_out, (uint8_t*)(FLASH_SHARED_DATA_START), CHUNK_SIZE);
-#endif
-}
-
 static const memory_interface_functions_t* _interface_functions = NULL;
 
 /********* Exposed functions ****************/
@@ -309,7 +276,7 @@ bool memory_setup(const memory_interface_functions_t* ifs)
 
     chunk_shared_t shared_chunk = {0};
     CLEANUP_CHUNK(shared_chunk);
-    _read_shared_bootdata(shared_chunk.bytes);
+    memory_read_shared_bootdata(&shared_chunk);
 
     // Sanity check: io/auth keys must not have been set before.
     uint8_t empty[32] = {0};
@@ -507,7 +474,7 @@ void memory_get_io_protection_key(uint8_t* key_out)
 
     chunk_shared_t shared_chunk = {0};
     CLEANUP_CHUNK(shared_chunk);
-    _read_shared_bootdata(shared_chunk.bytes);
+    memory_read_shared_bootdata(&shared_chunk);
 
     // check assumption
     if (sizeof(shared_chunk.fields.io_protection_key_split) !=
@@ -531,7 +498,7 @@ void memory_get_authorization_key(uint8_t* key_out)
 
     chunk_shared_t shared_chunk = {0};
     CLEANUP_CHUNK(shared_chunk);
-    _read_shared_bootdata(shared_chunk.bytes);
+    memory_read_shared_bootdata(&shared_chunk);
 
     // check assumption
     if (sizeof(shared_chunk.fields.authorization_key_split) !=
@@ -555,7 +522,7 @@ void memory_get_encryption_key(uint8_t* key_out)
 
     chunk_shared_t shared_chunk = {0};
     CLEANUP_CHUNK(shared_chunk);
-    _read_shared_bootdata(shared_chunk.bytes);
+    memory_read_shared_bootdata(&shared_chunk);
 
     // check assumption
     if (sizeof(shared_chunk.fields.encryption_key_split) != sizeof(chunk.fields.encryption_key)) {
@@ -640,7 +607,7 @@ bool memory_bootloader_set_flags(auto_enter_t auto_enter, upside_down_t upside_d
 {
     chunk_shared_t chunk = {0};
     CLEANUP_CHUNK(chunk);
-    _read_shared_bootdata(chunk.bytes);
+    memory_read_shared_bootdata(&chunk);
     chunk.fields.auto_enter = auto_enter.value;
     chunk.fields.upside_down = upside_down.value ? 1 : 0;
     // As this operation is quite important to succeed, we try it multiple times.

--- a/src/memory/memory_shared.c
+++ b/src/memory/memory_shared.c
@@ -1,0 +1,35 @@
+// Copyright 2022 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <flags.h>
+
+#include "memory_shared.h"
+
+#ifdef TESTING
+#include <mock_memory.h>
+#endif
+
+void memory_read_shared_bootdata(chunk_shared_t* chunk_out)
+{
+#ifdef TESTING
+    memory_read_shared_bootdata_mock(chunk_out->bytes);
+#else
+    memcpy(chunk_out->bytes, (uint8_t*)(FLASH_SHARED_DATA_START), FLASH_SHARED_DATA_LEN);
+#endif
+}

--- a/src/memory/memory_shared.h
+++ b/src/memory/memory_shared.h
@@ -1,0 +1,54 @@
+// Copyright 2022 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _MEMORY_SHARED_H_
+#define _MEMORY_SHARED_H_
+
+#include <stdint.h>
+
+#include <flags.h>
+
+#if (FLASH_SHARED_DATA_LEN != CHUNK_SIZE)
+#error "Shared data chunk not correct length"
+#endif
+
+// CHUNK_SHARED: Shared data between the bootloader and firmware.
+//    auto_enter: if sectrue_u8, bootloader mode is entered on reboot
+//    upside_down: passes screen orientation to the bootloader
+//
+// ** DO NOT CHANGE MEMBER ORDER OR MEMORY LOCATION **
+//
+// Because the bootloader is fixed, changes may break the bootloader!
+//
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpacked"
+#pragma GCC diagnostic ignored "-Wattributes"
+typedef union {
+    struct __attribute__((__packed__)) {
+        // Shared flags - do not change order!
+        uint8_t auto_enter;
+        uint8_t upside_down;
+        // Following are used by firmware only
+        uint8_t reserved[2];
+        uint8_t io_protection_key_split[32];
+        uint8_t authorization_key_split[32];
+        uint8_t encryption_key_split[32];
+    } fields;
+    uint8_t bytes[FLASH_SHARED_DATA_LEN];
+} chunk_shared_t;
+#pragma GCC diagnostic pop
+
+void memory_read_shared_bootdata(chunk_shared_t* chunk_out);
+
+#endif

--- a/test/unit-test/framework/mock_memory.c
+++ b/test/unit-test/framework/mock_memory.c
@@ -24,8 +24,6 @@
 #include <stdio.h>
 #include <string.h>
 
-#define CHUNK_SIZE FLASH_ERASE_MIN_LEN
-
 static uint8_t _memory_shared_data[FLASH_SHARED_DATA_LEN] = {0};
 static uint8_t _memory_app_data[FLASH_APPDATA_LEN] = {0};
 static uint8_t _memory_smarteeprom[SMARTEEPROM_RESERVED_FLASH_PAGES * FLASH_PAGE_SIZE] = {0};


### PR DESCRIPTION
The bootloader and firmware both access the same memory starting at
FLASH_SHARED_DATA_START. The bootloader doesn't link memory.c, and had
a local copy of the relevant struct.

This creates a memory_shared.c linked into both bootloader and
firmware for better code reuse. This is done in preparation of adding
a `screen_type` memory field which will determine which screen driver
to use.