### PR TITLE
api/setpassword,restore: return UserAbort on user abort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ customers cannot upgrade their bootloader, its changes are recorded separately.
 - The BackupData.length field is now obsolete and always set to 0
 - Port remaining protobuf code to Rust, remove the C nanopb protobuf dependency.
 - Ethereum: replace ERC20 token names with their unit codes in the receive screen
+- SetPassword now returns the UserAbort error instead of the Generic error if the user cancelled
 
 ### 9.12.0
 - Ethereum: add support for EIP-712 structured data signing

--- a/src/rust/bitbox02-rust/src/hww/api/error.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/error.rs
@@ -48,6 +48,21 @@ impl core::convert::From<crate::workflow::cancel::Error> for Error {
     }
 }
 
+impl core::convert::From<crate::workflow::password::EnterTwiceError> for Error {
+    fn from(error: crate::workflow::password::EnterTwiceError) -> Self {
+        match error {
+            crate::workflow::password::EnterTwiceError::DoNotMatch => {
+                // For backwards compatibility.
+                Error::Generic
+            }
+            crate::workflow::password::EnterTwiceError::Cancelled => {
+                // Added in v9.13.0.
+                Error::UserAbort
+            }
+        }
+    }
+}
+
 impl core::convert::From<crate::workflow::confirm::UserAbort> for Error {
     fn from(_error: crate::workflow::confirm::UserAbort) -> Self {
         Error::UserAbort

--- a/src/rust/bitbox02-rust/src/hww/api/restore.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/restore.rs
@@ -115,14 +115,15 @@ pub async fn from_mnemonic(
     // the process immediately. We break out only if the user confirms.
     let password = loop {
         match password::enter_twice().await {
-            Err(()) => {
-                let params = confirm::Params {
+            Err(password::EnterTwiceError::DoNotMatch) => {
+                confirm::confirm(&confirm::Params {
                     title: "",
                     body: "Passwords\ndo not match.\nTry again?",
                     ..Default::default()
-                };
-                confirm::confirm(&params).await?;
+                })
+                .await?;
             }
+            Err(password::EnterTwiceError::Cancelled) => return Err(Error::UserAbort),
             Ok(password) => break password,
         }
     };

--- a/src/rust/bitbox02-rust/src/workflow/cancel.rs
+++ b/src/rust/bitbox02-rust/src/workflow/cancel.rs
@@ -47,7 +47,6 @@ pub async fn with_cancel<R>(
     component: &mut bitbox02::ui::Component<'_>,
     result_cell: &ResultCell<R>,
 ) -> Result<R, Error> {
-    *result_cell.borrow_mut() = None;
     component.screen_stack_push();
     loop {
         let result = option(result_cell).await;


### PR DESCRIPTION
Before, Generic would be returned no matter if the user did not enter the same password twice or if they aborted on the `Your password has fewer than 4 characters.\nContinue?` screen.

Now that we handle the user abort, we can also allow to abort during password entry itself.