### PR TITLE
unit-test: less manual mocking of securechip_kdf

### DIFF
--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -228,11 +228,11 @@ set(TEST_LIST
    cleanup
    "-Wl,--wrap=util_cleanup_32"
    keystore
-   "-Wl,--wrap=secp256k1_anti_exfil_sign,--wrap=memory_is_initialized,--wrap=memory_is_seeded,--wrap=memory_get_failed_unlock_attempts,--wrap=memory_reset_failed_unlock_attempts,--wrap=memory_increment_failed_unlock_attempts,--wrap=memory_set_encrypted_seed_and_hmac,--wrap=memory_get_encrypted_seed_and_hmac,--wrap=reset_reset,--wrap=salt_hash_data,--wrap=cipher_aes_hmac_encrypt,--wrap=random_32_bytes"
+   "-Wl,--wrap=secp256k1_anti_exfil_sign,--wrap=memory_is_initialized,--wrap=memory_is_seeded,--wrap=memory_get_failed_unlock_attempts,--wrap=memory_reset_failed_unlock_attempts,--wrap=memory_increment_failed_unlock_attempts,--wrap=memory_set_encrypted_seed_and_hmac,--wrap=memory_get_encrypted_seed_and_hmac,--wrap=reset_reset,--wrap=salt_hash_data,--wrap=cipher_aes_hmac_encrypt,--wrap=random_32_bytes,--wrap=securechip_kdf"
    keystore_antiklepto
    ""
    keystore_functional
-   "-Wl,--wrap=memory_is_initialized,--wrap=memory_is_seeded,--wrap=memory_set_encrypted_seed_and_hmac,--wrap=memory_get_encrypted_seed_and_hmac,--wrap=memory_get_salt_root,--wrap=memory_get_failed_unlock_attempts,--wrap=memory_reset_failed_unlock_attempts,--wrap=memory_increment_failed_unlock_attempts,--wrap=securechip_kdf"
+   "-Wl,--wrap=memory_is_initialized,--wrap=memory_is_seeded,--wrap=memory_set_encrypted_seed_and_hmac,--wrap=memory_get_encrypted_seed_and_hmac,--wrap=memory_get_salt_root,--wrap=memory_get_failed_unlock_attempts,--wrap=memory_reset_failed_unlock_attempts,--wrap=memory_increment_failed_unlock_attempts"
    gestures
    ""
    random

--- a/test/unit-test/framework/mock_securechip.c
+++ b/test/unit-test/framework/mock_securechip.c
@@ -30,12 +30,30 @@ bool securechip_update_keys(void)
     return true;
 }
 
+// Mocked contents of the secure chip rollkey slot.
+static const uint8_t _rollkey[32] =
+    "\x9d\xd1\x34\x1f\x6b\x4b\x26\xb1\x72\x89\xa1\xa3\x92\x71\x5c\xf0\xd0\x57\x8c\x84\xdb\x9a\x51"
+    "\xeb\xde\x14\x24\x06\x69\xd1\xd0\x5e";
+
+// Mocked contents of the securechip kdf slot.
+static const uint8_t _kdfkey[32] =
+    "\xd2\xe1\xe6\xb1\x8b\x6c\x6b\x08\x43\x3e\xdb\xc1\xd1\x68\xc1\xa0\x04\x37\x74\xa4\x22\x18\x77"
+    "\xe7\x9e\xd5\x66\x84\xbe\x5a\xc0\x1b";
+
 int securechip_kdf(securechip_slot_t slot, const uint8_t* msg, size_t len, uint8_t* kdf_out)
 {
-    check_expected(slot);
-    check_expected(msg);
-    // wally_sha256(msg, len, kdf_out, 32);
-    memcpy(kdf_out, (const uint8_t*)mock(), 32);
+    const uint8_t* key;
+    switch (slot) {
+    case SECURECHIP_SLOT_ROLLKEY:
+        key = _rollkey;
+        break;
+    case SECURECHIP_SLOT_KDF:
+        key = _kdfkey;
+        break;
+    default:
+        return SC_ERR_INVALID_ARGS;
+    }
+    wally_hmac_sha256(key, 32, msg, len, kdf_out, 32);
     return 0;
 }
 

--- a/test/unit-test/test_keystore.c
+++ b/test/unit-test/test_keystore.c
@@ -34,6 +34,14 @@
 
 #define PASSWORD ("password")
 
+int __wrap_securechip_kdf(securechip_slot_t slot, const uint8_t* msg, size_t len, uint8_t* kdf_out)
+{
+    check_expected(slot);
+    check_expected(msg);
+    memcpy(kdf_out, (const uint8_t*)mock(), 32);
+    return 0;
+}
+
 static uint8_t _mock_seed[32] = {
     0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22,
     0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44,
@@ -324,19 +332,19 @@ static void _expect_stretch(bool valid)
     will_return(__wrap_salt_hash_data, _password_salted_hashed_stretch_in);
 
     // KDF 1
-    expect_value(securechip_kdf, slot, SECURECHIP_SLOT_ROLLKEY);
-    expect_memory(securechip_kdf, msg, _password_salted_hashed_stretch_in, 32);
-    will_return(securechip_kdf, _kdf_out_1);
+    expect_value(__wrap_securechip_kdf, slot, SECURECHIP_SLOT_ROLLKEY);
+    expect_memory(__wrap_securechip_kdf, msg, _password_salted_hashed_stretch_in, 32);
+    will_return(__wrap_securechip_kdf, _kdf_out_1);
 
     // KDF 2
-    expect_value(securechip_kdf, slot, SECURECHIP_SLOT_KDF);
-    expect_memory(securechip_kdf, msg, _kdf_out_1, 32);
-    will_return(securechip_kdf, _kdf_out_2);
+    expect_value(__wrap_securechip_kdf, slot, SECURECHIP_SLOT_KDF);
+    expect_memory(__wrap_securechip_kdf, msg, _kdf_out_1, 32);
+    will_return(__wrap_securechip_kdf, _kdf_out_2);
 
     // KDF 3
-    expect_value(securechip_kdf, slot, SECURECHIP_SLOT_KDF);
-    expect_memory(securechip_kdf, msg, _kdf_out_2, 32);
-    will_return(securechip_kdf, _kdf_out_3);
+    expect_value(__wrap_securechip_kdf, slot, SECURECHIP_SLOT_KDF);
+    expect_memory(__wrap_securechip_kdf, msg, _kdf_out_2, 32);
+    will_return(__wrap_securechip_kdf, _kdf_out_3);
 
     expect_memory(__wrap_salt_hash_data, data, PASSWORD, strlen(PASSWORD));
     expect_value(__wrap_salt_hash_data, data_len, strlen(PASSWORD));

--- a/test/unit-test/test_keystore_functional.c
+++ b/test/unit-test/test_keystore_functional.c
@@ -48,14 +48,6 @@ static uint8_t _salt_root[KEYSTORE_MAX_SEED_LENGTH] = {
     0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22,
 };
 
-int __wrap_securechip_kdf(securechip_slot_t slot, const uint8_t* msg, size_t len, uint8_t* kdf_out)
-{
-    assert_true(slot == SECURECHIP_SLOT_KDF || slot == SECURECHIP_SLOT_ROLLKEY);
-    uint8_t key[3] = "key";
-    assert_int_equal(WALLY_OK, wally_hmac_sha256(key, sizeof(key), msg, len, kdf_out, SHA256_LEN));
-    return 0;
-}
-
 /** Reset the SmartEEPROM configuration. */
 static void _smarteeprom_reset(void)
 {


### PR DESCRIPTION
We don't need to mock the input and output of the kdf function in each
unit test - by default it should do the same as the actual securechip,
but with mocked slot contents. This allows unit tests that run
securechip_kdf to work in Rust as well, where we cannot (or will not!)
use cmocka mocking.