### PR TITLE
btc/btc_common.h: remove dependency on nanopb header

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -405,6 +405,9 @@ add_custom_target(rust-bindgen
     --whitelist-function app_eth_params_get
     --whitelist-function app_eth_erc20_params_get
     --whitelist-function app_eth_sighash
+    --rustified-enum simple_type_t
+    --rustified-enum multisig_script_type_t
+    --rustified-enum output_type_t
     --whitelist-function btc_common_pkscript_from_payload
     --whitelist-function btc_common_payload_at_keypath
     --whitelist-function btc_common_pkscript_from_multisig

--- a/src/apps/btc/btc_common.c
+++ b/src/apps/btc/btc_common.c
@@ -27,18 +27,18 @@
 bool btc_common_payload_at_keypath(
     const uint32_t* keypath,
     size_t keypath_len,
-    BTCScriptConfig_SimpleType script_type,
+    simple_type_t script_type,
     uint8_t* output_payload,
     size_t* output_payload_size)
 {
     switch (script_type) {
-    case BTCScriptConfig_SimpleType_P2WPKH:
+    case SIMPLE_TYPE_P2WPKH:
         if (!keystore_secp256k1_pubkey_hash160(keypath, keypath_len, output_payload)) {
             return false;
         }
         *output_payload_size = HASH160_LEN;
         break;
-    case BTCScriptConfig_SimpleType_P2WPKH_P2SH: {
+    case SIMPLE_TYPE_P2WPKH_P2SH: {
         uint8_t pubkey_hash[HASH160_LEN];
         UTIL_CLEANUP_20(pubkey_hash);
         if (!keystore_secp256k1_pubkey_hash160(keypath, keypath_len, pubkey_hash)) {
@@ -59,7 +59,7 @@ bool btc_common_payload_at_keypath(
         *output_payload_size = HASH160_LEN;
         break;
     }
-    case BTCScriptConfig_SimpleType_P2TR:
+    case SIMPLE_TYPE_P2TR:
         if (!keystore_secp256k1_schnorr_bip86_pubkey(keypath, keypath_len, output_payload)) {
             return false;
         }
@@ -73,7 +73,7 @@ bool btc_common_payload_at_keypath(
 
 bool btc_common_pkscript_from_payload(
     bool taproot_support,
-    BTCOutputType output_type,
+    output_type_t output_type,
     const uint8_t* payload,
     size_t payload_size,
     uint8_t* pk_script,
@@ -84,23 +84,23 @@ bool btc_common_pkscript_from_payload(
     }
     size_t len = *pk_script_len;
     switch (output_type) {
-    case BTCOutputType_P2PKH:
+    case OUTPUT_TYPE_P2PKH:
         if (payload_size != HASH160_LEN) {
             return false;
         }
         return wally_scriptpubkey_p2pkh_from_bytes(
                    payload, payload_size, 0, pk_script, len, pk_script_len) == WALLY_OK;
-    case BTCOutputType_P2SH:
+    case OUTPUT_TYPE_P2SH:
         if (payload_size != HASH160_LEN) {
             return false;
         }
         return wally_scriptpubkey_p2sh_from_bytes(
                    payload, payload_size, 0, pk_script, len, pk_script_len) == WALLY_OK;
-    case BTCOutputType_P2WPKH:
-    case BTCOutputType_P2WSH:
+    case OUTPUT_TYPE_P2WPKH:
+    case OUTPUT_TYPE_P2WSH:
         return wally_witness_program_from_bytes(
                    payload, payload_size, 0, pk_script, len, pk_script_len) == WALLY_OK;
-    case BTCOutputType_P2TR:
+    case OUTPUT_TYPE_P2TR:
         if (!taproot_support || payload_size != 32) {
             return false;
         }
@@ -160,7 +160,7 @@ bool btc_common_pkscript_from_multisig(
 
 bool btc_common_payload_from_multisig(
     const multisig_t* multisig,
-    BTCScriptConfig_Multisig_ScriptType script_type,
+    multisig_script_type_t script_type,
     uint32_t keypath_change,
     uint32_t keypath_address,
     uint8_t* output_payload,
@@ -179,10 +179,10 @@ bool btc_common_payload_from_multisig(
     // Note that the witness script has an additional varint prefix.
 
     switch (script_type) {
-    case BTCScriptConfig_Multisig_ScriptType_P2WSH:
+    case MULTISIG_SCRIPT_TYPE_P2WSH:
         *output_payload_size = SHA256_LEN;
         return wally_sha256(script, written, output_payload, SHA256_LEN) == WALLY_OK;
-    case BTCScriptConfig_Multisig_ScriptType_P2WSH_P2SH: {
+    case MULTISIG_SCRIPT_TYPE_P2WSH_P2SH: {
         // script_sha256 contains the hash of the multisig redeem script as used in a P2WSH output.
         uint8_t script_sha256[SHA256_LEN] = {0};
         if (wally_sha256(script, written, script_sha256, sizeof(script_sha256)) != WALLY_OK) {

--- a/src/apps/btc/btc_common.h
+++ b/src/apps/btc/btc_common.h
@@ -22,8 +22,6 @@
 #include <compiler_util.h>
 #include <keystore.h>
 
-#include <hww.pb.h>
-
 #include <wally_bip32.h>
 #include <wally_crypto.h>
 #include <wally_script.h>
@@ -35,6 +33,26 @@ typedef struct {
     uint8_t xpubs[MULTISIG_P2WSH_MAX_SIGNERS][BIP32_SERIALIZED_LEN];
     uint32_t threshold;
 } multisig_t;
+
+typedef enum {
+    SIMPLE_TYPE_P2WPKH_P2SH = 0,
+    SIMPLE_TYPE_P2WPKH = 1,
+    SIMPLE_TYPE_P2TR = 2
+} simple_type_t;
+
+typedef enum {
+    MULTISIG_SCRIPT_TYPE_P2WSH = 0,
+    MULTISIG_SCRIPT_TYPE_P2WSH_P2SH = 1
+} multisig_script_type_t;
+
+typedef enum {
+    OUTPUT_TYPE_UNKNOWN = 0,
+    OUTPUT_TYPE_P2PKH = 1,
+    OUTPUT_TYPE_P2SH = 2,
+    OUTPUT_TYPE_P2WPKH = 3,
+    OUTPUT_TYPE_P2WSH = 4,
+    OUTPUT_TYPE_P2TR = 5
+} output_type_t;
 
 // see https://en.bitcoin.it/wiki/Protocol_documentation#Variable_length_integer
 #define MAX_VARINT_SIZE (9)
@@ -55,7 +73,7 @@ typedef struct {
 USE_RESULT bool btc_common_payload_at_keypath(
     const uint32_t* keypath,
     size_t keypath_len,
-    BTCScriptConfig_SimpleType script_type,
+    simple_type_t script_type,
     uint8_t* output_payload,
     size_t* output_payload_size);
 
@@ -68,7 +86,7 @@ USE_RESULT bool btc_common_payload_at_keypath(
  */
 USE_RESULT bool btc_common_pkscript_from_payload(
     bool taproot_support,
-    BTCOutputType output_type,
+    output_type_t output_type,
     const uint8_t* payload,
     size_t payload_size,
     uint8_t* pk_script,
@@ -105,7 +123,7 @@ USE_RESULT bool btc_common_pkscript_from_multisig(
  */
 USE_RESULT bool btc_common_payload_from_multisig(
     const multisig_t* multisig,
-    BTCScriptConfig_Multisig_ScriptType script_type,
+    multisig_script_type_t script_type,
     uint32_t keypath_change,
     uint32_t keypath_address,
     uint8_t* output_payload,

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin.rs
@@ -144,7 +144,8 @@ pub fn derive_address_simple(
         coin_params.taproot_support,
     )
     .or(Err(Error::InvalidInput))?;
-    let payload = bitbox02::app_btc::payload_at_keypath(keypath, simple_type as _)?;
+    let payload =
+        bitbox02::app_btc::payload_at_keypath(keypath, common::convert_simple_type(simple_type))?;
     let address = common::address_from_payload(
         coin_params,
         common::determine_output_type_from_simple_type(simple_type),
@@ -197,7 +198,7 @@ pub async fn address_multisig(
     }
     let payload = bitbox02::app_btc::payload_from_multisig(
         &multisig::convert_multisig(multisig)?,
-        script_type as _,
+        multisig::convert_multisig_script_type(script_type),
         keypath[keypath.len() - 2],
         keypath[keypath.len() - 1],
     )?;

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin/common.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin/common.rs
@@ -133,6 +133,27 @@ pub fn determine_output_type(script_config: &pb::BtcScriptConfig) -> Result<BtcO
     }
 }
 
+/// Converts a Rust protobuf SimpleType to a representation suitable to be passed to C functions.
+pub fn convert_simple_type(simple_type: SimpleType) -> bitbox02::app_btc::SimpleType {
+    match simple_type {
+        SimpleType::P2wpkhP2sh => bitbox02::app_btc::SimpleType::SIMPLE_TYPE_P2WPKH_P2SH,
+        SimpleType::P2wpkh => bitbox02::app_btc::SimpleType::SIMPLE_TYPE_P2WPKH,
+        SimpleType::P2tr => bitbox02::app_btc::SimpleType::SIMPLE_TYPE_P2TR,
+    }
+}
+
+/// Converts a Rust protobuf OutputType to a representation suitable to be passed to C functions.
+pub fn convert_output_type(simple_type: BtcOutputType) -> bitbox02::app_btc::OutputType {
+    match simple_type {
+        BtcOutputType::Unknown => bitbox02::app_btc::OutputType::OUTPUT_TYPE_UNKNOWN,
+        BtcOutputType::P2pkh => bitbox02::app_btc::OutputType::OUTPUT_TYPE_P2PKH,
+        BtcOutputType::P2sh => bitbox02::app_btc::OutputType::OUTPUT_TYPE_P2SH,
+        BtcOutputType::P2wpkh => bitbox02::app_btc::OutputType::OUTPUT_TYPE_P2WPKH,
+        BtcOutputType::P2wsh => bitbox02::app_btc::OutputType::OUTPUT_TYPE_P2WSH,
+        BtcOutputType::P2tr => bitbox02::app_btc::OutputType::OUTPUT_TYPE_P2TR,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin/multisig.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin/multisig.rs
@@ -51,6 +51,18 @@ pub fn convert_multisig(multisig: &Multisig) -> Result<bitbox02::app_btc::Multis
     })
 }
 
+/// Converts a Rust multisig script type to a representation suitable to be passed to C functions.
+pub fn convert_multisig_script_type(
+    script_type: ScriptType,
+) -> bitbox02::app_btc::MultisigScriptType {
+    match script_type {
+        ScriptType::P2wsh => bitbox02::app_btc::MultisigScriptType::MULTISIG_SCRIPT_TYPE_P2WSH,
+        ScriptType::P2wshP2sh => {
+            bitbox02::app_btc::MultisigScriptType::MULTISIG_SCRIPT_TYPE_P2WSH_P2SH
+        }
+    }
+}
+
 pub enum SortXpubs {
     No,
     Yes,

--- a/src/rust/bitbox02/src/app_btc.rs
+++ b/src/rust/bitbox02/src/app_btc.rs
@@ -16,11 +16,14 @@ extern crate alloc;
 use alloc::vec::Vec;
 
 pub use bitbox02_sys::multisig_t as Multisig;
-pub use bitbox02_sys::{BTCScriptConfig_Multisig_ScriptType, BTCScriptConfig_SimpleType};
+pub use bitbox02_sys::{
+    multisig_script_type_t as MultisigScriptType, output_type_t as OutputType,
+    simple_type_t as SimpleType,
+};
 
 pub fn pkscript_from_payload(
     taproot_support: bool,
-    output_type: bitbox02_sys::BTCOutputType,
+    output_type: OutputType,
     payload: &[u8],
 ) -> Result<Vec<u8>, ()> {
     // current expected max pk script size is a m-of-15 multisig. 700 is also enough for m-of-20, which
@@ -43,10 +46,7 @@ pub fn pkscript_from_payload(
     }
 }
 
-pub fn payload_at_keypath(
-    keypath: &[u32],
-    script_type: BTCScriptConfig_SimpleType,
-) -> Result<Vec<u8>, ()> {
+pub fn payload_at_keypath(keypath: &[u32], script_type: SimpleType) -> Result<Vec<u8>, ()> {
     let mut out = [0u8; 32];
     let mut out_len: bitbox02_sys::size_t = 0;
     match unsafe {
@@ -86,7 +86,7 @@ pub fn pkscript_from_multisig(
 
 pub fn payload_from_multisig(
     multisig: &Multisig,
-    script_type: BTCScriptConfig_Multisig_ScriptType,
+    script_type: MultisigScriptType,
     keypath_change: u32,
     keypath_address: u32,
 ) -> Result<Vec<u8>, ()> {
@@ -122,7 +122,7 @@ mod tests {
         assert_eq!(
             payload_at_keypath(
                 &[84 + HARDENED, 0 + HARDENED, 0 + HARDENED, 0, 0],
-                bitbox02_sys::_BTCScriptConfig_SimpleType_BTCScriptConfig_SimpleType_P2WPKH,
+                SimpleType::SIMPLE_TYPE_P2WPKH,
             ),
             Ok(
                 b"\x3f\x0d\xc2\xe9\x14\x2d\x88\x39\xae\x9c\x90\xa1\x9c\xa8\x6c\x36\xd9\x23\xd8\xab"

--- a/test/unit-test/test_app_btc_common.c
+++ b/test/unit-test/test_app_btc_common.c
@@ -60,7 +60,7 @@ static void _test_btc_common_payload_at_keypath(void** state)
         assert_true(btc_common_payload_at_keypath(
             keypath,
             sizeof(keypath) / sizeof(uint32_t),
-            BTCScriptConfig_SimpleType_P2WPKH,
+            SIMPLE_TYPE_P2WPKH,
             payload,
             &payload_size));
         assert_int_equal(payload_size, 20);
@@ -80,7 +80,7 @@ static void _test_btc_common_payload_at_keypath(void** state)
         assert_true(btc_common_payload_at_keypath(
             keypath,
             sizeof(keypath) / sizeof(uint32_t),
-            BTCScriptConfig_SimpleType_P2WPKH_P2SH,
+            SIMPLE_TYPE_P2WPKH_P2SH,
             payload,
             &payload_size));
         assert_int_equal(payload_size, 20);
@@ -98,11 +98,7 @@ static void _test_btc_common_payload_at_keypath(void** state)
             0,
         };
         assert_true(btc_common_payload_at_keypath(
-            keypath,
-            sizeof(keypath) / sizeof(uint32_t),
-            BTCScriptConfig_SimpleType_P2TR,
-            payload,
-            &payload_size));
+            keypath, sizeof(keypath) / sizeof(uint32_t), SIMPLE_TYPE_P2TR, payload, &payload_size));
         assert_int_equal(payload_size, 32);
         assert_memory_equal(
             payload,


### PR DESCRIPTION
This is the last use of nanopb generated code before we can remove the
nanopb dependency. It is only a few enums generated from the protobuf
files. For now, we simply use our own enums instead.