### PR TITLE
Subtract min sensor value per slider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ customers cannot upgrade their bootloader, its changes are recorded separately.
 - Increased performance when signing Bitcoin transactions
 - Warn if the transaction fee is higher than 10% of the coins sent
 - ETH Testnets: add Goerli and remove deprecated Rinkeby and Ropsten
+- Improved touch button positional accuracy in noisy environments
 
 ### 9.13.1
 - Fix bug introduced in 9.13.0: remove double cancel confirmation in the 'Restore from recovery words' workflow

--- a/src/qtouch/qtouch.h
+++ b/src/qtouch/qtouch.h
@@ -262,6 +262,9 @@ extern "C" {
     0.15 // Percent added weight to edge sensors, which are physically smaller
 #define DEF_SENSOR_NUM_PREV_POS \
     4 // Number of previous sensor positions to remember; used in a simple filter
+#define DEF_SENSOR_CEILING \
+    50 // Maximum sensor reading. Mitigates 'jumpy' channels that exist at higher
+       // sensor readings when in noisy environments.
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This improves touch position accuracy in noisy setups.

Touch position is calculated with a weighted average of the sensor readings. If properly calibrated, sensors on the opposite end of a finger touch would be zero and thus make no contribution to the weighted average. If the baseline sensor readings are elevated, the sensors on the opposite edge do contribute to the weighted average, making a positional artifact (i.e. the position is more central than it should be in reality). This artifact is higher when the finger is a bit distant while approaching and lower/negligible when the finger is fully touching the device. This can cause the position to move enough to enter "slide" mode and disable "tap" events being emitted.