### PR TITLE
ui/button: copy text into the button data struct

### DIFF
--- a/src/ui/components/button.c
+++ b/src/ui/components/button.c
@@ -30,7 +30,7 @@ static const uint8_t MIN_BUTTON_WIDTH = 32; // 0:SCREEN_WIDTH
  * Component data.
  */
 typedef struct {
-    const char* text;
+    char text[20];
     slider_location_t location;
     bool span_over_slider;
     bool upside_down;
@@ -203,7 +203,7 @@ void button_update(component_t* button, const char* text, void (*callback)(compo
 {
     button_data_t* data = (button_data_t*)button->data;
     data->callback = callback;
-    data->text = text;
+    snprintf(data->text, sizeof(data->text), "%s", text);
     UG_FontSelect(&font_font_a_11X10);
     UG_FontSetHSpace(0);
     UG_MeasureString(&(button->dimension.width), &(button->dimension.height), text);


### PR DESCRIPTION
Before the text that was passed to button_create was simply passed as a pointer to the data struct, making it the caller's responsibility to keep the string alive for as long as the component is alive.

The comments in ui.rs were incorrect:

```
    bitbox02_sys::trinary_choice_create(
        crate::util::str_to_cstr_vec(message).unwrap().as_ptr(), // copied in C
        crate::util::str_to_cstr_vec(label_left).unwrap().as_ptr(), // copied in C
        crate::util::str_to_cstr_vec(label_middle).unwrap().as_ptr(), // copied in C
        crate::util::str_to_cstr_vec(label_right).unwrap().as_ptr(), // copied in C
        ...
```

Since the three labels are buttons, the text was not copied and the pointer becomes dangling.

I checked all instances and found that all button label strings are
short and fit in 20 bytes. A lower number here is better to save
binary space. Can increase it in the future if needed.
