### PR TITLE
py/bitbox02: relax protobuf dependency constraint to v3.20

### DIFF
--- a/py/bitbox02/CHANGELOG.md
+++ b/py/bitbox02/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 6.1.1
+- Update protobuf dependency to >= 3.20, for better compatibility
+
 ## 6.1.0
 - Add `eth_sign_typed_msg()`
 - Update protobuf dependency to >= 3.21

--- a/py/bitbox02/setup.py
+++ b/py/bitbox02/setup.py
@@ -75,7 +75,7 @@ setup(
     install_requires=[
         "hidapi>=0.7.99.post21",
         "noiseprotocol>=0.3",
-        "protobuf>=3.21",
+        "protobuf>=3.20",
         "ecdsa>=0.14",
         "semver>=2.8.1",
         # Needed as long as we support python < 3.7


### PR DESCRIPTION
Current py bitbox02 deps require protobuf >= 3.21, which is not compatible
with files generated by protoc < 3.19.
It seems that protobuf v3.20.x is compatible with files generated by
both protoc < 3.19 and >= 3.19. This commit relaxes the constraint to
protobuf version >= 3.20, to provide better compatibility.