### PR TITLE
py: fix python linter

### DIFF
--- a/py/bitbox02/bitbox02/communication/devices.py
+++ b/py/bitbox02/bitbox02/communication/devices.py
@@ -160,6 +160,6 @@ def get_any_bitbox02_bootloader() -> DeviceInfo:
 def parse_device_version(serial_number: str) -> semver.VersionInfo:
     match = re.search(r"v([0-9]+\.[0-9]+\.[0-9]+.*)", serial_number)
     if match is None:
-        return None
+        raise Exception(f"Could not parse version string from serial_number: {serial_number}")
 
     return semver.VersionInfo.parse(match.group(1))


### PR DESCRIPTION
./scripts/lint-python

CI didn't find it earlier as ./scripts/check-pep8 aborts early if there are no Python files in the diff...