### PR TITLE
keystore/ed25519: unit test seed generation in Rust

### DIFF
--- a/src/rust/bitbox02-rust/src/hww/api/backup.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/backup.rs
@@ -231,6 +231,7 @@ mod tests {
         mock_sd();
         mock_unlocked_using_mnemonic(
             "memory raven era cave phone system dice come mechanic split moon repeat",
+            "",
         );
         mock_memory();
 
@@ -278,7 +279,7 @@ mod tests {
             ui_confirm_create: Some(Box::new(|_params| true)),
             ..Default::default()
         });
-        mock_unlocked_using_mnemonic("purity concert above invest pigeon category peace tuition hazard vivid latin since legal speak nation session onion library travel spell region blast estate stay");
+        mock_unlocked_using_mnemonic("purity concert above invest pigeon category peace tuition hazard vivid latin since legal speak nation session onion library travel spell region blast estate stay", "");
         mock_memory();
         bitbox02::memory::set_device_name(DEVICE_NAME_1).unwrap();
         assert!(block_on(create(&pb::CreateBackupRequest {
@@ -304,7 +305,7 @@ mod tests {
             ui_confirm_create: Some(Box::new(|_params| true)),
             ..Default::default()
         });
-        mock_unlocked_using_mnemonic("goddess item rack improve shaft occur actress rib emerge salad rich blame model glare lounge stable electric height scrub scrub oyster now dinner oven");
+        mock_unlocked_using_mnemonic("goddess item rack improve shaft occur actress rib emerge salad rich blame model glare lounge stable electric height scrub scrub oyster now dinner oven", "");
         mock_memory();
         bitbox02::memory::set_device_name(DEVICE_NAME_2).unwrap();
         assert!(block_on(create(&pb::CreateBackupRequest {

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin.rs
@@ -394,7 +394,7 @@ mod tests {
                 expected_display_title: "Litecoin\naccount #1",
             },
         ] {
-            mock_unlocked_using_mnemonic(test.mnemonic);
+            mock_unlocked_using_mnemonic(test.mnemonic, "");
 
             // Without display.
             let mut req = pb::BtcPubRequest {
@@ -424,7 +424,7 @@ mod tests {
                 })),
                 ..Default::default()
             });
-            mock_unlocked_using_mnemonic(test.mnemonic);
+            mock_unlocked_using_mnemonic(test.mnemonic, "");
             assert_eq!(
                 block_on(process_pub(&req)),
                 Ok(Response::Pub(pb::PubResponse {
@@ -678,7 +678,7 @@ mod tests {
             };
 
             // Without display.
-            mock_unlocked_using_mnemonic(test.mnemonic);
+            mock_unlocked_using_mnemonic(test.mnemonic, "");
             assert_eq!(
                 block_on(process_pub(&req)),
                 Ok(Response::Pub(pb::PubResponse {
@@ -699,7 +699,7 @@ mod tests {
                 })),
                 ..Default::default()
             });
-            mock_unlocked_using_mnemonic(test.mnemonic);
+            mock_unlocked_using_mnemonic(test.mnemonic, "");
             assert_eq!(
                 block_on(process_pub(&req)),
                 Ok(Response::Pub(pb::PubResponse {
@@ -908,6 +908,7 @@ mod tests {
             });
             mock_unlocked_using_mnemonic(
                 "sudden tenant fault inject concert weather maid people chunk youth stumble grit",
+                "",
             );
 
             let multisig = Multisig {

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin/common.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin/common.rs
@@ -538,6 +538,7 @@ mod tests {
     fn test_payload_simple() {
         mock_unlocked_using_mnemonic(
             "sudden tenant fault inject concert weather maid people chunk youth stumble grit",
+            "",
         );
         let mut xpub_cache = Bip32XpubCache::new();
         let coin_params = super::super::params::get(pb::BtcCoin::Btc);

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin/multisig.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin/multisig.rs
@@ -714,6 +714,7 @@ mod tests {
         // ok.
         mock_unlocked_using_mnemonic(
             "sudden tenant fault inject concert weather maid people chunk youth stumble grit",
+            "",
         );
         assert!(validate(&multisig, keypath, expected_coin).is_ok());
 

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin/signtx.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin/signtx.rs
@@ -2446,6 +2446,7 @@ mod tests {
         });
         mock_unlocked_using_mnemonic(
             "sudden tenant fault inject concert weather maid people chunk youth stumble grit",
+            "",
         );
         // For the multisig registration below.
         mock_memory();
@@ -2514,6 +2515,7 @@ mod tests {
         mock_default_ui();
         mock_unlocked_using_mnemonic(
             "sudden tenant fault inject concert weather maid people chunk youth stumble grit",
+            "",
         );
         let init_request = {
             let tx = transaction.borrow();
@@ -2571,6 +2573,7 @@ mod tests {
         mock_default_ui();
         mock_unlocked_using_mnemonic(
             "sudden tenant fault inject concert weather maid people chunk youth stumble grit",
+            "",
         );
         // For the multisig registration below.
         mock_memory();
@@ -2635,6 +2638,7 @@ mod tests {
         mock_default_ui();
         mock_unlocked_using_mnemonic(
             "sudden tenant fault inject concert weather maid people chunk youth stumble grit",
+            "",
         );
         // For the multisig registration below.
         mock_memory();

--- a/src/rust/bitbox02-rust/src/hww/api/rootfingerprint.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/rootfingerprint.rs
@@ -42,7 +42,8 @@ mod tests {
         assert_eq!(process(), Err(Error::Generic));
 
         mock_unlocked_using_mnemonic(
-            "purity concert above invest pigeon category peace tuition hazard vivid latin since legal speak nation session onion library travel spell region blast estate stay"
+            "purity concert above invest pigeon category peace tuition hazard vivid latin since legal speak nation session onion library travel spell region blast estate stay",
+            "",
         );
         assert_eq!(
             process(),
@@ -53,6 +54,7 @@ mod tests {
 
         mock_unlocked_using_mnemonic(
             "small agent wife animal marine cloth exit thank stool idea steel frame",
+            "",
         );
         assert_eq!(
             process(),

--- a/src/rust/bitbox02-rust/src/keystore.rs
+++ b/src/rust/bitbox02-rust/src/keystore.rs
@@ -48,7 +48,10 @@ mod tests {
         assert!(get_xpub(keypath).is_err());
 
         // 24 words
-        mock_unlocked_using_mnemonic("sleep own lobster state clean thrive tail exist cactus bitter pass soccer clinic riot dream turkey before sport action praise tunnel hood donate man");
+        mock_unlocked_using_mnemonic(
+            "sleep own lobster state clean thrive tail exist cactus bitter pass soccer clinic riot dream turkey before sport action praise tunnel hood donate man",
+            "",
+        );
         assert_eq!(
             get_xpub(&[]).unwrap().serialize_str(bip32::XPubType::Xpub).unwrap(),
             "xpub661MyMwAqRbcEhX8d9WJh78SZrxusAzWFoykz4n5CF75uYRzixw5FZPUSoWyhaaJ1bpiPFdzdHSQqJN38PcTkyrLmxT4J2JDYfoGJQ4ioE2",
@@ -59,7 +62,10 @@ mod tests {
         );
 
         // 18 words
-        mock_unlocked_using_mnemonic("sleep own lobster state clean thrive tail exist cactus bitter pass soccer clinic riot dream turkey before subject");
+        mock_unlocked_using_mnemonic(
+            "sleep own lobster state clean thrive tail exist cactus bitter pass soccer clinic riot dream turkey before subject",
+            "",
+        );
         assert_eq!(
             get_xpub(keypath).unwrap().serialize_str(bip32::XPubType::Xpub).unwrap(),
             "xpub6C7fKxGtTzEVxCC22U2VHx4GpaVy77DzU6KdZ1CLuHgoUGviBMWDc62uoQVxqcRa5RQbMPnffjpwxve18BG81VJhJDXnSpRe5NGKwVpXiAb",
@@ -68,6 +74,7 @@ mod tests {
         // 12 words
         mock_unlocked_using_mnemonic(
             "sleep own lobster state clean thrive tail exist cactus bitter pass sniff",
+            "",
         );
         assert_eq!(
             get_xpub(keypath).unwrap().serialize_str(bip32::XPubType::Xpub).unwrap(),
@@ -81,12 +88,14 @@ mod tests {
         assert_eq!(root_fingerprint(), Err(()));
 
         mock_unlocked_using_mnemonic(
-            "purity concert above invest pigeon category peace tuition hazard vivid latin since legal speak nation session onion library travel spell region blast estate stay"
+            "purity concert above invest pigeon category peace tuition hazard vivid latin since legal speak nation session onion library travel spell region blast estate stay",
+            "",
         );
         assert_eq!(root_fingerprint(), Ok(vec![0x02, 0x40, 0xe9, 0x2a]));
 
         mock_unlocked_using_mnemonic(
             "small agent wife animal marine cloth exit thank stool idea steel frame",
+            "",
         );
         assert_eq!(root_fingerprint(), Ok(vec![0xf4, 0x0b, 0x46, 0x9a]));
     }

--- a/src/rust/bitbox02-rust/src/keystore/ed25519.rs
+++ b/src/rust/bitbox02-rust/src/keystore/ed25519.rs
@@ -12,10 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use alloc::vec::Vec;
+
 use bip32_ed25519::{Xprv, Xpub, ED25519_EXPANDED_SECRET_KEY_SIZE};
 
+fn get_seed() -> Result<zeroize::Zeroizing<Vec<u8>>, ()> {
+    bitbox02::keystore::get_ed25519_seed()
+}
+
 fn get_xprv(keypath: &[u32]) -> Result<Xprv, ()> {
-    let root = bitbox02::keystore::get_ed25519_seed()?;
+    let root = get_seed()?;
     Ok(Xprv::from_normalize(
         &root[..ED25519_EXPANDED_SECRET_KEY_SIZE],
         &root[ED25519_EXPANDED_SECRET_KEY_SIZE..],
@@ -48,10 +54,46 @@ mod tests {
     use super::*;
 
     use bip32_ed25519::HARDENED_OFFSET;
-    use bitbox02::testing::mock_unlocked;
+    use bitbox02::testing::{mock_unlocked, mock_unlocked_using_mnemonic};
+
+    #[test]
+    fn test_get_seed() {
+        // Test vectors taken from:
+        // https://github.com/cardano-foundation/CIPs/blob/6c249ef48f8f5b32efc0ec768fadf4321f3173f2/CIP-0003/Ledger.md#test-vectors
+        // See also: https://github.com/cardano-foundation/CIPs/pull/132
+
+        mock_unlocked_using_mnemonic(
+            "recall grace sport punch exhibit mad harbor stand obey short width stem awkward used stairs wool ugly trap season stove worth toward congress jaguar",
+            "",
+        );
+        assert_eq!(
+            get_seed().unwrap().as_slice(),
+            b"\xa0\x8c\xf8\x5b\x56\x4e\xcf\x3b\x94\x7d\x8d\x43\x21\xfb\x96\xd7\x0e\xe7\xbb\x76\x08\x77\xe3\x71\x89\x9b\x14\xe2\xcc\xf8\x86\x58\x10\x4b\x88\x46\x82\xb5\x7e\xfd\x97\xde\xcb\xb3\x18\xa4\x5c\x05\xa5\x27\xb9\xcc\x5c\x2f\x64\xf7\x35\x29\x35\xa0\x49\xce\xea\x60\x68\x0d\x52\x30\x81\x94\xcc\xef\x2a\x18\xe6\x81\x2b\x45\x2a\x58\x15\xfb\xd7\xf5\xba\xbc\x08\x38\x56\x91\x9a\xaf\x66\x8f\xe7\xe4",
+        );
+
+        // Multiple loop iterations.
+        mock_unlocked_using_mnemonic(
+            "correct cherry mammal bubble want mandate polar hazard crater better craft exotic choice fun tourist census gap lottery neglect address glow carry old business",
+            "",
+        );
+        assert_eq!(
+            get_seed().unwrap().as_slice(),
+            b"\x58\x7c\x67\x74\x35\x7e\xcb\xf8\x40\xd4\xdb\x64\x04\xff\x7a\xf0\x16\xda\xce\x04\x00\x76\x97\x51\xad\x2a\xbf\xc7\x7b\x9a\x38\x44\xcc\x71\x70\x25\x20\xef\x1a\x4d\x1b\x68\xb9\x11\x87\x78\x7a\x9b\x8f\xaa\xb0\xa9\xbb\x6b\x16\x0d\xe5\x41\xb6\xee\x62\x46\x99\x01\xfc\x0b\xed\xa0\x97\x5f\xe4\x76\x3b\xea\xbd\x83\xb7\x05\x1a\x5f\xd5\xcb\xce\x5b\x88\xe8\x2c\x4b\xba\xca\x26\x50\x14\xe5\x24\xbd",
+        );
+
+        mock_unlocked_using_mnemonic(
+            "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art",
+            "foo",
+        );
+        assert_eq!(
+            get_seed().unwrap().as_slice(),
+            b"\xf0\x53\xa1\xe7\x52\xde\x5c\x26\x19\x7b\x60\xf0\x32\xa4\x80\x9f\x08\xbb\x3e\x5d\x90\x48\x4f\xe4\x20\x24\xbe\x31\xef\xcb\xa7\x57\x8d\x91\x4d\x3f\xf9\x92\xe2\x16\x52\xfe\xe6\xa4\xd9\x9f\x60\x91\x00\x69\x38\xfa\xc2\xc0\xc0\xf9\xd2\xde\x0b\xa6\x4b\x75\x4e\x92\xa4\xf3\x72\x3f\x23\x47\x20\x77\xaa\x4c\xd4\xdd\x8a\x8a\x17\x5d\xba\x07\xea\x18\x52\xda\xd1\xcf\x26\x8c\x61\xa2\x67\x9c\x38\x90",
+        );
+    }
 
     #[test]
     fn test_get_xpub() {
+        bitbox02::keystore::lock();
         assert!(get_xpub(&[]).is_err());
 
         mock_unlocked();

--- a/src/rust/bitbox02/src/input.rs
+++ b/src/rust/bitbox02/src/input.rs
@@ -29,6 +29,13 @@ impl SafeInputString {
         SafeInputString(Box::new([0; INPUT_STRING_MAX_SIZE]))
     }
 
+    #[cfg(feature = "testing")]
+    pub fn from_buf(buf: &[u8]) -> SafeInputString {
+        let mut s = SafeInputString::new();
+        s.as_mut()[..buf.len()].copy_from_slice(buf);
+        s
+    }
+
     /// Copies the string bytes from `source` without additional allocations.
     pub fn copy_from(&mut self, source: &Self) {
         self.0.copy_from_slice(&source.0[..]);
@@ -80,9 +87,7 @@ mod tests {
     use std::prelude::v1::*;
 
     fn from(buf: &[u8]) -> SafeInputString {
-        let mut pw = SafeInputString::new();
-        pw.as_mut()[..buf.len()].copy_from_slice(buf);
-        pw
+        SafeInputString::from_buf(buf)
     }
 
     #[test]

--- a/src/rust/bitbox02/src/keystore.rs
+++ b/src/rust/bitbox02/src/keystore.rs
@@ -369,6 +369,7 @@ mod tests {
         // 12 words
         mock_unlocked_using_mnemonic(
             "trust cradle viable innocent stand equal little small junior frost laundry room",
+            "",
         );
         assert_eq!(
             copy_seed().unwrap().as_slice(),
@@ -378,6 +379,7 @@ mod tests {
         // 18 words
         mock_unlocked_using_mnemonic(
             "pupil parent toe bright slam plastic spy suspect verb battle nominee loan call crystal upset razor luggage join",
+            "",
         );
         assert_eq!(
             copy_seed().unwrap().as_slice(),
@@ -386,6 +388,7 @@ mod tests {
 
         mock_unlocked_using_mnemonic(
             "purity concert above invest pigeon category peace tuition hazard vivid latin since legal speak nation session onion library travel spell region blast estate stay",
+            "",
         );
         assert_eq!(
             copy_seed().unwrap().as_slice(),

--- a/src/rust/bitbox02/src/testing.rs
+++ b/src/rust/bitbox02/src/testing.rs
@@ -47,13 +47,16 @@ pub fn mock(data: Data) {
     keystore::lock();
 }
 
-/// This mocks an unlocked keystore with the given bip39 recovery words.
-pub fn mock_unlocked_using_mnemonic(mnemonic: &str) {
+/// This mocks an unlocked keystore with the given bip39 recovery words and bip39 passphrase.
+pub fn mock_unlocked_using_mnemonic(mnemonic: &str, passphrase: &str) {
     let seed = keystore::bip39_mnemonic_to_seed(mnemonic).unwrap();
     unsafe {
         bitbox02_sys::keystore_mock_unlocked(seed.as_ptr(), seed.len() as _, core::ptr::null())
     }
-    keystore::unlock_bip39(&crate::input::SafeInputString::new()).unwrap();
+    keystore::unlock_bip39(&crate::input::SafeInputString::from_buf(
+        passphrase.as_bytes(),
+    ))
+    .unwrap();
 }
 
 pub const TEST_MNEMONIC: &str = "purity concert above invest pigeon category peace tuition hazard vivid latin since legal speak nation session onion library travel spell region blast estate stay";
@@ -61,7 +64,7 @@ pub const TEST_MNEMONIC: &str = "purity concert above invest pigeon category pea
 /// This mocks an unlocked keystore with a fixed bip39 seed based on these bip39 recovery words:
 /// `purity concert above invest pigeon category peace tuition hazard vivid latin since legal speak nation session onion library travel spell region blast estate stay`
 pub fn mock_unlocked() {
-    mock_unlocked_using_mnemonic(TEST_MNEMONIC)
+    mock_unlocked_using_mnemonic(TEST_MNEMONIC, "")
 }
 
 /// This mounts a new FAT32 volume in RAM for use in unit tests. As there is only one volume, access only serially.


### PR DESCRIPTION
Same tests as `_test_keystore_get_ed25519_seed()` in `test_keystore.c`. Then we can easily delete
`keystore_get_ed25519_seed()` in C and move it to Rust.