### PR TITLE
workflow/mnemonic: generalize lastword_choices to 12/18/24 words

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ customers cannot upgrade their bootloader, its changes are recorded separately.
 - Disable screensaver when displaying a receive address, confirming a transaction, and other interactive actions
 - Add Sepolia testnet for Ethereum
 - Added a disclaimer screen before the recovery words are displayed
+- Verifiable seed generation: when restoring from 12 or 18 recovery words, for the final word, restrict input to the valid candidate words which result in a valid checksum.
+  For 24 words, this feature was already introduced in 9.4.0.
+
 
 ### 9.15.0
 - Security bugfix: check index of an input's previous output to prevent the fee attack originally

--- a/src/rust/bitbox02-rust/src/workflow/mnemonic.rs
+++ b/src/rust/bitbox02-rust/src/workflow/mnemonic.rs
@@ -149,7 +149,7 @@ async fn get_24th_word(
             Ok(choice_idx) if choice_idx as usize == none_of_them_idx => {
                 let params = confirm::Params {
                     title: "",
-                    body: "Recovery words\ninvalid.\nRestart?",
+                    body: "Invalid. Check\nrecovery words.\nRestart?",
                     ..Default::default()
                 };
                 if let Ok(()) = confirm::confirm(&params).await {

--- a/src/rust/bitbox02-rust/src/workflow/mnemonic.rs
+++ b/src/rust/bitbox02-rust/src/workflow/mnemonic.rs
@@ -177,7 +177,7 @@ pub async fn get() -> Result<zeroize::Zeroizing<String>, CancelError> {
     status(&format!("Enter {} words", num_words), true).await;
 
     // Provide all bip39 words to restrict the keyboard entry.
-    let bip39_wordlist = bitbox02::keystore::get_bip39_wordlist().unwrap();
+    let bip39_wordlist = bitbox02::keystore::get_bip39_wordlist(None);
 
     let mut word_idx: usize = 0;
     let mut entered_words = vec![zeroize::Zeroizing::new(String::new()); num_words];


### PR DESCRIPTION
The function computed all 8 possible 24th candidate words to make up a valid bip39 mnemonic given the first 23 words.

The function is extended to also work with 12 and 18 word mnemonics, returning 128 (resp. 32) possible candidates for the final word.

This function can then be used to make the entry of the final word easier for the 12th/18th word by restricting the keyboard to only allow entering from these candidates. This also allows easily importing seeds that were made without computers by rolling dices or similar, helping with the checksum issue, like we do now for 24 word mnemonics.