### PR TITLE
rust: docs on how to remove eh_personality and build core manually

### DIFF
--- a/src/rust/bitbox02-rust-c/Cargo.toml
+++ b/src/rust/bitbox02-rust-c/Cargo.toml
@@ -33,6 +33,7 @@ sha3 = { version = "0.9.1", default-features = false, optional = true }
 
 [features]
 # "Negative" feature is a hack because tests are ran with `--all-features`, currently without a way to exclude specific features.
+# This should be enabled for Rust unit tests and Clippy, and not enabled for the firmware targets and the C unit tests.
 dont-export-eh-personality = []
 
 # Only one of the "target-" should be activated, which in turn defines/activates the dependent features.

--- a/src/rust/bitbox02-rust-c/src/lib.rs
+++ b/src/rust/bitbox02-rust-c/src/lib.rs
@@ -59,6 +59,13 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
 // Needed to link the C unit test executables in /test/unit-test.
 //
 // See https://doc.rust-lang.org/unstable-book/language-features/lang-items.html#writing-an-executable-without-stdlib.
+//
+// One could get rid of this and also considerably shrink the binary size by compiling core instead
+// of using pre-built binaries. See a proof of concept implementation here:
+// https://github.com/digitalbitbox/bitbox02-firmware/tree/build-std-PoC.  We decided against doing
+// this for now as the feature seems immature and because of the warnings against using it in
+// production:
+// https://github.com/rust-lang/wg-cargo-std-aware/tree/81765f0eb744b9c47840c16f43a32c9f61fd7f0c#mvp-implementation
 #[cfg(not(feature = "dont-export-eh-personality"))]
 #[lang = "eh_personality"]
 #[no_mangle]


### PR DESCRIPTION
For future reference.