### PR TITLE
releases/build.sh: fix to work with recently updated Docker image

### DIFF
--- a/releases/build.sh
+++ b/releases/build.sh
@@ -11,16 +11,24 @@ git clone --depth 1 --branch $1 --recurse-submodules https://github.com/digitalb
 
 cd temp;
 
+# The shallow clone above doesn't fetch tags. Even if only building the firmware, the CMakeLists.txt
+# fetches the bootloader version using `./scripts/get_version bootloader`, which requires a
+# bootloader tag. The build scripts can be changed to only use the firmware tag that is needed,
+# ignoring the others, but we fetch the tags here so that builds of previous releases continue to
+# work.
+git fetch --tags;
+
 # Build the Docker image (this can take a while):
 docker build --pull --force-rm --no-cache -t bitbox02-firmware .
 
-# Build the firmware. The inlined python package install can be
-# removed after v4.1.0, but is necessary for v4.1.0 as it is missing
-# in the Dockerfile of that release. The safe.directory config is so
-# that git commands work. even though the repo folder mounted in
-# Docker is owned by root, which can be different from the owner on
-# the host.
-docker run -it --rm --volume `pwd`:/bb02 bitbox02-firmware bash -c "apt-get update && apt-get install -y python && git config --global --add safe.directory /bb02 && cd /bb02 && $2"
+# Build the firmware.
+#
+# For firmware versions v4.1.0 and older, you'll need to manually install `python` inside the Docker
+# container, as it is missing in the Dockerfile of that release.
+#
+# The safe.directory config is so that git commands work. even though the repo folder mounted in
+# Docker is owned by root, which can be different from the owner on the host.
+docker run -it --rm --volume `pwd`:/bb02 bitbox02-firmware bash -c "git config --global --add safe.directory /bb02 && cd /bb02 && $2"
 
 echo "firmware.bin created at:"
 echo `pwd`/build/bin/firmware.bin


### PR DESCRIPTION
In 11eea89dffe215461327f8e7a34fbf8cd75ffa07, we updated the base image to Ubuntu 22.04.

`python` is not an installation candidate any longer. We simply remove it, as it was a fix for very old versions, and keep a comment in case someone wants to build these old versoins.

Somehow it seems that `git clone --depth 1` doesn't fetch the tags anymore - fixed by fetching the tags manually.