### PR TITLE
api: allow ShowMnemonic for initialization (allows skipping SD backup)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ customers cannot upgrade their bootloader, its changes are recorded separately.
 ## Firmware
 
 ### [Unreleased]
+- Allow skipping the microSD card backup in favor of backing up using the recovery words
 - Allow arbitrary input sequence numbers (fixes compatibility with Taproot transactions in Sparrow wallet)
 - The BackupData.length field is now obsolete and always set to 0
 

--- a/src/commander/commander_states.c
+++ b/src/commander/commander_states.c
@@ -40,6 +40,7 @@ static commander_states_endpoint_id _commands_uninitialized[] = {
 static commander_states_endpoint_id _commands_seeded[] = {
     Request_create_backup_tag,
     Request_set_password_tag,
+    Request_show_mnemonic_tag,
     Request_restore_backup_tag,
     Request_restore_from_mnemonic_tag,
 };


### PR DESCRIPTION
The normal initialization flow is unseeded -> seeded -> initialized:

SetPassword api call to create the seed and set the password -> seeded.

CreateBackup to create the backup onto a microSD card -> initialized.

ShowMnemonic was only allowed in the initalized state, i.e. after a
microSD card backup was made.

This commit allows skipping microSD card backups in favor of a
mnemonic backup, by allowing the ShowMnemonic API call also in the
seeded (not yet initialized) state.

The api call is modified to set the initialized state, and to not ask
for the user password when not initialized, which is the same way the
CreateBackup call works (which is also allowed after the
initialization).