### PR TITLE
show_mnemonic: line break in "Recovery words" title

### DIFF
--- a/src/rust/bitbox02-rust/src/hww/api/show_mnemonic.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/show_mnemonic.rs
@@ -78,7 +78,7 @@ pub async fn process() -> Result<Response, Error> {
     let mnemonic_sentence = keystore::get_bip39_mnemonic()?;
 
     confirm::confirm(&confirm::Params {
-        title: "Recovery words",
+        title: "Recovery\nwords",
         body: "Please write down\nthe following words",
         accept_is_nextarrow: true,
         ..Default::default()


### PR DESCRIPTION
Without a newline, the words touch the cross/checkmarks left and right. The cancel screen after already has a line break in the title, so this makes it also consistent.