### PR TITLE
external: update the ctaes dependency

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -243,6 +243,5 @@ target_include_directories(base32 SYSTEM PUBLIC base32)
 
 add_library(ctaes
   ctaes/ctaes.c
-  ctaes/ctaes-cbc.c
 )
 target_include_directories(ctaes SYSTEM PUBLIC ctaes)

--- a/src/cipher/cipher.c
+++ b/src/cipher/cipher.c
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "cipher.h"
-#include <ctaes-cbc.h>
+#include <ctaes.h>
 
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Before, the submodule pointed to
https://github.com/digitalbitbox/ctaes/tree/cbc, which was a re-host
of https://github.com/bitcoin-core/ctaes/pull/14 before it was merged.

It has since been
merged. https://github.com/digitalbitbox/ctaes/tree/master is now at
8012b062ea4931f10cc2fd2075fddc3782a57ee4, which is up to date with
upstream https://github.com/bitcoin-core/ctaes. The submodule is
updated to this commit revision.