### PR TITLE
bitcoin/signtx: cache xpubs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ customers cannot upgrade their bootloader, its changes are recorded separately.
 ## Firmware
 
 ### [Unreleased]
+- Increased performance when signing Bitcoin transactions
 - Warn if the transaction fee is higher than 10% of the coins sent
 - ETH Testnets: add Goerli and remove deprecated Rinkeby and Ropsten
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 set(DBB-FIRMWARE-SOURCES
+  ${CMAKE_SOURCE_DIR}/src/bip32.c
   ${CMAKE_SOURCE_DIR}/src/firmware_main_loop.c
   ${CMAKE_SOURCE_DIR}/src/keystore.c
   ${CMAKE_SOURCE_DIR}/src/random.c
@@ -271,6 +272,7 @@ add_custom_target(rust-bindgen
     --use-core
     --with-derive-default
     --ctypes-prefix util::c_types
+    --allowlist-function bip32_derive_xpub
     --allowlist-function strftime
     --allowlist-function localtime
     --allowlist-function wally_free_string

--- a/src/bip32.c
+++ b/src/bip32.c
@@ -1,0 +1,42 @@
+// Copyright 2023 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bip32.h"
+
+#include <string.h>
+#include <wally_bip32.h>
+
+bool bip32_derive_xpub(
+    const uint8_t* xpub78,
+    const uint32_t* keypath,
+    size_t keypath_len,
+    uint8_t* xpub78_out)
+{
+    if (keypath_len == 0) {
+        memcpy(xpub78_out, xpub78, BIP32_SERIALIZED_LEN);
+        return true;
+    }
+
+    struct ext_key xpub = {0};
+    if (bip32_key_unserialize(xpub78, BIP32_SERIALIZED_LEN, &xpub) != WALLY_OK) {
+        return false;
+    }
+    struct ext_key derived_xpub = {0};
+    if (bip32_key_from_parent_path(
+            &xpub, keypath, keypath_len, BIP32_FLAG_KEY_PUBLIC, &derived_xpub) != WALLY_OK) {
+        return false;
+    }
+    return bip32_key_serialize(
+               &derived_xpub, BIP32_FLAG_KEY_PUBLIC, xpub78_out, BIP32_SERIALIZED_LEN) == WALLY_OK;
+}

--- a/src/bip32.h
+++ b/src/bip32.h
@@ -1,0 +1,30 @@
+// Copyright 2023 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _BIP32_H_
+#define _BIP32_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <compiler_util.h>
+
+USE_RESULT bool bip32_derive_xpub(
+    const uint8_t* xpub78,
+    const uint32_t* keypath,
+    size_t keypath_len,
+    uint8_t* xpub78_out);
+
+#endif

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin.rs
@@ -134,7 +134,13 @@ pub fn derive_address_simple(
         coin_params.taproot_support,
     )
     .or(Err(Error::InvalidInput))?;
-    Ok(common::Payload::from_simple(coin_params, simple_type, keypath)?.address(coin_params)?)
+    Ok(common::Payload::from_simple(
+        &mut crate::xpubcache::XpubCache::new(),
+        coin_params,
+        simple_type,
+        keypath,
+    )?
+    .address(coin_params)?)
 }
 
 /// Processes a SimpleType (single-sig) adress api call.

--- a/src/rust/bitbox02-rust/src/keystore.rs
+++ b/src/rust/bitbox02-rust/src/keystore.rs
@@ -33,18 +33,6 @@ pub fn root_fingerprint() -> Result<Vec<u8>, ()> {
     Ok(get_xpub(&[])?.pubkey_hash160().get(..4).ok_or(())?.to_vec())
 }
 
-/// Return the tweaked taproot pubkey at the given keypath.
-///
-/// Instead of returning the original pubkey at the keypath directly, it is tweaked with the hash of
-/// the pubkey.
-///
-/// See
-/// https://github.com/bitcoin/bips/blob/edffe529056f6dfd33d8f716fb871467c3c09263/bip-0086.mediawiki#address-derivation
-pub fn secp256k1_schnorr_bip86_pubkey(keypath: &[u32]) -> Result<[u8; 32], ()> {
-    let xpub = get_xpub(keypath)?;
-    keystore::secp256k1_schnorr_bip86_pubkey(xpub.public_key())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -101,52 +89,5 @@ mod tests {
             "small agent wife animal marine cloth exit thank stool idea steel frame",
         );
         assert_eq!(root_fingerprint(), Ok(vec![0xf4, 0x0b, 0x46, 0x9a]));
-    }
-
-    #[test]
-    fn test_secp2e56k1_schnorr_bip86_pubkey() {
-        // Test vectors from:
-        // https://github.com/bitcoin/bips/blob/edffe529056f6dfd33d8f716fb871467c3c09263/bip-0086.mediawiki#test-vectors
-        // Here we only test the creation of the tweaked pubkkey. See `Payload::from_simple` for address generation.
-
-        keystore::lock();
-        assert_eq!(
-            secp256k1_schnorr_bip86_pubkey(&[86 + HARDENED, 0 + HARDENED, 0 + HARDENED, 0, 0]),
-            Err(())
-        );
-
-        mock_unlocked_using_mnemonic("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about");
-        assert_eq!(secp256k1_schnorr_bip86_pubkey(&[
-            86 + HARDENED,
-            0 + HARDENED,
-            0 + HARDENED,
-            0,
-            0
-        ])
-        .unwrap(),
-        *b"\xa6\x08\x69\xf0\xdb\xcf\x1d\xc6\x59\xc9\xce\xcb\xaf\x80\x50\x13\x5e\xa9\xe8\xcd\xc4\x87\x05\x3f\x1d\xc6\x88\x09\x49\xdc\x68\x4c",
-        );
-
-        assert_eq!(secp256k1_schnorr_bip86_pubkey(&[
-            86 + HARDENED,
-            0 + HARDENED,
-            0 + HARDENED,
-            0,
-            1
-        ])
-        .unwrap(),
-        *b"\xa8\x2f\x29\x94\x4d\x65\xb8\x6a\xe6\xb5\xe5\xcc\x75\xe2\x94\xea\xd6\xc5\x93\x91\xa1\xed\xc5\xe0\x16\xe3\x49\x8c\x67\xfc\x7b\xbb",
-        );
-
-        assert_eq!(secp256k1_schnorr_bip86_pubkey(&[
-            86 + HARDENED,
-            0 + HARDENED,
-            0 + HARDENED,
-            1,
-            0,
-        ])
-        .unwrap(),
-        *b"\x88\x2d\x74\xe5\xd0\x57\x2d\x5a\x81\x6c\xef\x00\x41\xa9\x6b\x6c\x1d\xe8\x32\xf6\xf9\x67\x6d\x96\x05\xc4\x4d\x5e\x9a\x97\xd3\xdc",
-        );
     }
 }

--- a/src/rust/bitbox02-rust/src/lib.rs
+++ b/src/rust/bitbox02-rust/src/lib.rs
@@ -36,6 +36,7 @@ pub mod keystore;
 mod version;
 mod waker_fn;
 pub mod workflow;
+mod xpubcache;
 
 // for `format!`
 #[macro_use]

--- a/src/rust/bitbox02-rust/src/xpubcache.rs
+++ b/src/rust/bitbox02-rust/src/xpubcache.rs
@@ -1,0 +1,260 @@
+// Copyright 2023 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::keystore;
+
+use crate::bip32;
+use alloc::vec::Vec;
+
+pub trait Xpub: Sized {
+    /// Derives a child xpub using the provided keypath.
+    fn derive(&self, keypath: &[u32]) -> Result<Self, ()>;
+
+    /// Derives an xpub from the root xpub using the provided keypath.
+    fn from_keypath(keypath: &[u32]) -> Result<Self, ()>;
+}
+
+/// Implements a cache for xpubs. Cached intermediate xpubs are used to derive child xpubs.
+///
+/// The cache must be configured using `cache_keypath()`, otherwise no caching occurs. The reason
+/// for this is that automatic caching is harder to get right and reason about, e.g. in a BTC tx, we
+/// shouldn't cache xpubs at the address level (e.g. m/84/0'/0'/0/0), as they don't repeat and there
+/// can be many of them.
+pub struct XpubCache<X> {
+    // List of keypaths for which we want to cache xpubs for.
+    keypaths: Vec<Vec<u32>>,
+    // Cached xpubs. First tuple element is the keypath for which the xpub was cached, the second
+    // element is the cached xpub.
+    xpubs: Vec<(Vec<u32>, X)>,
+}
+
+impl<X: Xpub + Clone> XpubCache<X> {
+    pub fn new() -> Self {
+        XpubCache {
+            keypaths: Vec::new(),
+            xpubs: Vec::new(),
+        }
+    }
+
+    /// Instruct the cache that we want to cache the xpub at this keypath. The xpub is not derived
+    /// yet, it will be derived when requested for the first time using `get_xpub()`.
+    pub fn add_keypath(&mut self, keypath: &[u32]) {
+        self.keypaths.push(keypath.to_vec());
+    }
+
+    // Retrieves a cached xpub. If the xpub is not cached, derive and cache it first.
+    fn cache_get_set(&mut self, keypath: &[u32]) -> Result<X, ()> {
+        // Return cached xpub if exists.
+        if let Some((_, xpub)) = self
+            .xpubs
+            .iter()
+            .find(|&(cached_keypath, _)| cached_keypath == keypath)
+        {
+            return Ok(xpub.clone());
+        }
+
+        // Otherwise, compute xpub and cache it.
+        //
+        // Before deriving the xpub from the root, try to derive it from an intermediate cached
+        // xpub. Only if the last element is not hardened, as we can only derive unhardened elements
+        // from an xpub (hardened elements require the xprv).
+        const UNHARDENED_LAST: u32 = util::bip32::HARDENED - 1;
+        let xpub = if let [prefix @ .., last @ 0..=UNHARDENED_LAST] = keypath {
+            self.get_xpub(&prefix)?.derive(&[*last])?
+        } else {
+            X::from_keypath(keypath)?
+        };
+        self.xpubs.push((keypath.to_vec(), xpub.clone()));
+        Ok(xpub)
+    }
+
+    /// Derive an xpub from the keystore's master key. If a prefix of the keypath is cached, the
+    /// cached xpub will be used as basis for derivation. The longest cached prefix (shortest
+    /// suffix) is used to minimize the number child derivations necessary afterwards.
+    pub fn get_xpub(&mut self, keypath: &[u32]) -> Result<X, ()> {
+        // Check if any prefix of keypath is is marked as cached. Get the longest such prefix.
+        let search_result = self
+            .keypaths
+            .iter()
+            .filter_map(|kp| {
+                keypath
+                    .strip_prefix(kp.as_slice())
+                    .map(|suffix| (kp, suffix))
+            })
+            .max_by_key(|(kp, _)| kp.len());
+        if let Some((cached_prefix, suffix)) = search_result {
+            let xpub = self.cache_get_set(&cached_prefix.clone())?;
+            return xpub.derive(suffix);
+        }
+        X::from_keypath(keypath)
+    }
+}
+
+impl Xpub for bip32::Xpub {
+    fn derive(&self, keypath: &[u32]) -> Result<Self, ()> {
+        bip32::Xpub::derive(self, keypath)
+    }
+
+    fn from_keypath(keypath: &[u32]) -> Result<Self, ()> {
+        keystore::get_xpub(keypath)
+    }
+}
+
+pub type Bip32XpubCache = XpubCache<bip32::Xpub>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::bip32;
+    use bitbox02::testing::mock_unlocked;
+    use util::bip32::HARDENED;
+
+    #[test]
+    fn test_xpub_cache() {
+        // Mock xpubs by storing the keypath only, so we can unit test access patterns.
+        #[derive(Clone)]
+        struct MockXpub(Vec<u32>);
+
+        static mut CHILD_DERIVATIONS: u32 = 0;
+        static mut ROOT_DERIVATIONS: u32 = 0;
+
+        impl Xpub for MockXpub {
+            fn derive(&self, keypath: &[u32]) -> Result<Self, ()> {
+                let mut kp = Vec::new();
+                kp.extend_from_slice(&self.0);
+                kp.extend_from_slice(keypath);
+                unsafe {
+                    CHILD_DERIVATIONS += keypath.len() as u32;
+                }
+                Ok(MockXpub(kp))
+            }
+
+            fn from_keypath(keypath: &[u32]) -> Result<Self, ()> {
+                unsafe {
+                    ROOT_DERIVATIONS += 1;
+                }
+                Ok(MockXpub(keypath.to_vec()))
+            }
+        }
+
+        type MockCache = XpubCache<MockXpub>;
+
+        let mut cache = MockCache::new();
+
+        assert_eq!(cache.get_xpub(&[]).unwrap().0.as_slice(), &[]);
+        unsafe {
+            assert_eq!(CHILD_DERIVATIONS, 0u32);
+            assert_eq!(ROOT_DERIVATIONS, 1u32);
+            ROOT_DERIVATIONS = 0;
+        }
+
+        assert_eq!(cache.get_xpub(&[1, 2, 3]).unwrap().0.as_slice(), &[1, 2, 3]);
+        unsafe {
+            assert_eq!(CHILD_DERIVATIONS, 0u32);
+            assert_eq!(ROOT_DERIVATIONS, 1u32);
+            ROOT_DERIVATIONS = 0;
+        }
+
+        // Cache some keypaths.
+        cache.add_keypath(&[84 + HARDENED, 0 + HARDENED, 0 + HARDENED]);
+        cache.add_keypath(&[84 + HARDENED, 0 + HARDENED, 0 + HARDENED, 1]);
+
+        assert_eq!(
+            cache
+                .get_xpub(&[84 + HARDENED, 0 + HARDENED, 0 + HARDENED, 1, 2])
+                .unwrap()
+                .0
+                .as_slice(),
+            &[84 + HARDENED, 0 + HARDENED, 0 + HARDENED, 1, 2]
+        );
+        unsafe {
+            // Two child derivations:
+            // 1: m/84'/0'/0' -> m/84'/0'/0'/1
+            // 2: m/84'/0'/0'/1 -> m/84'/0'/0'/1/2
+            assert_eq!(CHILD_DERIVATIONS, 2u32);
+            assert_eq!(ROOT_DERIVATIONS, 1u32);
+            CHILD_DERIVATIONS = 0;
+            ROOT_DERIVATIONS = 0;
+        }
+
+        // Same keypath again is a cache hit at m/84'/0'/0'/1 with one child derivation.
+        assert_eq!(
+            cache
+                .get_xpub(&[84 + HARDENED, 0 + HARDENED, 0 + HARDENED, 1, 2])
+                .unwrap()
+                .0
+                .as_slice(),
+            &[84 + HARDENED, 0 + HARDENED, 0 + HARDENED, 1, 2]
+        );
+        unsafe {
+            assert_eq!(CHILD_DERIVATIONS, 1u32);
+            assert_eq!(ROOT_DERIVATIONS, 0u32);
+            CHILD_DERIVATIONS = 0;
+        }
+
+        // m/84'/0'/0'/0/0 is a cache hit at m/84'/0'/0', which was cached because of the above we
+        // call using m/84'/0'/0'/1/2.
+        assert_eq!(
+            cache
+                .get_xpub(&[84 + HARDENED, 0 + HARDENED, 0 + HARDENED, 0, 0])
+                .unwrap()
+                .0
+                .as_slice(),
+            &[84 + HARDENED, 0 + HARDENED, 0 + HARDENED, 0, 0]
+        );
+        unsafe {
+            assert_eq!(CHILD_DERIVATIONS, 2u32);
+            assert_eq!(ROOT_DERIVATIONS, 0u32);
+        }
+    }
+
+    #[test]
+    fn test_bip32_xpub_cache() {
+        let mut cache = Bip32XpubCache::new();
+        cache.add_keypath(&[84 + HARDENED, 0 + HARDENED, 0 + HARDENED, 1]);
+        cache.add_keypath(&[84 + HARDENED, 0 + HARDENED, 0 + HARDENED]);
+
+        mock_unlocked();
+        assert_eq!(
+            &cache
+                .get_xpub(&[84 + HARDENED, 0 + HARDENED, 0 + HARDENED, 1, 2])
+                .unwrap()
+                .serialize_str(bip32::XPubType::Xpub)
+                .unwrap(),
+            "xpub6H18r9myxw9MztwzVyBYj26X1gVkz9ZzwJ8UgV9HWYu4ae6NQ6AEs2ibibhbF6oK3bzduzVNv4gwmu78o4Z4tkdzAcDMp6siTFbVegg9DEi",
+        );
+
+        // Make sure the following xpubs are derived using the cache only, not touching the seed.
+        bitbox02::keystore::lock();
+
+        assert_eq!(
+            &cache
+                .get_xpub(&[84 + HARDENED, 0 + HARDENED, 0 + HARDENED, 0, 0])
+                .unwrap()
+                .serialize_str(bip32::XPubType::Xpub)
+                .unwrap(),
+            "xpub6GugPDcUhrSudznFss7wXvQV3gwFTEanxHdCyoNoHnZEr3PTbh2Fosg4JjfphaYAsqjBhmtTZ3Yo8tmGjSHtaPhExNiMCSvPzreqjrX4Wr7",
+        );
+
+        assert_eq!(
+            &cache
+                .get_xpub(&[84 + HARDENED, 0 + HARDENED, 0 + HARDENED, 1, 3])
+                .unwrap()
+                .serialize_str(bip32::XPubType::Xpub)
+                .unwrap(),
+            "xpub6H18r9myxw9N57ip5QtLS7m78pMKKpWM18Mzj9rCjgec4SPndPWT5C8EvjxtGBoWhpdNRizdeii73qKPZT2YgqxjVr5xyZuVT979N7pmGAS",
+        );
+    }
+}

--- a/src/rust/bitbox02-sys/wrapper.h
+++ b/src/rust/bitbox02-sys/wrapper.h
@@ -14,6 +14,7 @@
 
 #include <apps/btc/btc_common.h>
 #include <apps/eth/eth_params.h>
+#include <bip32.h>
 #include <keystore.h>
 #include <memory/bitbox02_smarteeprom.h>
 #include <memory/memory.h>

--- a/src/rust/bitbox02/src/bip32.rs
+++ b/src/rust/bitbox02/src/bip32.rs
@@ -1,0 +1,48 @@
+// Copyright 2023 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use alloc::vec;
+use alloc::vec::Vec;
+use bitbox02_sys::BIP32_SERIALIZED_LEN;
+
+pub fn derive_xpub(xpub78: &[u8], keypath: &[u32]) -> Result<Vec<u8>, ()> {
+    let mut xpub = vec![0u8; BIP32_SERIALIZED_LEN as _];
+    match unsafe {
+        bitbox02_sys::bip32_derive_xpub(
+            xpub78.as_ptr(),
+            keypath.as_ptr(),
+            keypath.len(),
+            xpub.as_mut_ptr(),
+        )
+    } {
+        true => Ok(xpub),
+        false => Err(()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_derive_xpub() {
+        // xpub661MyMwAqRbcGpuMRXa55WgyqinF4dpxvqQK63xBHtnH5yK4e3cTLqbX9CP4mEMHUbqsjSQ8y3hhbAzuMhpn8eEiLNVSWYaVSbKMAtUPyYH
+        let xpub = b"\x04\x88\xb2\x1e\x00\x00\x00\x00\x00\x00\x00\x00\x00\xe5\x67\x65\x23\x1c\x63\xfd\x41\xe0\x42\xbe\x95\xd0\x17\x81\x75\x23\x49\xc6\x6b\x10\x0c\x50\xdb\x84\x90\x95\xa7\x4e\x9f\x69\x6f\x02\xfb\xca\x9a\xde\xb7\xdb\xc9\x62\xfa\xa0\xf6\x0e\x32\x8f\x11\xfe\x84\xec\xc5\x3f\xf6\x22\xe9\x9d\x13\xa4\x60\xa8\x47\x84\x54\xa7";
+
+        assert_eq!(derive_xpub(xpub, &[]).unwrap(), xpub.to_vec());
+        // xpub6CYiDoWMtLVQNrc4tbAvuRk5wjsp6MFgtYEdBUV7TGLUjutavHdEKLu9KpTpRxEZULbSwM1UQPaQpqAhmWYvngXCGHGE7hSZFNofeSRzmk5
+        let expected = b"\x04\x88\xb2\x1e\x03\x79\xd7\xa1\x2b\x00\x00\x00\x02\x00\x43\x25\x50\x64\xb5\x0c\x27\x32\x98\x22\x4a\xf7\xb1\x18\x7b\x27\xd4\x14\x00\x04\x71\x84\x64\x2a\x6f\x46\xe0\x95\x90\xe5\xc7\x02\xf1\xf4\x18\xcc\xc3\x19\x2d\x1b\xa9\x6b\xfe\x40\x96\x57\x8a\x25\x7c\x73\x5b\x92\x7c\x4b\x1e\x55\x2f\x7e\x1a\x03\x4b\x56\xf3\x85";
+        assert_eq!(derive_xpub(xpub, &[0, 1, 2]).unwrap(), expected.to_vec());
+    }
+}

--- a/src/rust/bitbox02/src/lib.rs
+++ b/src/rust/bitbox02/src/lib.rs
@@ -34,6 +34,7 @@ pub mod testing;
 pub mod app_btc;
 #[cfg(feature = "app-ethereum")]
 pub mod app_eth;
+pub mod bip32;
 pub mod input;
 pub mod keystore;
 pub mod memory;


### PR DESCRIPTION
When loading a transaction, every input and change address requires the public key in order to compute the pkScript, which is used in the sighash that is signed.

For single-sig, these public keys are currently always at keypaths:

- `m/(49'|84'|86')/coin'/account'/0/*` (receive inputs)
- `m/(49'|84'|86')/coin'/account'/1/*` (change inputs)

where `coin` and `account` are the same for all inputs/changes in the transaction.

Instead of deriving the xpub at these keypaths repeatedly, we cache the xpubs at the account level and the receive/change level. The xpub then only has to be derived once once for the account level and once for change/receive per script type.

Benefits:

- Greatly increased speed. Loading inputs is now about 3x faster for segwit inputs and around 5x faster for Taproot transactions (where no previous transactions need to be streamed).
- The seed only has to be used once (to derive the account-level xpub) instead of once per input/change. This increases security assuming the seed receives additional protection (currently it is sitting in RAM unencrypted after unlock, but that will likely change). Fewer seed accesses means it is harder to exploit a potential RAM extraction bug.