### PR TITLE
scripts/container: add container selection for dockerinit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ jlink-flash-factory-setup: | build
 jlink-flash-firmware-semihosting: | build
 	JLinkExe -if SWD -device ATSAMD51J20 -speed 4000 -autoconnect 1 -CommanderScript ./build/scripts/firmware-semihosting.jlink
 dockerinit:
-	docker build --pull --force-rm --no-cache -t shiftcrypto/firmware_v2 .
+	./scripts/container.sh build --pull --force-rm --no-cache -t shiftcrypto/firmware_v2 .
 dockerdev:
 	./scripts/dockerenv.sh
 dockerrel:

--- a/scripts/container.sh
+++ b/scripts/container.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Copyright 2023 Shift Crypto AG
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script wraps podman or docker or the specified container
+# runtime.
+
+if [ -n "$CONTAINER_RUNTIME" ]; then
+  RUNTIME="$CONTAINER_RUNTIME"
+elif command -v podman &>/dev/null; then
+  RUNTIME=podman
+else
+  RUNTIME=docker
+fi
+
+$RUNTIME $@


### PR DESCRIPTION
In cb16b81 and b9a05b1 we added podman support for containers, but `make dockerinit` was still fixed on docker, causing ad error when building and executing a new image with podman installed. This updates the Makefile to use podman if available also when building the image.