### PR TITLE
rust: remove unneeded `extern crate ...` statements

### DIFF
--- a/src/rust/bitbox02-rust/src/async_usb.rs
+++ b/src/rust/bitbox02-rust/src/async_usb.rs
@@ -15,8 +15,6 @@
 //! This module provides the executor for tasks that are spawned with an API request and deliver a
 //! USB response. Terminology: host = computer, device = BitBox02.
 
-extern crate alloc;
-
 use crate::bb02_async::{option, spin as spin_task, Task};
 use alloc::boxed::Box;
 use alloc::vec::Vec;

--- a/src/rust/bitbox02-rust/src/bb02_async.rs
+++ b/src/rust/bitbox02-rust/src/bb02_async.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate alloc;
-
 use alloc::boxed::Box;
 use core::cell::RefCell;
 use core::pin::Pin;

--- a/src/rust/bitbox02-rust/src/hww.rs
+++ b/src/rust/bitbox02-rust/src/hww.rs
@@ -15,7 +15,6 @@
 pub mod api;
 pub mod noise;
 
-extern crate alloc;
 use alloc::vec::Vec;
 
 const OP_UNLOCK: u8 = b'u';

--- a/src/rust/bitbox02-rust/src/hww/api/backup.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/backup.rs
@@ -158,14 +158,13 @@ pub fn list() -> Result<Response, Error> {
 
 #[cfg(test)]
 mod tests {
-    extern crate std;
     use super::*;
 
     use crate::bb02_async::block_on;
+    use alloc::boxed::Box;
     use bitbox02::testing::{
         mock, mock_memory, mock_sd, mock_unlocked, mock_unlocked_using_mnemonic, Data,
     };
-    use std::boxed::Box;
 
     /// Test backup creation on a uninitialized keystore.
     #[test]

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin/signmsg.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin/signmsg.rs
@@ -130,12 +130,11 @@ pub async fn process(request: &pb::BtcSignMessageRequest) -> Result<Response, Er
 
 #[cfg(test)]
 mod tests {
-    extern crate std;
     use super::*;
 
     use crate::bb02_async::block_on;
+    use alloc::boxed::Box;
     use bitbox02::testing::{mock, mock_unlocked, Data};
-    use std::boxed::Box;
     use util::bip32::HARDENED;
 
     const MESSAGE: &[u8] = b"message";

--- a/src/rust/bitbox02-rust/src/hww/api/cardano/xpubs.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/cardano/xpubs.rs
@@ -15,7 +15,6 @@
 use super::pb;
 use super::Error;
 
-extern crate alloc;
 use alloc::vec::Vec;
 
 use pb::cardano_response::Response;

--- a/src/rust/bitbox02-rust/src/hww/api/electrum.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/electrum.rs
@@ -48,12 +48,11 @@ pub async fn process(
 
 #[cfg(test)]
 mod tests {
-    extern crate std;
     use super::*;
 
     use crate::bb02_async::block_on;
+    use alloc::boxed::Box;
     use bitbox02::testing::mock_unlocked;
-    use std::boxed::Box;
 
     #[test]
     pub fn test_process() {

--- a/src/rust/bitbox02-rust/src/hww/api/ethereum/pubrequest.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/ethereum/pubrequest.rs
@@ -21,7 +21,6 @@ use pb::eth_response::Response;
 use crate::workflow::confirm;
 use bitbox02::keystore;
 
-extern crate alloc;
 use core::convert::TryInto;
 
 async fn process_address(request: &pb::EthPubRequest) -> Result<Response, Error> {
@@ -95,12 +94,11 @@ pub async fn process(request: &pb::EthPubRequest) -> Result<Response, Error> {
 
 #[cfg(test)]
 mod tests {
-    extern crate std;
     use super::*;
 
     use crate::bb02_async::block_on;
+    use alloc::boxed::Box;
     use bitbox02::testing::{mock, mock_unlocked, Data};
-    use std::boxed::Box;
     use util::bip32::HARDENED;
 
     #[test]

--- a/src/rust/bitbox02-rust/src/hww/api/ethereum/sign.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/ethereum/sign.rs
@@ -276,12 +276,11 @@ pub async fn process(request: &pb::EthSignRequest) -> Result<Response, Error> {
 
 #[cfg(test)]
 mod tests {
-    extern crate std;
     use super::*;
 
     use crate::bb02_async::block_on;
+    use alloc::boxed::Box;
     use bitbox02::testing::{mock, mock_unlocked, Data};
-    use std::boxed::Box;
     use util::bip32::HARDENED;
 
     #[test]

--- a/src/rust/bitbox02-rust/src/hww/api/ethereum/signmsg.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/ethereum/signmsg.rs
@@ -90,12 +90,11 @@ pub async fn process(request: &pb::EthSignMessageRequest) -> Result<Response, Er
 
 #[cfg(test)]
 mod tests {
-    extern crate std;
     use super::*;
 
     use crate::bb02_async::block_on;
+    use alloc::boxed::Box;
     use bitbox02::testing::{mock, mock_unlocked, Data};
-    use std::boxed::Box;
     use util::bip32::HARDENED;
 
     const KEYPATH: &[u32] = &[44 + HARDENED, 60 + HARDENED, 0 + HARDENED, 0, 0];

--- a/src/rust/bitbox02-rust/src/hww/api/reset.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/reset.rs
@@ -36,12 +36,11 @@ pub async fn process() -> Result<Response, Error> {
 
 #[cfg(test)]
 mod tests {
-    extern crate std;
     use super::*;
 
     use crate::bb02_async::block_on;
+    use alloc::boxed::Box;
     use bitbox02::testing::{mock, Data};
-    use std::boxed::Box;
 
     #[test]
     pub fn test_reset() {

--- a/src/rust/bitbox02-rust/src/hww/api/sdcard.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/sdcard.rs
@@ -40,12 +40,11 @@ pub async fn process(
 
 #[cfg(test)]
 mod tests {
-    extern crate std;
     use super::*;
 
     use crate::bb02_async::block_on;
+    use alloc::boxed::Box;
     use bitbox02::testing::{mock, Data};
-    use std::boxed::Box;
 
     #[test]
     pub fn test_reset() {

--- a/src/rust/bitbox02-rust/src/hww/api/set_device_name.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/set_device_name.rs
@@ -42,12 +42,11 @@ pub async fn process(
 
 #[cfg(test)]
 mod tests {
-    extern crate std;
     use super::*;
 
     use crate::bb02_async::block_on;
+    use alloc::boxed::Box;
     use bitbox02::testing::{mock, mock_memory, Data};
-    use std::boxed::Box;
 
     #[test]
     pub fn test_set_device_name() {

--- a/src/rust/bitbox02-rust/src/hww/api/set_mnemonic_passphrase_enabled.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/set_mnemonic_passphrase_enabled.rs
@@ -40,12 +40,11 @@ pub async fn process(
 
 #[cfg(test)]
 mod tests {
-    extern crate std;
     use super::*;
 
     use crate::bb02_async::block_on;
+    use alloc::boxed::Box;
     use bitbox02::testing::{mock, mock_memory, Data};
-    use std::boxed::Box;
 
     #[test]
     pub fn test_mnemonic_passphrase_enabled() {

--- a/src/rust/bitbox02-rust/src/hww/api/show_mnemonic.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/show_mnemonic.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate alloc;
 use alloc::string::String;
 use alloc::vec::Vec;
 

--- a/src/rust/bitbox02-rust/src/hww/api/system.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/system.rs
@@ -42,8 +42,8 @@ mod tests {
     use super::*;
 
     use crate::bb02_async::block_on;
+    use alloc::boxed::Box;
     use bitbox02::testing::{mock, Data};
-    use std::boxed::Box;
 
     #[test]
     pub fn test_reboot() {

--- a/src/rust/bitbox02-rust/src/lib.rs
+++ b/src/rust/bitbox02-rust/src/lib.rs
@@ -45,14 +45,11 @@ pub extern crate arrayvec;
 
 #[cfg(test)]
 mod test {
-    // Enable standard library for testing
-    extern crate std;
     use super::*;
-    use std::prelude::v1::*;
 
     #[test]
     fn trivial_test() {
-        let a = String::from("abc");
+        let a = alloc::string::String::from("abc");
         assert!(&a == "abc");
     }
 }

--- a/src/rust/bitbox02-rust/src/waker_fn.rs
+++ b/src/rust/bitbox02-rust/src/waker_fn.rs
@@ -2,7 +2,6 @@
 // https://github.com/async-rs/async-task/blob/b7a249680490991f92cc2144d4eff65e4effb3b7/src/waker_fn.rs
 // https://github.com/async-rs/async-task/blob/b7a249680490991f92cc2144d4eff65e4effb3b7/LICENSE-APACHE
 
-extern crate alloc;
 use alloc::sync::Arc;
 use core::mem::{self, ManuallyDrop};
 use core::task::{RawWaker, RawWakerVTable, Waker};

--- a/src/rust/bitbox02-rust/src/workflow/menu.rs
+++ b/src/rust/bitbox02-rust/src/workflow/menu.rs
@@ -16,7 +16,6 @@ pub use super::cancel::Error as CancelError;
 
 use crate::bb02_async::option;
 
-extern crate alloc;
 use alloc::boxed::Box;
 use core::cell::RefCell;
 

--- a/src/rust/bitbox02-rust/src/workflow/mnemonic.rs
+++ b/src/rust/bitbox02-rust/src/workflow/mnemonic.rs
@@ -20,7 +20,6 @@ use super::status::status;
 use super::trinary_choice::{choose, TrinaryChoice};
 use super::trinary_input_string;
 
-extern crate alloc;
 use alloc::boxed::Box;
 use alloc::string::String;
 use alloc::vec::Vec;
@@ -259,11 +258,10 @@ pub async fn get() -> Result<zeroize::Zeroizing<String>, ()> {
 
 #[cfg(test)]
 mod tests {
-    extern crate std;
     use super::*;
 
+    use alloc::boxed::Box;
     use bitbox02::testing::{mock, Data};
-    use std::boxed::Box;
 
     fn bruteforce_lastword(mnemonic: &[&str]) -> Vec<zeroize::Zeroizing<String>> {
         let mut result = Vec::new();

--- a/src/rust/bitbox02-rust/src/workflow/transaction.rs
+++ b/src/rust/bitbox02-rust/src/workflow/transaction.rs
@@ -15,7 +15,6 @@
 use crate::bb02_async::option;
 use core::cell::RefCell;
 
-extern crate alloc;
 use alloc::boxed::Box;
 
 pub struct UserAbort;

--- a/src/rust/bitbox02-rust/src/workflow/trinary_choice.rs
+++ b/src/rust/bitbox02-rust/src/workflow/trinary_choice.rs
@@ -15,7 +15,6 @@
 use crate::bb02_async::option;
 use core::cell::RefCell;
 
-extern crate alloc;
 use alloc::boxed::Box;
 
 use bitbox02::ui::trinary_choice_create;

--- a/src/rust/bitbox02-rust/src/workflow/trinary_input_string.rs
+++ b/src/rust/bitbox02-rust/src/workflow/trinary_input_string.rs
@@ -19,7 +19,6 @@ use crate::bb02_async::option;
 use bitbox02::input::SafeInputString;
 use core::cell::RefCell;
 
-extern crate alloc;
 use alloc::boxed::Box;
 
 pub enum CanCancel {

--- a/src/rust/bitbox02-rust/src/workflow/verify_message.rs
+++ b/src/rust/bitbox02-rust/src/workflow/verify_message.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate alloc;
 use alloc::vec::Vec;
 
 use super::confirm;


### PR DESCRIPTION
Once in the root lib.rs is enough to make the crate available.