### PR TITLE
bitcoin: warn if fee is higher than 10%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ customers cannot upgrade their bootloader, its changes are recorded separately.
 ## Firmware
 
 ### [Unreleased]
+- Bitcoin: warn if the transaction fee is higher than 10% of the coins sent
 
 ### 9.13.0
 - Bitcoin: allow displaying BTC values in the 'sat' unit

--- a/py/send_message.py
+++ b/py/send_message.py
@@ -428,6 +428,33 @@ class SendMessage:
         for input_index, sig in sigs:
             print("Signature for input {}: {}".format(input_index, sig.hex()))
 
+    def _sign_btc_high_fee(self) -> None:
+        # pylint: disable=no-member
+        bip44_account: int = 0 + HARDENED
+        inputs, outputs = _btc_demo_inputs_outputs(bip44_account)
+        outputs[1].value = int(1e8 * 0.18)
+        sigs = self._device.btc_sign(
+            bitbox02.btc.BTC,
+            [
+                bitbox02.btc.BTCScriptConfigWithKeypath(
+                    script_config=bitbox02.btc.BTCScriptConfig(
+                        simple_type=bitbox02.btc.BTCScriptConfig.P2WPKH
+                    ),
+                    keypath=[84 + HARDENED, 0 + HARDENED, bip44_account],
+                ),
+                bitbox02.btc.BTCScriptConfigWithKeypath(
+                    script_config=bitbox02.btc.BTCScriptConfig(
+                        simple_type=bitbox02.btc.BTCScriptConfig.P2WPKH_P2SH
+                    ),
+                    keypath=[49 + HARDENED, 0 + HARDENED, bip44_account],
+                ),
+            ],
+            inputs=inputs,
+            outputs=outputs,
+        )
+        for input_index, sig in sigs:
+            print("Signature for input {}: {}".format(input_index, sig.hex()))
+
     def _sign_btc_multiple_changes(self) -> None:
         # pylint: disable=no-member
         bip44_account: int = 0 + HARDENED
@@ -647,6 +674,7 @@ class SendMessage:
                     format_unit=bitbox02.btc.BTCSignInitRequest.FormatUnit.SAT
                 ),
             ),
+            ("High fee warning", self._sign_btc_high_fee),
             ("Multiple change outputs", self._sign_btc_multiple_changes),
             ("Locktime/RBF", self._sign_btc_locktime_rbf),
             ("Taproot inputs", self._sign_btc_taproot_inputs),

--- a/src/rust/bitbox02-rust/src/hww/api/cardano/sign_transaction.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/cardano/sign_transaction.rs
@@ -260,6 +260,7 @@ async fn _process(request: &pb::CardanoSignTransactionRequest) -> Result<Respons
         transaction::verify_total_fee(
             &format_value(params, total + request.fee),
             &format_value(params, request.fee),
+            None,
         )
         .await?;
     }
@@ -451,9 +452,10 @@ mod tests {
                     _ => panic!("unexpected user confirmations"),
                 }
             })),
-            ui_transaction_fee_create: Some(Box::new(|total, fee| {
+            ui_transaction_fee_create: Some(Box::new(|total, fee, longtouch| {
                 assert_eq!(total, "6.170499 ADA");
                 assert_eq!(fee, "0.170499 ADA");
+                assert!(longtouch);
                 unsafe {
                     TOTAL_CONFIRMED = true;
                 }
@@ -826,7 +828,7 @@ mod tests {
         mock(Data {
             ui_confirm_create: Some(Box::new(|_params| true)),
             ui_transaction_address_create: Some(Box::new(|_amount, _address| true)),
-            ui_transaction_fee_create: Some(Box::new(|_total, _fee| true)),
+            ui_transaction_fee_create: Some(Box::new(|_total, _fee, _longtouch| true)),
             ..Default::default()
         });
         mock_unlocked();
@@ -901,7 +903,7 @@ mod tests {
             })),
 
             ui_transaction_address_create: Some(Box::new(|_amount, _address| true)),
-            ui_transaction_fee_create: Some(Box::new(|_total, _fee| true)),
+            ui_transaction_fee_create: Some(Box::new(|_total, _fee, _longtouch| true)),
             ..Default::default()
         });
         mock_unlocked();
@@ -971,7 +973,7 @@ mod tests {
                 }
             })),
             ui_transaction_address_create: Some(Box::new(|_amount, _address| true)),
-            ui_transaction_fee_create: Some(Box::new(|_total, _fee| true)),
+            ui_transaction_fee_create: Some(Box::new(|_total, _fee, _longtouch| true)),
             ..Default::default()
         });
         mock_unlocked();
@@ -1032,7 +1034,7 @@ mod tests {
                 }
             })),
             ui_transaction_address_create: Some(Box::new(|_amount, _address| true)),
-            ui_transaction_fee_create: Some(Box::new(|_total, _fee| true)),
+            ui_transaction_fee_create: Some(Box::new(|_total, _fee, _longtouch| true)),
             ..Default::default()
         });
         mock_unlocked();
@@ -1158,7 +1160,7 @@ mod tests {
                     _ => panic!("unexpected user confirmation"),
                 }
             })),
-            ui_transaction_fee_create: Some(Box::new(|_total, _fee| true)),
+            ui_transaction_fee_create: Some(Box::new(|_total, _fee, _longtouch| true)),
             ..Default::default()
         });
         mock_unlocked();

--- a/src/rust/bitbox02-rust/src/hww/api/ethereum/sign.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/ethereum/sign.rs
@@ -113,7 +113,7 @@ async fn verify_erc20_transaction(
         None => ("Unknown token".into(), "Unknown amount".into()),
     };
     transaction::verify_recipient(&recipient_address, &formatted_value).await?;
-    transaction::verify_total_fee(&formatted_total, &formatted_fee).await?;
+    transaction::verify_total_fee(&formatted_total, &formatted_fee, None).await?;
     Ok(())
 }
 
@@ -176,7 +176,7 @@ async fn verify_standard_transaction(
         decimals: WEI_DECIMALS,
         value: amount.value.add(&fee.value),
     };
-    transaction::verify_total_fee(&total.format(), &fee.format()).await?;
+    transaction::verify_total_fee(&total.format(), &fee.format(), None).await?;
     Ok(())
 }
 
@@ -355,9 +355,10 @@ mod tests {
                 assert_eq!(address, "0x04F264Cf34440313B4A0192A352814FBe927b885");
                 true
             })),
-            ui_transaction_fee_create: Some(Box::new(|total, fee| {
+            ui_transaction_fee_create: Some(Box::new(|total, fee, longtouch| {
                 assert_eq!(total, "0.53069 ETH");
                 assert_eq!(fee, "0.000126 ETH");
+                assert!(longtouch);
                 true
             })),
             ..Default::default()
@@ -408,9 +409,10 @@ mod tests {
                 assert_eq!(address, "0x04F264Cf34440313B4A0192A352814FBe927b885");
                 true
             })),
-            ui_transaction_fee_create: Some(Box::new(|total, fee| {
+            ui_transaction_fee_create: Some(Box::new(|total, fee, longtouch| {
                 assert_eq!(total, "0.53069 TETH");
                 assert_eq!(fee, "0.000126 TETH");
+                assert!(longtouch);
                 true
             })),
             ..Default::default()
@@ -461,9 +463,10 @@ mod tests {
                 assert_eq!(address, "0x04F264Cf34440313B4A0192A352814FBe927b885");
                 true
             })),
-            ui_transaction_fee_create: Some(Box::new(|total, fee| {
+            ui_transaction_fee_create: Some(Box::new(|total, fee, longtouch| {
                 assert_eq!(total, "0.53069 ETH");
                 assert_eq!(fee, "0.000126 ETH");
+                assert!(longtouch);
                 true
             })),
             ..Default::default()
@@ -501,9 +504,10 @@ mod tests {
                 assert_eq!(address, "0xE6CE0a092A99700CD4ccCcBb1fEDc39Cf53E6330");
                 true
             })),
-            ui_transaction_fee_create: Some(Box::new(|total, fee| {
+            ui_transaction_fee_create: Some(Box::new(|total, fee, longtouch| {
                 assert_eq!(total, "57 USDT");
                 assert_eq!(fee, "0.0012658164 ETH");
+                assert!(longtouch);
                 true
             })),
             ..Default::default()
@@ -540,9 +544,10 @@ mod tests {
                 assert_eq!(address, "0x857B3D969eAcB775a9f79cabc62Ec4bB1D1cd60e");
                 true
             })),
-            ui_transaction_fee_create: Some(Box::new(|total, fee| {
+            ui_transaction_fee_create: Some(Box::new(|total, fee, longtouch| {
                 assert_eq!(total, "Unknown amount");
                 assert_eq!(fee, "0.000067973 ETH");
+                assert!(longtouch);
                 true
             })),
             ..Default::default()
@@ -665,9 +670,10 @@ mod tests {
                     assert_eq!(address, "0x04F264Cf34440313B4A0192A352814FBe927b885");
                     true
                 })),
-                ui_transaction_fee_create: Some(Box::new(|total, fee| {
+                ui_transaction_fee_create: Some(Box::new(|total, fee, longtouch| {
                     assert_eq!(total, "0.53069 ETH");
                     assert_eq!(fee, "0.000126 ETH");
+                    assert!(longtouch);
                     false
                 })),
                 ..Default::default()
@@ -678,7 +684,7 @@ mod tests {
             // Keystore locked.
             mock(Data {
                 ui_transaction_address_create: Some(Box::new(|_, _| true)),
-                ui_transaction_fee_create: Some(Box::new(|_, _| true)),
+                ui_transaction_fee_create: Some(Box::new(|_, _, _| true)),
                 ..Default::default()
             });
             assert_eq!(block_on(process(&valid_request)), Err(Error::Generic));
@@ -727,7 +733,7 @@ mod tests {
                     _ => panic!("unexpected user confirmation"),
                 }
             })),
-            ui_transaction_fee_create: Some(Box::new(|total, fee| {
+            ui_transaction_fee_create: Some(Box::new(|total, fee, longtouch| {
                 match unsafe {
                     CONFIRM_COUNTER += 1;
                     CONFIRM_COUNTER
@@ -735,6 +741,7 @@ mod tests {
                     4 => {
                         assert_eq!(total, "0.53069 ");
                         assert_eq!(fee, "0.000126 ");
+                        assert!(longtouch);
                         true
                     }
                     _ => panic!("unexpected user confirmation"),

--- a/src/rust/bitbox02/src/testing.rs
+++ b/src/rust/bitbox02/src/testing.rs
@@ -27,7 +27,7 @@ pub struct Data {
     pub sdcard_inserted: Option<bool>,
     pub ui_sdcard_create_arg: Option<bool>,
     pub ui_transaction_address_create: Option<Box<dyn Fn(&str, &str) -> bool>>,
-    pub ui_transaction_fee_create: Option<Box<dyn Fn(&str, &str) -> bool>>,
+    pub ui_transaction_fee_create: Option<Box<dyn Fn(&str, &str, bool) -> bool>>,
     pub ui_trinary_input_string_create:
         Option<Box<dyn Fn(&super::ui::TrinaryInputStringParams) -> String>>,
 }

--- a/src/rust/bitbox02/src/ui/ui.rs
+++ b/src/rust/bitbox02/src/ui/ui.rs
@@ -384,6 +384,7 @@ pub fn confirm_transaction_address_create<'a, 'b>(
 pub fn confirm_transaction_fee_create<'a, 'b>(
     amount: &'a str,
     fee: &'a str,
+    longtouch: bool,
     callback: AcceptRejectCb<'b>,
 ) -> Component<'b> {
     unsafe extern "C" fn c_callback(result: bool, param: *mut c_void) {
@@ -396,6 +397,7 @@ pub fn confirm_transaction_fee_create<'a, 'b>(
         bitbox02_sys::confirm_transaction_fee_create(
             crate::util::str_to_cstr_vec(amount).unwrap().as_ptr(), // copied in C
             crate::util::str_to_cstr_vec(fee).unwrap().as_ptr(),    // copied in C
+            longtouch,
             Some(c_callback as _),
             callback_param,
         )

--- a/src/rust/bitbox02/src/ui/ui_stub.rs
+++ b/src/rust/bitbox02/src/ui/ui_stub.rs
@@ -137,10 +137,11 @@ pub fn confirm_transaction_address_create<'a, 'b>(
 pub fn confirm_transaction_fee_create<'a, 'b>(
     amount: &'a str,
     fee: &'a str,
+    longtouch: bool,
     mut callback: AcceptRejectCb<'b>,
 ) -> Component<'b> {
     let data = crate::testing::DATA.0.borrow();
-    let result = data.ui_transaction_fee_create.as_ref().unwrap()(amount, fee);
+    let result = data.ui_transaction_fee_create.as_ref().unwrap()(amount, fee, longtouch);
     callback(result);
     Component {
         is_pushed: false,

--- a/src/ui/components/confirm_transaction.c
+++ b/src/ui/components/confirm_transaction.c
@@ -89,6 +89,7 @@ static component_t* _confirm_transaction_create(
     const char* address,
     const char* fee,
     bool verify_total, /* if true, verify total and fee, otherwise verify amount and address */
+    bool longtouch,
     void (*callback)(bool, void*),
     void* callback_param)
 {
@@ -119,7 +120,6 @@ static component_t* _confirm_transaction_create(
 
     ui_util_add_sub_component(confirm, icon_button_create(top_slider, ICON_BUTTON_CROSS, _cancel));
 
-    bool longtouch = verify_total;
     ui_util_add_sub_component(confirm, confirm_button_create(longtouch, ICON_BUTTON_NEXT));
 
     if (data->has_address) {
@@ -156,14 +156,17 @@ component_t* confirm_transaction_address_create(
     void (*callback)(bool accepted, void* param),
     void* callback_param)
 {
-    return _confirm_transaction_create(amount, address, NULL, false, callback, callback_param);
+    return _confirm_transaction_create(
+        amount, address, NULL, false, false, callback, callback_param);
 }
 
 component_t* confirm_transaction_fee_create(
     const char* amount,
     const char* fee,
+    bool longtouch,
     void (*callback)(bool accepted, void* param),
     void* callback_param)
 {
-    return _confirm_transaction_create(amount, NULL, fee, true, callback, callback_param);
+    return _confirm_transaction_create(
+        amount, NULL, fee, true, longtouch, callback, callback_param);
 }

--- a/src/ui/components/confirm_transaction.h
+++ b/src/ui/components/confirm_transaction.h
@@ -35,6 +35,8 @@ component_t* confirm_transaction_address_create(
  * Creates a confirm screen.
  * @param[in] amount of coins to send, including the unit suffix.
  * @param[in] fee to send coins
+ * @param[in] longtouch if the confirmation dialog should have a longtouch. Otherwise, the
+ * next-arrow is shown.
  * @param[in] callback The callback triggered when the user accepts or rejects. Is called at most
  * once.
  * @param[in] callback_param Passed to `callback`.
@@ -42,6 +44,7 @@ component_t* confirm_transaction_address_create(
 component_t* confirm_transaction_fee_create(
     const char* amount,
     const char* fee,
+    bool longtouch,
     void (*callback)(bool accepted, void* param),
     void* callback_param);
 


### PR DESCRIPTION
This is to prevent accidents with fees. False positives can happen, but the information might still be useful and the user can confirm the high fee.