### PR TITLE
py/requirements: remove pyserial

### DIFF
--- a/py/requirements.txt
+++ b/py/requirements.txt
@@ -2,6 +2,4 @@
 tzlocal>=1.5,<2.0
 # until bitbox02 is released it must be installed from py/bitbox02
 bitbox02
-# Serial module
-pyserial
 requests


### PR DESCRIPTION
Added in 9bcae185cc1054bad068d2cc73c56a0d2d2ba063 for the BitBoxBase,
which was removed from the Python libs in
e66818cb2f6a64fce216b7698e8a9443778e27cb. Forgot to remove this dep
here.