### PR TITLE
Makefile: make unit test SANITIZE_* configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@
 # This makefile is used as a command runner and not for tracking dependencies between recipies
 
 .DEFAULT_GOAL := firmware
+SANITIZE ?= ON
 
 bootstrap:
 	git submodule update --init --recursive
@@ -26,7 +27,7 @@ build/Makefile:
 
 build-build/Makefile:
 	mkdir -p build-build
-	cd build-build && cmake .. -DCOVERAGE=ON -DSANITIZE_ADDRESS=ON -DSANITIZE_UNDEFINED=ON
+	cd build-build && cmake .. -DCOVERAGE=ON -DSANITIZE_ADDRESS=$(SANITIZE) -DSANITIZE_UNDEFINED=$(SANITIZE)
 	$(MAKE) -C py/bitbox02
 
 # Should only be used for rust unit tests since we didn't add support to

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -255,8 +255,8 @@ foreach(I RANGE 0 ${TEST_LIST_LEN} 2)
   add_executable(${EXE} test_${TEST_NAME}.c framework/eh_personality.c)
   # asan must be first library in linking order
   target_link_libraries(${EXE} PRIVATE
-    $<$<BOOL:SANITIZE_ADDRESS>:asan>
-    $<$<BOOL:SANITIZE_UNDEFINED>:-fsanitize=undefined>
+    $<$<BOOL:${SANITIZE_ADDRESS}>:asan>
+    $<$<BOOL:${SANITIZE_UNDEFINED}>:-fsanitize=undefined>
     -Wl,--start-group
     c-unit-tests_rust_c
     bitbox
@@ -281,8 +281,8 @@ foreach(TEST_NAME ${U2F_TESTS})
   # This tests link to our code
   add_executable(${EXE} test_${TEST_NAME}.c framework/mock_hidapi.c framework/eh_personality.c)
   target_link_libraries(${EXE} PRIVATE
-    $<$<BOOL:SANITIZE_ADDRESS>:asan>
-    $<$<BOOL:SANITIZE_UNDEFINED>:-fsanitize=undefined>
+    $<$<BOOL:${SANITIZE_ADDRESS}>:asan>
+    $<$<BOOL:${SANITIZE_UNDEFINED}>:-fsanitize=undefined>
     -Wl,--start-group
     c-unit-tests_rust_c
     bitbox
@@ -298,8 +298,8 @@ foreach(TEST_NAME ${U2F_TESTS})
   add_executable(${EXE} test_${TEST_NAME}.c)
   # asan must be first library in linking order
   target_link_libraries(${EXE} PRIVATE
-    $<$<BOOL:SANITIZE_ADDRESS>:asan>
-    $<$<BOOL:SANITIZE_UNDEFINED>:-fsanitize=undefined>
+    $<$<BOOL:${SANITIZE_ADDRESS}>:asan>
+    $<$<BOOL:${SANITIZE_UNDEFINED}>:-fsanitize=undefined>
     u2f-util
     hidapi-hidraw
     ${CMOCKA_LIBRARIES}


### PR DESCRIPTION
To build the unit tests without sanitizers, call `make unit-test
SANITIZE=OFF`.

On my machine I can't run sanitizers for some reason, so this is a
workaround. It still defaults to ON, and the CI will keep using the
sanitizers.

