### PR TITLE
eth-testnets: add goerli and remove ropsten and rinkeby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ customers cannot upgrade their bootloader, its changes are recorded separately.
 
 ### [Unreleased]
 - Bitcoin: warn if the transaction fee is higher than 10% of the coins sent
+- ETH Testnets: add Goerli and remove deprecated Rinkeby and Ropsten
 
 ### 9.13.0
 - Bitcoin: allow displaying BTC values in the 'sat' unit

--- a/src/apps/eth/eth_params.c
+++ b/src/apps/eth/eth_params.c
@@ -16,15 +16,6 @@
 
 #include <util.h>
 
-static const app_eth_erc20_params_t _ropsten_erc20_params[] = {
-    {
-        .unit = "TEST",
-        .contract_address =
-            "\x2f\x45\xb6\xfb\x2f\x28\xa7\x3f\x11\x04\x00\x38\x6d\xa3\x10\x44\xb2\xe9\x53\xd4",
-        .decimals = 18,
-    },
-};
-
 static const app_eth_erc20_params_t _ethereum_erc20_params[] = {
     {
         .unit = "1SG",
@@ -13904,22 +13895,12 @@ const app_eth_erc20_params_t* app_eth_erc20_params_get(
     uint64_t chain_id,
     const uint8_t* contract_address)
 {
-    const app_eth_erc20_params_t* erc20_params;
-    size_t len;
-    switch (chain_id) {
-    case 1:
-        erc20_params = _ethereum_erc20_params;
-        len = sizeof(_ethereum_erc20_params) / sizeof(app_eth_erc20_params_t);
-        break;
-    case 3:
-        erc20_params = _ropsten_erc20_params;
-        len = sizeof(_ropsten_erc20_params) / sizeof(app_eth_erc20_params_t);
-        break;
-    default:
+    if (chain_id != 1) {
         return NULL;
     }
+    size_t len = sizeof(_ethereum_erc20_params) / sizeof(app_eth_erc20_params_t);
     for (size_t index = 0; index < len; index++) {
-        const app_eth_erc20_params_t* params = &erc20_params[index];
+        const app_eth_erc20_params_t* params = &_ethereum_erc20_params[index];
         if (MEMEQ(contract_address, params->contract_address, sizeof(params->contract_address))) {
             return params;
         }

--- a/src/rust/bitbox02-rust/src/hww/api/ethereum/params.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/ethereum/params.rs
@@ -43,18 +43,11 @@ const PARAMS: &[Params] = &[
         unit: "ETH",
     },
     Params {
-        coin: Some(EthCoin::RopstenEth),
+        coin: Some(EthCoin::GoerliEth),
         bip44_coin: 1 + HARDENED,
-        chain_id: 3,
-        name: "Ropsten",
-        unit: "TETH",
-    },
-    Params {
-        coin: Some(EthCoin::RinkebyEth),
-        bip44_coin: 1 + HARDENED,
-        chain_id: 4,
-        name: "Rinkeby",
-        unit: "TETH",
+        chain_id: 5,
+        name: "Goerli",
+        unit: "GOETH",
     },
     Params {
         coin: None,
@@ -151,10 +144,8 @@ mod tests {
     pub fn test_get() {
         assert_eq!(get(EthCoin::Eth, 0).unwrap().name, "Ethereum");
         assert_eq!(get(EthCoin::Eth, 1).unwrap().name, "Ethereum");
-        assert_eq!(get(EthCoin::RopstenEth, 0).unwrap().name, "Ropsten");
-        assert_eq!(get(EthCoin::Eth, 3).unwrap().name, "Ropsten");
-        assert_eq!(get(EthCoin::RinkebyEth, 0).unwrap().name, "Rinkeby");
-        assert_eq!(get(EthCoin::Eth, 4).unwrap().name, "Rinkeby");
+        assert_eq!(get(EthCoin::GoerliEth, 0).unwrap().name, "Goerli");
+        assert_eq!(get(EthCoin::Eth, 5).unwrap().name, "Goerli");
         assert_eq!(get(EthCoin::Eth, 56).unwrap().name, "Binance Smart Chain");
 
         // Unknown chain id.

--- a/src/rust/bitbox02-rust/src/hww/api/ethereum/pubrequest.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/ethereum/pubrequest.rs
@@ -210,11 +210,11 @@ mod tests {
                     CONFIRM_COUNTER
                 } {
                     1 => {
-                        assert_eq!(params.title, "Ropsten");
+                        assert_eq!(params.title, "Goerli");
                         assert_eq!(params.body, "Unusual keypath warning: m/44'/60'/0'/0/0. Proceed only if you know what you are doing.");
                     }
                     2 => {
-                        assert_eq!(params.title, "Ropsten");
+                        assert_eq!(params.title, "Goerli");
                         assert_eq!(params.body, ADDRESS);
                     }
                     _ => panic!("too many user confirmations"),
@@ -228,7 +228,7 @@ mod tests {
             block_on(process(&pb::EthPubRequest {
                 output_type: OutputType::Address as _,
                 keypath: [44 + HARDENED, 60 + HARDENED, 0 + HARDENED, 0, 0].to_vec(),
-                coin: pb::EthCoin::RopstenEth as _,
+                coin: pb::EthCoin::GoerliEth as _,
                 display: true,
                 contract_address: b"".to_vec(),
                 chain_id: 0,

--- a/src/rust/bitbox02-rust/src/hww/api/ethereum/sign.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/ethereum/sign.rs
@@ -384,7 +384,7 @@ mod tests {
         );
     }
 
-    /// Standard ETH transaction on an unusual keypath (Ropsten on mainnet keypath)
+    /// Standard ETH transaction on an unusual keypath (Goerly on mainnet keypath)
     #[test]
     pub fn test_process_warn_unusual_keypath() {
         const KEYPATH: &[u32] = &[44 + HARDENED, 60 + HARDENED, 0 + HARDENED, 0, 0];
@@ -397,7 +397,7 @@ mod tests {
                     CONFIRM_COUNTER
                 } {
                     1 => {
-                        assert_eq!(params.title, "Ropsten");
+                        assert_eq!(params.title, "Goerli");
                         assert_eq!(params.body, "Unusual keypath warning: m/44'/60'/0'/0/0. Proceed only if you know what you are doing.");
                         true
                     }
@@ -405,13 +405,13 @@ mod tests {
                 }
             })),
             ui_transaction_address_create: Some(Box::new(|amount, address| {
-                assert_eq!(amount, "0.530564 TETH");
+                assert_eq!(amount, "0.530564 GOETH");
                 assert_eq!(address, "0x04F264Cf34440313B4A0192A352814FBe927b885");
                 true
             })),
             ui_transaction_fee_create: Some(Box::new(|total, fee, longtouch| {
-                assert_eq!(total, "0.53069 TETH");
-                assert_eq!(fee, "0.000126 TETH");
+                assert_eq!(total, "0.53069 GOETH");
+                assert_eq!(fee, "0.000126 GOETH");
                 assert!(longtouch);
                 true
             })),
@@ -420,7 +420,7 @@ mod tests {
         mock_unlocked();
 
         block_on(process(&pb::EthSignRequest {
-            coin: pb::EthCoin::RopstenEth as _,
+            coin: pb::EthCoin::GoerliEth as _,
             keypath: KEYPATH.to_vec(),
             nonce: b"\x1f\xdc".to_vec(),
             gas_price: b"\x01\x65\xa0\xbc\x00".to_vec(),
@@ -515,7 +515,7 @@ mod tests {
         mock_unlocked();
         assert_eq!(
             block_on(process(&pb::EthSignRequest {
-                coin: pb::EthCoin::RinkebyEth as _, // ignored because chain_id > 0
+                coin: pb::EthCoin::GoerliEth as _, // ignored because chain_id > 0
                 keypath: KEYPATH.to_vec(),
                 nonce: b"\x23\x67".to_vec(),
                 gas_price: b"\x02\x7a\xca\x1a\x80".to_vec(),

--- a/src/rust/bitbox02-rust/src/hww/api/ethereum/signmsg.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/ethereum/signmsg.rs
@@ -157,12 +157,12 @@ mod tests {
                     CONFIRM_COUNTER
                 } {
                     1 => {
-                        assert_eq!(params.title, "Ropsten");
+                        assert_eq!(params.title, "Goerli");
                         assert_eq!(params.body, "Unusual keypath warning: m/44'/60'/0'/0/0. Proceed only if you know what you are doing.");
                         true
                     }
                     2 => {
-                        assert_eq!(params.title, "Ropsten");
+                        assert_eq!(params.title, "Goerli");
                         assert_eq!(params.body, EXPECTED_ADDRESS);
                         true
                     }
@@ -178,7 +178,7 @@ mod tests {
         });
         mock_unlocked();
         block_on(process(&pb::EthSignMessageRequest {
-            coin: pb::EthCoin::RopstenEth as _,
+            coin: pb::EthCoin::GoerliEth as _,
             keypath: KEYPATH.to_vec(),
             msg: MESSAGE.to_vec(),
             host_nonce_commitment: None,

--- a/src/rust/bitbox02-rust/src/shiftcrypto.bitbox02.rs
+++ b/src/rust/bitbox02-rust/src/shiftcrypto.bitbox02.rs
@@ -912,8 +912,11 @@ pub mod eth_response {
 #[repr(i32)]
 pub enum EthCoin {
     Eth = 0,
+    // Removed in v9.14.0 - deprecated
     RopstenEth = 1,
+    // Removed in v9.14.0 - deprecated
     RinkebyEth = 2,
+    GoerliEth = 3,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ElectrumEncryptionKeyRequest {


### PR DESCRIPTION
Ropsten and Rinkeby ETH testnets are currently deprecated. This commit removes them from the code and introduces support to the Goerly testnet.

Since the erc20 test token has been removed from the wallet-app in 4347b1, it is now removed here too.