### PR TITLE
rust: remove str_to_cstr and str_to_cstr_force

### DIFF
--- a/src/rust/bitbox02/src/lib.rs
+++ b/src/rust/bitbox02/src/lib.rs
@@ -51,13 +51,14 @@ pub use bitbox02_sys::buffer_t;
 #[macro_use]
 pub mod util;
 
-// ug_put_string displays a debug message on the screen for 3 sec.
 pub fn ug_put_string(x: i16, y: i16, input: &str, inverted: bool) {
-    match str_to_cstr!(input, 128) {
-        Ok(buf) => unsafe {
-            bitbox02_sys::UG_PutString(x, y, buf.as_ptr() as *const _, inverted);
-        },
-        Err(msg) => screen_print_debug(msg, 3000),
+    unsafe {
+        bitbox02_sys::UG_PutString(
+            x,
+            y,
+            crate::util::str_to_cstr_vec(input).unwrap().as_ptr(),
+            inverted,
+        );
     }
 }
 
@@ -99,16 +100,11 @@ pub fn delay(duration: Duration) {
 }
 
 pub fn screen_print_debug(msg: &str, duration: i32) {
-    match str_to_cstr!(msg, 200) {
-        Ok(cstr) => unsafe {
-            bitbox02_sys::screen_print_debug(cstr.as_ptr() as *const _, duration)
-        },
-        Err(errmsg) => unsafe {
-            bitbox02_sys::screen_print_debug(
-                str_to_cstr_force!(errmsg, 200).as_ptr() as *const _,
-                duration,
-            )
-        },
+    unsafe {
+        bitbox02_sys::screen_print_debug(
+            crate::util::str_to_cstr_vec(msg).unwrap().as_ptr(),
+            duration,
+        )
     }
 }
 

--- a/src/rust/bitbox02/src/memory.rs
+++ b/src/rust/bitbox02/src/memory.rs
@@ -35,12 +35,10 @@ pub fn get_device_name() -> String {
         .into()
 }
 
-/// `name.as_bytes()` must be smaller or equal to
-/// `DEVICE_NAME_MAX_LEN`, otherwise this function panics.
 pub fn set_device_name(name: &str) -> Result<(), Error> {
     match unsafe {
         bitbox02_sys::memory_set_device_name(
-            crate::str_to_cstr_force!(name, DEVICE_NAME_MAX_LEN).as_ptr(),
+            crate::util::str_to_cstr_vec(name).or(Err(Error))?.as_ptr(),
         )
     } {
         true => Ok(()),

--- a/src/rust/bitbox02/src/ui/types.rs
+++ b/src/rust/bitbox02/src/ui/types.rs
@@ -14,6 +14,7 @@
 
 extern crate alloc;
 use alloc::boxed::Box;
+use alloc::vec::Vec;
 
 use util::Survive;
 
@@ -73,20 +74,18 @@ impl<'a> ConfirmParams<'a> {
     /// alive for as long as the C params live.
     pub(crate) fn to_c_params(
         &self,
-        title_scatch: &'a mut [u8; MAX_LABEL_SIZE + 2],
-        body_scratch: &'a mut [u8; MAX_LABEL_SIZE + 2],
+        title_scatch: &'a mut Vec<u8>,
+        body_scratch: &'a mut Vec<u8>,
     ) -> Survive<'a, bitbox02_sys::confirm_params_t> {
         // We truncate at a bit higher than MAX_LABEL_SIZE, so the label component will correctly
         // truncate and append '...'.
         const TRUNCATE_SIZE: usize = MAX_LABEL_SIZE + 1;
-        *title_scatch = crate::str_to_cstr_force!(
-            crate::util::truncate_str(self.title, TRUNCATE_SIZE),
-            TRUNCATE_SIZE
-        );
-        *body_scratch = crate::str_to_cstr_force!(
-            crate::util::truncate_str(self.body, TRUNCATE_SIZE),
-            TRUNCATE_SIZE
-        );
+        *title_scatch =
+            crate::util::str_to_cstr_vec(crate::util::truncate_str(self.title, TRUNCATE_SIZE))
+                .unwrap();
+        *body_scratch =
+            crate::util::str_to_cstr_vec(crate::util::truncate_str(self.body, TRUNCATE_SIZE))
+                .unwrap();
         Survive::new(bitbox02_sys::confirm_params_t {
             title: title_scatch.as_ptr(),
             title_autowrap: self.title_autowrap,
@@ -117,16 +116,15 @@ impl<'a> TrinaryInputStringParams<'a> {
     #[cfg_attr(feature = "testing", allow(dead_code))]
     pub(crate) fn to_c_params(
         &self,
-        title_scratch: &'a mut [u8; MAX_LABEL_SIZE + 2],
+        title_scratch: &'a mut Vec<u8>,
     ) -> Survive<'a, bitbox02_sys::trinary_input_string_params_t> {
         // We truncate at a bit higher than MAX_LABEL_SIZE, so the label component will correctly
         // truncate and append '...'.
         const TRUNCATE_SIZE: usize = MAX_LABEL_SIZE + 1;
 
-        *title_scratch = crate::str_to_cstr_force!(
-            crate::util::truncate_str(self.title, TRUNCATE_SIZE),
-            TRUNCATE_SIZE
-        );
+        *title_scratch =
+            crate::util::str_to_cstr_vec(crate::util::truncate_str(self.title, TRUNCATE_SIZE))
+                .unwrap();
 
         Survive::new(bitbox02_sys::trinary_input_string_params_t {
             title: title_scratch.as_ptr(),

--- a/src/rust/bitbox02/src/util.rs
+++ b/src/rust/bitbox02/src/util.rs
@@ -46,52 +46,6 @@ pub unsafe fn str_from_null_terminated_ptr<'a>(ptr: *const u8) -> Result<&'a str
     core::str::from_utf8(s).or(Err(()))
 }
 
-/// Macro for creating a stack allocated buffer with the content of a string and a null-terminator
-///
-/// Example usage:
-///
-/// ```
-/// # #[macro_use] extern crate bitbox02;
-/// let name = "sample_string";
-/// let buf = match str_to_cstr!(name, 50) {
-///     Ok(buf) => buf,
-///     Err(msg) => panic!("{}", msg),
-/// };
-/// ```
-#[macro_export]
-macro_rules! str_to_cstr {
-    ($input:expr, $len:expr) => {{
-        let mut buf = [0u8; $len + 1];
-        if !$input.is_ascii() {
-            Err("non-ascii input")
-        } else {
-            let len = core::cmp::min($len, $input.len());
-            {
-                // Take a slice of buf of the correct length
-                let buf = &mut buf[..len];
-                // Take a slice of input of the correct length
-                let input = &$input.as_bytes()[..len];
-                buf.copy_from_slice(input);
-            }
-            if $input.len() > len {
-                Err("str is too long")
-            } else {
-                Ok(buf)
-            }
-        }
-    }};
-}
-
-#[macro_export]
-macro_rules! str_to_cstr_force {
-    ($input:expr, $len:expr) => {
-        match $crate::str_to_cstr!($input, $len) {
-            Ok(buf) => buf,
-            Err(msg) => panic!("{}", msg),
-        }
-    };
-}
-
 /// truncate_str truncates string `s` to `len` chars. If `s` is
 /// shorter than `len`, the string is returned unchanged (no panics).
 pub fn truncate_str(s: &str, len: usize) -> &str {


### PR DESCRIPTION
Simplify code by using str_to_cstr_vec instead (which we already use in many places for the same purpose), which uses core::alloc::CString for conversion. Since it uses a Vec (heap), one does not have to determine a mac size upfront.

This also saves 4k in binary space, as the macro apparently duplicated a lot of code.