### PR TITLE
cmake: error if get_version fails

### DIFF
--- a/.ci/run-container-ci
+++ b/.ci/run-container-ci
@@ -49,9 +49,11 @@ git fetch origin
 
 TARGET_BRANCH=origin/${TARGET_BRANCH}
 
+# The safe.directory config is so that git commands work. even though the repo folder mounted in
+# Docker is owned by root, which can be different from the owner on the host.
 docker run -e TARGET_BRANCH="${TARGET_BRANCH}" \
 	--cap-add SYS_PTRACE \
 	--volume ${WORKSPACE_DIR}:/bitbox02-firmware/ \
 	--workdir /bitbox02-firmware \
 	${CONTAINER} \
-	bash -c "./.ci/ci"
+	bash -c "git config --global --add safe.directory /bitbox02-firmware && ./.ci/ci"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,7 @@ if(GIT_FOUND AND PYTHONINTERP_FOUND)
     OUTPUT_STRIP_TRAILING_WHITESPACE
   )
   if(NOT exit_code EQUAL "0")
-    set(GIT_FIRMWARE_VERSION_STRING "v0.0.0")
+    message(FATAL_ERROR "get_version firmware failed")
   endif()
   execute_process(
     COMMAND ${PYTHON_EXECUTABLE} ./scripts/get_version firmware-btc-only --check-semver --check-gpg
@@ -116,7 +116,7 @@ if(GIT_FOUND AND PYTHONINTERP_FOUND)
     OUTPUT_STRIP_TRAILING_WHITESPACE
   )
   if(NOT exit_code EQUAL "0")
-    set(GIT_FIRMWARE_BTC_ONLY_VERSION_STRING "v0.0.0")
+    message(FATAL_ERROR "get_version firmware-btc-only failed")
   endif()
   execute_process(
     COMMAND ${PYTHON_EXECUTABLE} ./scripts/get_version bootloader --check-semver --check-gpg
@@ -126,7 +126,7 @@ if(GIT_FOUND AND PYTHONINTERP_FOUND)
     OUTPUT_STRIP_TRAILING_WHITESPACE
   )
   if(NOT exit_code EQUAL "0")
-    set(GIT_BOOTLOADER_VERSION_STRING "v0.0.0")
+    message(FATAL_ERROR "get_version bootloader failed")
   endif()
 
   execute_process(


### PR DESCRIPTION
It would have prevented an issue where reproducible builds failed due
to the version falling back to being 'v0.0.0' instead of exiting with
an error (see e17cfccef30c54cd2646613041b630f823786c87).