### PR TITLE
rust/btc: remove an indirection to C

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -423,7 +423,6 @@ add_custom_target(rust-bindgen
     --whitelist-var MAX_PK_SCRIPT_SIZE
     --whitelist-function app_btc_params_get
     --whitelist-function app_btc_sign_init_wrapper
-    --whitelist-function app_btc_sign_payload_at_keypath_wrapper
     --whitelist-function app_btc_sign_sighash_script_wrapper
     --whitelist-function app_btc_sign_reset
     --whitelist-function reboot

--- a/src/apps/btc/btc_sign.h
+++ b/src/apps/btc/btc_sign.h
@@ -34,20 +34,7 @@ USE_RESULT app_btc_result_t app_btc_sign_sighash_script(
     // in: size of the sighash_script buffer. out: resulting size of sighash_script.
     size_t* sighash_script_size);
 
-USE_RESULT app_btc_result_t app_btc_sign_payload_at_keypath(
-    const uint32_t* keypath,
-    size_t keypath_len,
-    const BTCScriptConfigWithKeypath* script_config_account,
-    uint8_t* payload_bytes,
-    size_t* payload_size);
-
 USE_RESULT app_btc_result_t app_btc_sign_init_wrapper(in_buffer_t request_buf);
-USE_RESULT app_btc_result_t app_btc_sign_payload_at_keypath_wrapper(
-    in_buffer_t requet_buf,
-    const uint32_t* keypath,
-    size_t keypath_len,
-    uint8_t* payload_bytes,
-    size_t* payload_size);
 USE_RESULT app_btc_result_t app_btc_sign_sighash_script_wrapper(
     in_buffer_t request_buf,
     // at least MAX_PK_SCRIPT_SIZE + MAX_VARINT_SIZE bytes

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin.rs
@@ -196,21 +196,7 @@ pub async fn address_multisig(
         multisig::confirm(title, coin_params, &name, multisig).await?;
     }
     let payload = bitbox02::app_btc::payload_from_multisig(
-        &bitbox02::app_btc::Multisig {
-            xpubs_count: multisig.xpubs.len() as _,
-            xpubs: {
-                let mut xpubs = [[0u8; 78]; multisig::MAX_SIGNERS];
-                for (i, xpub) in multisig.xpubs.iter().enumerate() {
-                    xpubs[i] =
-                        crate::bip32::serialize_xpub(xpub, Some(crate::bip32::XPubType::Xpub))
-                            .or(Err(Error::InvalidInput))?
-                            .try_into()
-                            .or(Err(Error::Generic))?;
-                }
-                xpubs
-            },
-            threshold: multisig.threshold,
-        },
+        &multisig::convert_multisig(multisig)?,
         script_type as _,
         keypath[keypath.len() - 2],
         keypath[keypath.len() - 1],

--- a/src/rust/bitbox02/src/app_btc.rs
+++ b/src/rust/bitbox02/src/app_btc.rs
@@ -31,29 +31,6 @@ pub fn sign_init_wrapper(buffer_in: &[u8]) -> Result<(), Error> {
     }
 }
 
-pub fn sign_payload_at_keypath_wrapper(
-    buffer_in: &[u8],
-    keypath: &[u32],
-) -> Result<Vec<u8>, Error> {
-    let mut payload = [0u8; 32];
-    let mut payload_size: bitbox02_sys::size_t = 0;
-    unsafe {
-        match bitbox02_sys::app_btc_sign_payload_at_keypath_wrapper(
-            bitbox02_sys::in_buffer_t {
-                data: buffer_in.as_ptr(),
-                len: buffer_in.len() as _,
-            },
-            keypath.as_ptr(),
-            keypath.len() as _,
-            payload.as_mut_ptr(),
-            &mut payload_size,
-        ) {
-            Error::APP_BTC_OK => Ok(payload[..payload_size as usize].to_vec()),
-            err => Err(err),
-        }
-    }
-}
-
 pub fn sign_sighash_script_wrapper(buffer_in: &[u8]) -> Result<Vec<u8>, Error> {
     let mut sighash_script_out = vec![
         0u8;


### PR DESCRIPTION
Less reliance on complex C nanopb types, furthering the goal of removing nanopb.