### PR TITLE
confirm: use next-arrow instead of checkmark where it makes sense

### DIFF
--- a/src/rust/bitbox02-rust/src/hww/api/backup.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/backup.rs
@@ -39,23 +39,22 @@ pub async fn check(
         return Err(Error::Generic);
     }
     if !silent {
-        let params = confirm::Params {
+        confirm::confirm(&confirm::Params {
             title: "Name?",
             body: &metadata.name,
             scrollable: true,
+            accept_is_nextarrow: true,
             ..Default::default()
-        };
+        })
+        .await?;
 
-        confirm::confirm(&params).await?;
-
-        let params = confirm::Params {
+        confirm::confirm(&confirm::Params {
             title: "ID?",
             body: &id,
             scrollable: true,
             ..Default::default()
-        };
-
-        confirm::confirm(&params).await?;
+        })
+        .await?;
 
         status::status("Backup valid", true).await;
     }

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin/signtx.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin/signtx.rs
@@ -700,6 +700,7 @@ async fn _process(request: &pb::BtcSignInitRequest) -> Result<Response, Error> {
         confirm::confirm(&confirm::Params {
             title: "Warning",
             body: &format!("There are {}\nchange outputs.\nProceed?", num_changes),
+            accept_is_nextarrow: true,
             ..Default::default()
         })
         .await?;
@@ -729,6 +730,7 @@ async fn _process(request: &pb::BtcSignInitRequest) -> Result<Response, Error> {
                     ""
                 }
             ),
+            accept_is_nextarrow: true,
             ..Default::default()
         })
         .await?;

--- a/src/rust/bitbox02-rust/src/hww/api/ethereum/keypath.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/ethereum/keypath.rs
@@ -42,14 +42,15 @@ pub async fn warn_unusual_keypath(
             "Unusual keypath warning: {}. Proceed only if you know what you are doing.",
             util::bip32::to_string(keypath)
         );
-        let params = confirm::Params {
+        return Ok(confirm::confirm(&confirm::Params {
             title,
             body: &body,
             title_autowrap: true,
             scrollable: true,
+            accept_is_nextarrow: true,
             ..Default::default()
-        };
-        return Ok(confirm::confirm(&params).await?);
+        })
+        .await?);
     }
     Ok(())
 }

--- a/src/rust/bitbox02-rust/src/hww/api/restore.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/restore.rs
@@ -93,12 +93,13 @@ pub async fn from_mnemonic(
     #[cfg(feature = "app-u2f")]
     {
         let datetime_string = bitbox02::format_datetime(timestamp, timezone_offset, false);
-        let params = confirm::Params {
+        confirm::confirm(&confirm::Params {
             title: "Is now?",
             body: &datetime_string,
+            accept_is_nextarrow: true,
             ..Default::default()
-        };
-        confirm::confirm(&params).await?;
+        })
+        .await?;
     }
 
     let mnemonic = mnemonic::get().await?;


### PR DESCRIPTION
If more confirmations/dialogs follow, we use the next arrow.