### PR TITLE
bitcoin/signtx: restore comment lost in Rust conversion

### DIFF
--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin/signtx.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin/signtx.rs
@@ -616,6 +616,9 @@ async fn _process(request: &pb::BtcSignInitRequest) -> Result<Response, Error> {
     // Verify locktime/rbf.
     // A locktime of 0 will also not be verified, as it's certainly in the past and can't do any
     // harm.
+    //
+    // This is not a security feature, the extra locktime/RBF user confirmation is skipped if the tx
+    // is not rbf or has a locktime of 0.
     if request.locktime > 0 && locktime_applies {
         // The RBF nsequence bytes are often set in conjunction with a locktime,
         // so verify both simultaneously.


### PR DESCRIPTION
A comment was not copied over from C from this commit, when porting
the locktime/rbf checks to Rust:
082dd1ae523fbf868dd178b3e857bf4d15ab70be

The dialog is not shown if locktime is 0, as a beginner user should
not be confrontend with RBF, which is enabled by default in the
BitBoxApp.