### PR TITLE
api: display error type on screen if create/restore fails

### DIFF
--- a/src/keystore.h
+++ b/src/keystore.h
@@ -38,10 +38,11 @@ typedef enum {
     KEYSTORE_ERR_MAX_ATTEMPTS_EXCEEDED,
     KEYSTORE_ERR_UNSEEDED,
     KEYSTORE_ERR_MEMORY,
-    KEYSTORE_ERR_SC_KDF,
+    KEYSTORE_ERR_SECURECHIP,
     KEYSTORE_ERR_SEED_SIZE,
     KEYSTORE_ERR_SALT,
     KEYSTORE_ERR_HASH,
+    KEYSTORE_ERR_ENCRYPT,
 } keystore_error_t;
 
 #ifdef TESTING
@@ -67,10 +68,8 @@ USE_RESULT bool keystore_copy_seed(uint8_t* seed_out, uint32_t* length_out);
  * @param[in] seed_length The length of the seed (max. 32 bytes).
  * @param[in] password The password with which we encrypt the seed.
  */
-USE_RESULT bool keystore_encrypt_and_store_seed(
-    const uint8_t* seed,
-    uint32_t seed_length,
-    const char* password);
+USE_RESULT keystore_error_t
+keystore_encrypt_and_store_seed(const uint8_t* seed, uint32_t seed_length, const char* password);
 
 /**
    Generates the seed, mixes it with host_entropy, and stores it encrypted with the
@@ -79,7 +78,7 @@ USE_RESULT bool keystore_encrypt_and_store_seed(
    @param[in] host_entropy bytes of entropy to be mixed in.
    @param[in] host_entropy_size must be 16 or 32.
 */
-USE_RESULT bool keystore_create_and_store_seed(
+USE_RESULT keystore_error_t keystore_create_and_store_seed(
     const char* password,
     const uint8_t* host_entropy,
     size_t host_entropy_size);

--- a/src/rust/bitbox02-rust/src/hww/api/restore.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/restore.rs
@@ -58,8 +58,8 @@ pub async fn from_file(request: &pb::RestoreBackupRequest) -> Result<Response, E
     }
 
     let password = password::enter_twice().await?;
-    if bitbox02::keystore::encrypt_and_store_seed(data.get_seed(), &password).is_err() {
-        status::status("Could not\nrestore backup", false).await;
+    if let Err(err) = bitbox02::keystore::encrypt_and_store_seed(data.get_seed(), &password) {
+        status::status(&format!("Could not\nrestore backup\n{:?}", err), false).await;
         return Err(Error::Generic);
     }
 
@@ -128,8 +128,8 @@ pub async fn from_mnemonic(
         }
     };
 
-    if bitbox02::keystore::encrypt_and_store_seed(&seed, &password).is_err() {
-        status::status("Could not\nrestore backup", false).await;
+    if let Err(err) = bitbox02::keystore::encrypt_and_store_seed(&seed, &password) {
+        status::status(&format!("Could not\nrestore backup\n{:?}", err), false).await;
         return Err(Error::Generic);
     };
 

--- a/src/rust/bitbox02-rust/src/hww/api/set_password.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/set_password.rs
@@ -15,7 +15,7 @@
 use super::Error;
 use crate::pb;
 
-use crate::workflow::{password, unlock};
+use crate::workflow::{password, status, unlock};
 use bitbox02::keystore;
 use pb::response::Response;
 
@@ -33,7 +33,8 @@ pub async fn process(
         return Err(Error::InvalidInput);
     }
     let password = password::enter_twice().await?;
-    if !keystore::create_and_store_seed(&password, entropy) {
+    if let Err(err) = keystore::create_and_store_seed(&password, entropy) {
+        status::status(&format!("Error\n{:?}", err), false).await;
         return Err(Error::Generic);
     }
     if keystore::unlock(&password).is_err() {

--- a/src/rust/bitbox02/src/keystore.rs
+++ b/src/rust/bitbox02/src/keystore.rs
@@ -39,12 +39,28 @@ pub enum Error {
     MaxAttemptsExceeded,
     Unseeded,
     Memory,
-    // Securechip error with the error code from securechip.c
+    // Securechip error with the error code from securechip.c. 0 if the error is unspecified.
     SecureChip(i32),
     Salt,
     Hash,
     SeedSize,
     Encrypt,
+}
+
+impl core::convert::From<keystore_error_t> for Error {
+    fn from(error: keystore_error_t) -> Self {
+        match error {
+            keystore_error_t::KEYSTORE_ERR_MAX_ATTEMPTS_EXCEEDED => Error::MaxAttemptsExceeded,
+            keystore_error_t::KEYSTORE_ERR_UNSEEDED => Error::Unseeded,
+            keystore_error_t::KEYSTORE_ERR_MEMORY => Error::Memory,
+            keystore_error_t::KEYSTORE_ERR_SEED_SIZE => Error::SeedSize,
+            keystore_error_t::KEYSTORE_ERR_SECURECHIP => Error::SecureChip(0),
+            keystore_error_t::KEYSTORE_ERR_SALT => Error::Salt,
+            keystore_error_t::KEYSTORE_ERR_HASH => Error::Hash,
+            keystore_error_t::KEYSTORE_ERR_ENCRYPT => Error::Encrypt,
+            _ => panic!("cannot convert error"),
+        }
+    }
 }
 
 pub fn unlock(password: &SafeInputString) -> Result<(), Error> {
@@ -61,14 +77,8 @@ pub fn unlock(password: &SafeInputString) -> Result<(), Error> {
         keystore_error_t::KEYSTORE_ERR_INCORRECT_PASSWORD => {
             Err(Error::IncorrectPassword { remaining_attempts })
         }
-        keystore_error_t::KEYSTORE_ERR_MAX_ATTEMPTS_EXCEEDED => Err(Error::MaxAttemptsExceeded),
-        keystore_error_t::KEYSTORE_ERR_UNSEEDED => Err(Error::Unseeded),
-        keystore_error_t::KEYSTORE_ERR_MEMORY => Err(Error::Memory),
-        keystore_error_t::KEYSTORE_ERR_SEED_SIZE => Err(Error::SeedSize),
         keystore_error_t::KEYSTORE_ERR_SECURECHIP => Err(Error::SecureChip(securechip_result)),
-        keystore_error_t::KEYSTORE_ERR_SALT => Err(Error::Salt),
-        keystore_error_t::KEYSTORE_ERR_HASH => Err(Error::Hash),
-        keystore_error_t::KEYSTORE_ERR_ENCRYPT => Err(Error::Encrypt),
+        err => Err(err.into()),
     }
 }
 
@@ -84,7 +94,7 @@ pub fn unlock_bip39(mnemonic_passphrase: &SafeInputString) -> Result<(), Error> 
     }
 }
 
-pub fn create_and_store_seed(password: &SafeInputString, host_entropy: &[u8]) -> bool {
+pub fn create_and_store_seed(password: &SafeInputString, host_entropy: &[u8]) -> Result<(), Error> {
     match unsafe {
         bitbox02_sys::keystore_create_and_store_seed(
             password.as_cstr(),
@@ -92,8 +102,8 @@ pub fn create_and_store_seed(password: &SafeInputString, host_entropy: &[u8]) ->
             host_entropy.len() as _,
         )
     } {
-        keystore_error_t::KEYSTORE_OK => true,
-        _ => false,
+        keystore_error_t::KEYSTORE_OK => Ok(()),
+        err => Err(err.into()),
     }
 }
 
@@ -282,7 +292,7 @@ pub fn root_fingerprint() -> Result<[u8; 4], ()> {
     }
 }
 
-pub fn encrypt_and_store_seed(seed: &[u8], password: &SafeInputString) -> Result<(), ()> {
+pub fn encrypt_and_store_seed(seed: &[u8], password: &SafeInputString) -> Result<(), Error> {
     match unsafe {
         bitbox02_sys::keystore_encrypt_and_store_seed(
             seed.as_ptr(),
@@ -291,7 +301,7 @@ pub fn encrypt_and_store_seed(seed: &[u8], password: &SafeInputString) -> Result
         )
     } {
         keystore_error_t::KEYSTORE_OK => Ok(()),
-        _ => Err(()),
+        err => Err(err.into()),
     }
 }
 

--- a/test/unit-test/test_keystore_functional.c
+++ b/test/unit-test/test_keystore_functional.c
@@ -67,13 +67,15 @@ static void _test_seeds(void** state)
     assert_false(keystore_copy_seed(read_seed, &read_seed_len));
 
     will_return(__wrap_memory_is_initialized, true);
-    assert_false(keystore_encrypt_and_store_seed(_seed, 32, _some_password));
+    assert_int_equal(
+        keystore_encrypt_and_store_seed(_seed, 32, _some_password), KEYSTORE_ERR_MEMORY);
 
     uint32_t seed_sizes[3] = {16, 24, 32};
     for (size_t seed_size_idx = 0; seed_size_idx < 3; seed_size_idx++) {
         uint32_t seed_size = seed_sizes[seed_size_idx];
         will_return(__wrap_memory_is_initialized, false);
-        assert_true(keystore_encrypt_and_store_seed(_seed, seed_size, _some_password));
+        assert_int_equal(
+            keystore_encrypt_and_store_seed(_seed, seed_size, _some_password), KEYSTORE_OK);
         uint8_t remaining_attempts;
         will_return(__wrap_memory_is_seeded, true);
         assert_int_equal(
@@ -146,7 +148,7 @@ static void _test_combination(
     assert_false(keystore_unlock_bip39(mnemonic_passphrase));
 
     will_return(__wrap_memory_is_initialized, false);
-    assert_true(keystore_encrypt_and_store_seed(_seed, seed_len, _some_password));
+    assert_int_equal(keystore_encrypt_and_store_seed(_seed, seed_len, _some_password), KEYSTORE_OK);
     assert_false(keystore_unlock_bip39(mnemonic_passphrase));
     uint8_t remaining_attempts;
     assert_true(keystore_is_locked());


### PR DESCRIPTION
If there was a securechip or memory error, creating or restoring a
wallet would show and return a generic looking error. If e.g. the
securechip is the problem, we want to see that, so the user can better
report the problem.

We might also return a specific error code to the host, but for now
displaying the error will do (same as do when unlocking a device fails).
