### PR TITLE
py: require hidapi>=0.14.0

### DIFF
--- a/py/bitbox02/CHANGELOG.md
+++ b/py/bitbox02/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 6.2.0
 - btc_sign: allow displaying BTC values in the 'sat' unit
+- require hidapi 0.14.0 to fix a bug on macOS 13.3 which lists two BitBox02s instead of one
 
 ## 6.1.1
 - Update protobuf dependency to >= 3.20, for better compatibility

--- a/py/bitbox02/setup.py
+++ b/py/bitbox02/setup.py
@@ -73,7 +73,7 @@ setup(
         ],
     },
     install_requires=[
-        "hidapi>=0.7.99.post21",
+        "hidapi>=0.14.0",
         "noiseprotocol>=0.3",
         "protobuf>=3.20",
         "ecdsa>=0.14",


### PR DESCRIPTION
Fixing https://github.com/trezor/cython-hidapi/issues/151, which includes the fix https://github.com/libusb/hidapi/issues/531, which fixes a bug where on macOS, the interface number of all hid interfaces would be 0. This lead to one BitBox02 multi being listed twice instead of once (as it exposes a second interface for U2F).