### PR TITLE
.github/workflows/ci.yml: update to ubuntu-22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 
 jobs:
   linux-docker:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Clone the repo
         uses: actions/checkout@v2


### PR DESCRIPTION
This is only for the CI base image. Our actual CI runs in a docker image that has an independent base image, which happens to be 22.04 as well.

This change is needed as GitHub deprecated ubuntu-18.04:

>  The ubuntu-18.04 environment is deprecated, consider switching to ubuntu-20.04 or ubuntu-22.04 (ubuntu-latest). For more details, see https://github.com/actions/runner-images/issues/6002