### PR TITLE
keystore: use consistent types for seed length

### DIFF
--- a/src/keystore.c
+++ b/src/keystore.c
@@ -38,7 +38,7 @@
 static bool _is_unlocked_device = false;
 // Must be defined if is_unlocked is true. Length of the seed store in `_retained_seed`. See also:
 // `_validate_seed_length()`.
-static uint8_t _seed_length = 0;
+static size_t _seed_length = 0;
 // Must be defined if is_unlocked is true. ONLY ACCESS THIS WITH _get_seed()
 static uint8_t _retained_seed[KEYSTORE_MAX_SEED_LENGTH] = {0};
 
@@ -78,7 +78,7 @@ static const uint8_t* _get_seed(void)
     return _retained_seed;
 }
 
-bool keystore_copy_seed(uint8_t* seed_out, uint32_t* length_out)
+bool keystore_copy_seed(uint8_t* seed_out, size_t* length_out)
 {
     if (_get_seed() == NULL) {
         return false;
@@ -236,7 +236,7 @@ static bool _verify_seed(
 
 keystore_error_t keystore_encrypt_and_store_seed(
     const uint8_t* seed,
-    uint32_t seed_length,
+    size_t seed_length,
     const char* password)
 {
     if (memory_is_initialized()) {
@@ -268,7 +268,8 @@ keystore_error_t keystore_encrypt_and_store_seed(
     if (encrypted_seed_len > 255) { // sanity check, can't happen
         Abort("keystore_encrypt_and_store_seed");
     }
-    if (!memory_set_encrypted_seed_and_hmac(encrypted_seed, encrypted_seed_len)) {
+    uint8_t encrypted_seed_len_u8 = (uint8_t)encrypted_seed_len;
+    if (!memory_set_encrypted_seed_and_hmac(encrypted_seed, encrypted_seed_len_u8)) {
         return KEYSTORE_ERR_MEMORY;
     }
     if (!_verify_seed(password, seed, seed_length)) {

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -60,7 +60,7 @@ void keystore_mock_unlocked(const uint8_t* seed, size_t seed_len, const uint8_t*
  * @param[out] length_out The seed length.
  * @return true if the seed was still retained.
  */
-USE_RESULT bool keystore_copy_seed(uint8_t* seed_out, uint32_t* length_out);
+USE_RESULT bool keystore_copy_seed(uint8_t* seed_out, size_t* length_out);
 
 /**
  * Restores a seed.
@@ -69,7 +69,7 @@ USE_RESULT bool keystore_copy_seed(uint8_t* seed_out, uint32_t* length_out);
  * @param[in] password The password with which we encrypt the seed.
  */
 USE_RESULT keystore_error_t
-keystore_encrypt_and_store_seed(const uint8_t* seed, uint32_t seed_length, const char* password);
+keystore_encrypt_and_store_seed(const uint8_t* seed, size_t seed_length, const char* password);
 
 /**
    Generates the seed, mixes it with host_entropy, and stores it encrypted with the

--- a/src/rust/bitbox02/src/keystore.rs
+++ b/src/rust/bitbox02/src/keystore.rs
@@ -108,9 +108,9 @@ pub fn create_and_store_seed(password: &SafeInputString, host_entropy: &[u8]) ->
 
 pub fn copy_seed() -> Result<zeroize::Zeroizing<Vec<u8>>, ()> {
     let mut seed = zeroize::Zeroizing::new([0u8; MAX_SEED_LENGTH]);
-    let mut seed_len: u32 = 0;
+    let mut seed_len: usize = 0;
     match unsafe { bitbox02_sys::keystore_copy_seed(seed.as_mut_ptr(), &mut seed_len) } {
-        true => Ok(zeroize::Zeroizing::new(seed[..seed_len as usize].to_vec())),
+        true => Ok(zeroize::Zeroizing::new(seed[..seed_len].to_vec())),
         false => Err(()),
     }
 }
@@ -283,7 +283,7 @@ pub fn encrypt_and_store_seed(seed: &[u8], password: &SafeInputString) -> Result
     match unsafe {
         bitbox02_sys::keystore_encrypt_and_store_seed(
             seed.as_ptr(),
-            seed.len() as _,
+            seed.len(),
             password.as_cstr(),
         )
     } {

--- a/test/unit-test/test_keystore.c
+++ b/test/unit-test/test_keystore.c
@@ -364,7 +364,7 @@ static void _test_keystore_create_and_unlock_twice(void** state)
 static void _expect_seeded(bool seeded)
 {
     uint8_t seed[KEYSTORE_MAX_SEED_LENGTH];
-    uint32_t len;
+    size_t len;
     assert_int_equal(seeded, keystore_copy_seed(seed, &len));
 }
 

--- a/test/unit-test/test_keystore_functional.c
+++ b/test/unit-test/test_keystore_functional.c
@@ -64,7 +64,7 @@ static void _test_seeds(void** state)
     _smarteeprom_reset();
     assert_true(keystore_is_locked());
     uint8_t read_seed[KEYSTORE_MAX_SEED_LENGTH];
-    uint32_t read_seed_len;
+    size_t read_seed_len;
     assert_false(keystore_copy_seed(read_seed, &read_seed_len));
 
     will_return(__wrap_memory_is_initialized, true);


### PR DESCRIPTION
Before this commit, we used size_t, uint32_t and uint8_t for seed sizes, which can only be 16, 24 or 32 bytes long.

uint8_t is only needed when storing the encrypted seed length to flash memory (see `memory_set_encrypted_seed_and_hmac()`) and when reading it back. We only keep uint8_t there and use size_t everywhere else for seed lenghts.