### PR TITLE
rust/bitbox02: remove sha256() ffi call

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -355,7 +355,6 @@ add_custom_target(rust-bindgen
     --whitelist-function menu_create
     --whitelist-function trinary_choice_create
     --rustified-enum trinary_choice_t
-    --whitelist-function wally_sha256
     --whitelist-var BASE58_CHECKSUM_LEN
     --whitelist-function random_32_bytes_mcu
     --whitelist-function random_mock_reset
@@ -366,7 +365,6 @@ add_custom_target(rust-bindgen
     --whitelist-var font_font_a_11X10
     --whitelist-var font_monogram_5X9
     --whitelist-var font_password_11X12
-    --whitelist-var WALLY_OK
     --whitelist-type trinary_input_string_params_t
     --whitelist-var INPUT_STRING_MAX_SIZE
     --whitelist-function trinary_input_string_create

--- a/src/rust/bitbox02-rust/src/attestation.rs
+++ b/src/rust/bitbox02-rust/src/attestation.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use sha2::{Digest, Sha256};
+
 pub struct Data {
     pub bootloader_hash: [u8; 32],
     pub device_pubkey: [u8; 64],
@@ -33,8 +35,7 @@ pub fn perform(host_challenge: [u8; 32]) -> Result<Data, ()> {
         &mut result.certificate,
         &mut result.root_pubkey_identifier,
     )?;
-    let mut hash: [u8; 32] = [0; 32];
-    bitbox02::sha256(&host_challenge[..], &mut hash[..])?;
+    let hash: [u8; 32] = Sha256::digest(&host_challenge).into();
     bitbox02::memory::bootloader_hash(&mut result.bootloader_hash);
     bitbox02::securechip::attestation_sign(&hash, &mut result.challenge_signature)?;
     Ok(result)

--- a/src/rust/bitbox02/src/lib.rs
+++ b/src/rust/bitbox02/src/lib.rs
@@ -115,22 +115,6 @@ pub fn screen_print_debug(msg: &str, duration: i32) {
     }
 }
 
-pub fn sha256(input: &[u8], output: &mut [u8]) -> Result<(), ()> {
-    let res = unsafe {
-        bitbox02_sys::wally_sha256(
-            input.as_ptr(),
-            input.len() as _,
-            output.as_mut_ptr(),
-            output.len() as _,
-        )
-    };
-    if res == bitbox02_sys::WALLY_OK as i32 {
-        Ok(())
-    } else {
-        Err(())
-    }
-}
-
 pub fn reset(status: bool) {
     unsafe { bitbox02_sys::reset_reset(status) }
 }


### PR DESCRIPTION
Can use the Rust sha256 dep instead.