### PR TITLE
i2c_ecc,random: remove duplicate definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -320,6 +320,10 @@ string(APPEND CMAKE_C_FLAGS " -Wno-cast-function-type")
 # Hardening
 string(APPEND CMAKE_C_FLAGS " -fstack-protector-all")
 
+# Disallow duplicate definitions, which is the default since GCC
+# 10. It was not default in gcc-arm-none-eabi-8-2018-q4.
+string(APPEND CMAKE_C_FLAGS " -fno-common")
+
 # For `struct timespec` and `strdup`
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_XOPEN_SOURCE=600")
 

--- a/src/i2c_ecc.c
+++ b/src/i2c_ecc.c
@@ -19,8 +19,6 @@
 #include "util.h"
 #include <string.h>
 
-struct i2c_m_sync_desc I2C_0;
-
 uint8_t i2c_ecc_read(uint8_t* rxdata, uint32_t rxlen)
 {
     struct _i2c_m_msg packet;
@@ -28,7 +26,7 @@ uint8_t i2c_ecc_read(uint8_t* rxdata, uint32_t rxlen)
     int32_t r;
 
     packet.addr = I2C_ECC_ADDR >> 1;
-    packet.len = rxlen;
+    packet.len = (int32_t)rxlen;
     packet.buffer = rxdata;
     packet.flags = I2C_M_SEVEN | I2C_M_RD | I2C_M_STOP;
 
@@ -47,7 +45,7 @@ uint8_t i2c_ecc_write(uint8_t* txdata, uint32_t txlen)
     int32_t r;
 
     packet.addr = I2C_ECC_ADDR >> 1;
-    packet.len = txlen;
+    packet.len = (int32_t)txlen;
     packet.buffer = txdata;
     packet.flags = I2C_M_SEVEN | I2C_M_STOP;
 

--- a/src/random.c
+++ b/src/random.c
@@ -25,10 +25,6 @@
 #include "util.h"
 #include <wally_crypto.h>
 
-#ifndef TESTING
-struct rand_sync_desc RAND_0;
-#endif
-
 void random_32_bytes_mcu(uint8_t* buf)
 {
     if (buf == NULL) {


### PR DESCRIPTION
These symbols are already defined in driver_init.c.

The current GCC version doesn't complain, I discovered this when
trying to build with an updated
GCC (arm-gnu-toolchain-11.3.rel1-x86_64) and getting errors about
these redefinitions.

The reason that the current GCC version (GCC 8) didn't complain and
the updated one (GCC 11) did complain is that the default for the
-fcommon flag changed from on to off in GCC 10.

See:
- https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85678
- https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html (-fcommon)
