### PR TITLE
Miniscript: registration & signing

### DIFF
--- a/messages/btc.proto
+++ b/messages/btc.proto
@@ -170,6 +170,7 @@ message BTCSignOutputRequest {
 message BTCScriptConfigRegistration {
   BTCCoin coin = 1;
   BTCScriptConfig script_config = 2;
+  // Unused for policy registrations.
   repeated uint32 keypath = 3;
 }
 

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin.rs
@@ -240,11 +240,16 @@ async fn address_policy(
     let parsed = policies::parse(policy)?;
     parsed.validate(coin)?;
 
+    let name = match policies::get_name(coin, policy)? {
+        Some(name) => name,
+        None => return Err(Error::InvalidInput),
+    };
+
     let title = "Receive to";
 
-    // TODO: check that the policy was registered before.
-
-    // TODO: confirm policy registration
+    if display {
+        policies::confirm(title, coin_params, &name, policy, policies::Mode::Basic).await?;
+    }
 
     let address = common::Payload::from_policy(&parsed, keypath)?.address(coin_params)?;
     if display {

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin.rs
@@ -234,6 +234,9 @@ async fn address_policy(
     display: bool,
 ) -> Result<Response, Error> {
     let coin_params = params::get(coin);
+
+    keypath::validate_address_policy(keypath).or(Err(Error::InvalidInput))?;
+
     let parsed = policies::parse(policy)?;
     parsed.validate(coin)?;
 

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin/common.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin/common.rs
@@ -199,6 +199,13 @@ impl Payload {
                 keypath[keypath.len() - 2],
                 keypath[keypath.len() - 1],
             ),
+            pb::BtcScriptConfigWithKeypath {
+                script_config:
+                    Some(pb::BtcScriptConfig {
+                        config: Some(pb::btc_script_config::Config::Policy(policy)),
+                    }),
+                ..
+            } => Self::from_policy(&super::policies::parse(policy)?, keypath),
             _ => Err(Error::InvalidInput),
         }
     }

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin/policies.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin/policies.rs
@@ -332,6 +332,20 @@ impl<'a> ParsedPolicy<'a> {
             }
         }
     }
+
+    /// Returns true if the address-level keypath points to a change address.
+    pub fn is_change_keypath(&self, keypath: &[u32]) -> Result<bool, Error> {
+        match self {
+            Self::Wsh(Wsh {
+                policy,
+                miniscript_expr,
+            }) => {
+                let (is_change, _) =
+                    get_change_and_address_index(miniscript_expr.iter_pk(), &policy.keys, keypath)?;
+                Ok(is_change)
+            }
+        }
+    }
 }
 
 /// Parses a policy as specified by 'Wallet policies': https://github.com/bitcoin/bips/pull/1389.

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin/policies.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin/policies.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::params::Params;
 use super::pb;
 use super::Error;
 use pb::BtcCoin;
@@ -26,6 +27,11 @@ use core::str::FromStr;
 use util::bip32::HARDENED;
 
 use miniscript::TranslatePk;
+
+use crate::bip32;
+use crate::workflow::confirm;
+
+use sha2::{Digest, Sha256};
 
 // Arbitrary limit of keys that can be present in a policy.
 const MAX_KEYS: usize = 20;
@@ -50,7 +56,7 @@ fn is_our_key(key: &pb::KeyOriginInfo) -> Result<bool, ()> {
             ..
         } if root_fingerprint.as_slice() == our_root_fingerprint.as_slice() => {
             let our_xpub = crate::keystore::get_xpub(keypath)?.serialize(None)?;
-            let maybe_our_xpub = crate::bip32::Xpub::from(xpub).serialize(None)?;
+            let maybe_our_xpub = bip32::Xpub::from(xpub).serialize(None)?;
             Ok(our_xpub == maybe_our_xpub)
         }
         _ => Ok(false),
@@ -154,8 +160,8 @@ impl<'a> miniscript::Translator<String, bitcoin::PublicKey, Error>
                 } else {
                     multipath_index_left
                 };
-                let derived_xpub = crate::bip32::Xpub::from(xpub)
-                    .derive(&[multipath_index, self.address_index])?;
+                let derived_xpub =
+                    bip32::Xpub::from(xpub).derive(&[multipath_index, self.address_index])?;
                 Ok(bitcoin::PublicKey::from_slice(derived_xpub.public_key())
                     .or(Err(Error::Generic))?)
             }
@@ -350,6 +356,151 @@ pub fn parse(policy: &Policy) -> Result<ParsedPolicy, Error> {
         }
         _ => Err(Error::InvalidInput),
     }
+}
+
+/// Confirmation mode.
+pub enum Mode {
+    /// Confirm coin, number of keys and account name and optionally the advanced details.
+    Basic,
+    /// Confirm coin, number of keys, account name, the policy string, and the key origin infos.
+    Advanced,
+}
+
+/// Confirm the policy. In advanced mode, all details are shown. In basic mode, the advanced details
+/// are optional. Used to verify the policy during account registration (advanced mode), creating a
+/// receive address (basic mode) and signing a transaction (basic mode).
+pub async fn confirm(
+    title: &str,
+    params: &Params,
+    name: &str,
+    policy: &Policy,
+    mode: Mode,
+) -> Result<(), Error> {
+    confirm::confirm(&confirm::Params {
+        title,
+        body: &format!("{}\npolicy with\n{} keys", params.name, policy.keys.len(),),
+        accept_is_nextarrow: true,
+        ..Default::default()
+    })
+    .await?;
+
+    confirm::confirm(&confirm::Params {
+        title: "Name",
+        body: name,
+        scrollable: true,
+        accept_is_nextarrow: true,
+        ..Default::default()
+    })
+    .await?;
+
+    if matches!(mode, Mode::Basic) {
+        if let Err(confirm::UserAbort) = confirm::confirm(&confirm::Params {
+            body: "Show policy\ndetails?",
+            accept_is_nextarrow: true,
+            ..Default::default()
+        })
+        .await
+        {
+            return Ok(());
+        }
+    }
+
+    confirm::confirm(&confirm::Params {
+        title: "Policy",
+        body: &policy.policy,
+        scrollable: true,
+        accept_is_nextarrow: true,
+        ..Default::default()
+    })
+    .await?;
+
+    let num_keys = policy.keys.len();
+    for (i, key) in policy.keys.iter().enumerate() {
+        let key_str = match key {
+            pb::KeyOriginInfo {
+                root_fingerprint,
+                keypath,
+                xpub: Some(xpub),
+            } => {
+                let xpub_str = bip32::Xpub::from(xpub)
+                    .serialize_str(bip32::XPubType::Xpub)
+                    .or(Err(Error::InvalidInput))?;
+                if root_fingerprint.is_empty() {
+                    xpub_str
+                } else if root_fingerprint.len() != 4 {
+                    return Err(Error::InvalidInput);
+                } else {
+                    format!(
+                        "[{}/{}]{}",
+                        hex::encode(root_fingerprint),
+                        util::bip32::to_string_no_prefix(keypath),
+                        xpub_str
+                    )
+                }
+            }
+            _ => return Err(Error::InvalidInput),
+        };
+        confirm::confirm(&confirm::Params {
+            title: &format!("Key {}/{}", i + 1, num_keys),
+            body: (if is_our_key(key)? {
+                format!("This device: {}", key_str)
+            } else {
+                key_str
+            })
+            .as_str(),
+            scrollable: true,
+            longtouch: i == num_keys - 1 && matches!(mode, Mode::Advanced),
+            accept_is_nextarrow: true,
+            ..Default::default()
+        })
+        .await?;
+    }
+    Ok(())
+}
+
+/// Creates a hash of this policy config, useful for registration and identification.
+pub fn get_hash(coin: BtcCoin, policy: &Policy) -> Result<Vec<u8>, ()> {
+    let mut hasher = Sha256::new();
+    {
+        // 1. Type of registration: policy.
+        // It is chosen to never conflict with multisig hashes which start with the coin (0x00-0x03).
+        hasher.update(&[0xff]);
+    }
+    {
+        // 2. coin
+        let byte: u8 = match coin {
+            BtcCoin::Btc => 0x00,
+            BtcCoin::Tbtc => 0x01,
+            BtcCoin::Ltc => 0x02,
+            BtcCoin::Tltc => 0x03,
+        };
+        hasher.update(byte.to_le_bytes());
+    }
+    {
+        // 3. policy
+        let len: u32 = policy.policy.len() as _;
+        hasher.update(len.to_le_bytes());
+        hasher.update(policy.policy.as_bytes());
+    }
+    {
+        // 4. keys
+        let num: u32 = policy.keys.len() as _;
+        hasher.update(num.to_le_bytes());
+        for key in policy.keys.iter() {
+            hasher.update(&bip32::Xpub::from(key.xpub.as_ref().unwrap()).serialize(None)?);
+        }
+    }
+    Ok(hasher.finalize().as_slice().into())
+}
+
+/// Get the name of a registered policy account. The poliy is not validated, it must be
+/// pre-validated!
+///
+/// Returns the name of the registered policy account if it exists or None otherwise.
+pub fn get_name(coin: BtcCoin, policy: &Policy) -> Result<Option<String>, ()> {
+    Ok(bitbox02::memory::multisig_get_by_hash(&get_hash(
+        coin, policy,
+    )?))
 }
 
 #[cfg(test)]
@@ -735,10 +886,10 @@ mod tests {
         );
 
         let our_key = make_our_key(KEYPATH_ACCOUNT);
-        let our_xpub = crate::bip32::Xpub::from(our_key.xpub.as_ref().unwrap());
+        let our_xpub = bip32::Xpub::from(our_key.xpub.as_ref().unwrap());
 
         let some_key = make_key(SOME_XPUB_1);
-        let some_xpub = crate::bip32::Xpub::from(some_key.xpub.as_ref().unwrap());
+        let some_xpub = bip32::Xpub::from(some_key.xpub.as_ref().unwrap());
         let address_index = 5;
 
         let witness_script = |pol: &str, keys: &[pb::KeyOriginInfo], is_change: bool| {
@@ -855,5 +1006,57 @@ mod tests {
                 expected_witness_script,
             );
         }
+    }
+
+    #[test]
+    fn test_get_hash() {
+        // Fixture below verified with:
+        // import hashlib
+        // import base58
+        //
+        // xpubs = [
+        //     "xpub6EMfjyGVUvwhqh719Z4b9j4hxgWwZg9NrNRhs4s4QHP4qMkYfkxD3i3fcQuE51i99G1AhSyoSymjbEZMfa1bcPJK281gPNCS7VPQ7YmovG4",
+        //     "xpub6FMWuwbCA9KhoRzAMm63ZhLspk5S2DM5sePo8J8mQhcS1xyMbAqnc7Q7UescVEVFCS6qBMQLkEJWQ9Z3aDPgBov5nFUYxsJhwumsxM4npSo",
+        // ]
+        //
+        // policy = b'wsh(multi(2,@0/**,@1/**))'
+        //
+        // i32 = lambda i: i.to_bytes(4, 'little')
+        //
+        // msg = []
+        // msg.append(b'\xff') # registration type
+        // msg.append(b'\x00') # coin
+        // msg.append(i32(len(policy)))
+        // msg.append(policy) # script config type
+        // msg.append(i32(len(xpubs)))
+        // msg.extend(base58.b58decode_check(xpub)[4:] for xpub in xpubs)
+        // print(hashlib.sha256(b''.join(msg)).hexdigest())
+
+        mock_unlocked_using_mnemonic(
+            "sudden tenant fault inject concert weather maid people chunk youth stumble grit",
+            "",
+        );
+
+        let pol = make_policy(
+            "wsh(multi(2,@0/**,@1/**))",
+            &[make_our_key(KEYPATH_ACCOUNT), make_key(SOME_XPUB_1)],
+        );
+
+        assert_eq!(
+            hex::encode(get_hash(BtcCoin::Btc, &pol).unwrap()).as_str(),
+            "26b4cd47ee808288cebf95b77b31cafa2ab88ec377eb94f01aa8860abf67b6d6",
+        );
+        assert_eq!(
+            hex::encode(get_hash(BtcCoin::Tbtc, &pol).unwrap()).as_str(),
+            "3c2e1194a9c5ebe0703f580e1493818b2af3eb30368f1dddcaddb2b4a93fbcf3",
+        );
+        assert_eq!(
+            hex::encode(get_hash(BtcCoin::Ltc, &pol).unwrap()).as_str(),
+            "7538418014c911a2812afabca3f725d32a076fb756a867d0a2f7bf23879bd474",
+        );
+        assert_eq!(
+            hex::encode(get_hash(BtcCoin::Tltc, &pol).unwrap()).as_str(),
+            "6160dc5cf72b79380e9e715c75ae54573b81dcb4ed8ab2e90fde5d661e443781",
+        );
     }
 }

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin/signtx.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin/signtx.rs
@@ -214,6 +214,11 @@ fn validate_keypath(
             keypath::validate_address_multisig(keypath, params.bip44_coin, script_type)
                 .or(Err(Error::InvalidInput))?;
         }
+        Some(pb::BtcScriptConfig {
+            config: Some(pb::btc_script_config::Config::Policy(_)),
+        }) => {
+            keypath::validate_address_policy(keypath).or(Err(Error::InvalidInput))?;
+        }
         _ => return Err(Error::InvalidInput),
     }
     // Check that keypath_account is a prefix to keypath with two elements left (change, address).
@@ -224,6 +229,7 @@ fn validate_keypath(
         return Err(Error::InvalidInput);
     }
     let change = keypath[keypath.len() - 2];
+    // TODO: change path in a policy must be determined using multipath
     if must_be_change && change != 1 {
         return Err(Error::InvalidInput);
     }
@@ -298,6 +304,13 @@ fn sighash_script(
             keypath[keypath.len() - 2],
             keypath[keypath.len() - 1],
         )?),
+        pb::BtcScriptConfigWithKeypath {
+            script_config:
+                Some(pb::BtcScriptConfig {
+                    config: Some(pb::btc_script_config::Config::Policy(policy)),
+                }),
+            ..
+        } => super::policies::parse(policy)?.witness_script_at_keypath(keypath),
         _ => Err(Error::InvalidInput),
     }
 }
@@ -395,6 +408,38 @@ async fn validate_script_configs(
         let name = super::multisig::get_name(coin_params.coin, multisig, keypath)?
             .ok_or(Error::InvalidInput)?;
         super::multisig::confirm("Spend from", coin_params, &name, multisig).await?;
+        return Ok(());
+    }
+
+    // Then we get policies out of the way.
+
+    if let [pb::BtcScriptConfigWithKeypath {
+        script_config:
+            Some(pb::BtcScriptConfig {
+                config: Some(pb::btc_script_config::Config::Policy(policy)),
+            }),
+        keypath: _,
+    }] = script_configs
+    {
+        super::policies::parse(policy)?.validate(coin_params.coin)?;
+        let name =
+            super::policies::get_name(coin_params.coin, policy)?.ok_or(Error::InvalidInput)?;
+
+        // We could check here that the account keypath matches one of our keys in the policy and
+        // abort early, but we don't have to - if the keypath does not match we will fail when
+        // processing the first input, where it is checked that the account keypath is a prefix of
+        // the input keypath, and the computation of the pk_script checks that full keypath is
+        // valid.
+
+        super::policies::confirm(
+            "Spend from",
+            coin_params,
+            &name,
+            policy,
+            super::policies::Mode::Basic,
+        )
+        .await?;
+
         return Ok(());
     }
 
@@ -1204,6 +1249,18 @@ mod tests {
             }
         }
 
+        /// An arbitrary policy test transaction with some inputs and outputs.
+        fn new_policy() -> Self {
+            let mut tx = Self::new_multisig();
+            tx.total_confirmations = 9;
+            let bip44_coin = super::super::params::get(tx.coin).bip44_coin;
+            tx.inputs[0].input.keypath =
+                vec![48 + HARDENED, bip44_coin, 0 + HARDENED, 3 + HARDENED, 0, 0];
+            tx.outputs[0].keypath =
+                vec![48 + HARDENED, bip44_coin, 0 + HARDENED, 3 + HARDENED, 1, 0];
+            tx
+        }
+
         fn init_request(&self) -> pb::BtcSignInitRequest {
             pb::BtcSignInitRequest {
                 coin: self.coin as _,
@@ -1218,6 +1275,27 @@ mod tests {
                         super::super::params::get(self.coin).bip44_coin,
                         10 + HARDENED,
                     ],
+                }],
+                version: self.version,
+                num_inputs: self.inputs.len() as _,
+                num_outputs: self.outputs.len() as _,
+                locktime: self.locktime,
+                format_unit: FormatUnit::Default as _,
+            }
+        }
+
+        fn init_request_policy(
+            &self,
+            policy: pb::btc_script_config::Policy,
+            keypath_account: &[u32],
+        ) -> pb::BtcSignInitRequest {
+            pb::BtcSignInitRequest {
+                coin: self.coin as _,
+                script_configs: vec![pb::BtcScriptConfigWithKeypath {
+                    script_config: Some(pb::BtcScriptConfig {
+                        config: Some(pb::btc_script_config::Config::Policy(policy)),
+                    }),
+                    keypath: keypath_account.to_vec(),
                 }],
                 version: self.version,
                 num_inputs: self.inputs.len() as _,
@@ -2703,5 +2781,232 @@ mod tests {
             }
             _ => panic!("wrong result"),
         }
+    }
+
+    #[test]
+    fn test_policy() {
+        let transaction = alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new_policy()));
+        mock_host_responder(transaction.clone());
+
+        static mut UI_COUNTER: u32 = 0;
+        mock(Data {
+            ui_confirm_create: Some(Box::new(move |params| {
+                match unsafe {
+                    UI_COUNTER += 1;
+                    UI_COUNTER
+                } {
+                    1 => {
+                        assert_eq!(params.title, "Spend from");
+                        assert_eq!(params.body, "BTC Testnet\npolicy with\n2 keys");
+                    }
+                    2 => {
+                        assert_eq!(params.title, "Name");
+                        assert_eq!(params.body, "test policy account name");
+                    }
+                    3 => {
+                        assert_eq!(params.title, "");
+                        assert_eq!(params.body, "Show policy\ndetails?");
+                    }
+                    4 => {
+                        assert_eq!(params.title, "Policy");
+                        assert_eq!(params.body, "wsh(multi(2,@0/**,@1/**))");
+                        assert!(params.scrollable);
+                    }
+                    5 => {
+                        assert_eq!(params.title, "Key 1/2");
+                        assert_eq!(params.body, "This device: [93531fa9/48'/1'/0'/3']xpub6EMfjyGVUvwhqh719Z4b9j4hxgWwZg9NrNRhs4s4QHP4qMkYfkxD3i3fcQuE51i99G1AhSyoSymjbEZMfa1bcPJK281gPNCS7VPQ7YmovG4");
+                        assert!(params.scrollable);
+                    }
+                    6 => {
+                        assert_eq!(params.title, "Key 2/2");
+                        assert_eq!(params.body, "xpub6Eu7xJRyXRCi4eLYhJPnfZVjgAQtM7qFaEZwUhvgxGf4enEZMxevGzWvZTawCj9USP2MFTEhKQAwnqHwoaPHetTLqGuvq5r5uaLKyGx5QDZ");
+                        assert!(params.scrollable);
+                    }
+                    8 => {
+                        assert_eq!(params.title, "");
+                        assert_eq!(
+                            params.body,
+                            "Locktime on block:\n1663289\nTransaction is not RBF"
+                        );
+                    }
+                    _ => panic!("unexpected UI dialog"),
+                }
+                true
+            })),
+            ui_transaction_address_create: Some(Box::new(move |amount, address| {
+                match unsafe {
+                    UI_COUNTER += 1;
+                    UI_COUNTER
+                } {
+                    7 => {
+                        assert_eq!(
+                            address,
+                            "tb1qtxyqynfxwsk8f5gu8v5g8e6hs3njtglkywhvyztk6v8znvx5kddsmhuve2"
+                        );
+                        assert_eq!(amount, "0.0009 TBTC");
+                    }
+                    _ => panic!("unexpected UI dialog"),
+                }
+                true
+            })),
+            ui_transaction_fee_create: Some(Box::new(|total, fee, longtouch| {
+                match unsafe {
+                    UI_COUNTER += 1;
+                    UI_COUNTER
+                } {
+                    9 => {
+                        assert_eq!(total, "0.00090175 TBTC");
+                        assert_eq!(fee, "0.00000175 TBTC");
+                        assert!(longtouch);
+                    }
+                    _ => panic!("unexpected UI dialog"),
+                }
+                true
+            })),
+            ..Default::default()
+        });
+
+        mock_unlocked_using_mnemonic(
+            "sudden tenant fault inject concert weather maid people chunk youth stumble grit",
+            "",
+        );
+        // For the policy registration below.
+        mock_memory();
+
+        let keypath_account = &[48 + HARDENED, 1 + HARDENED, 0 + HARDENED, 3 + HARDENED];
+
+        let policy = pb::btc_script_config::Policy {
+            policy: "wsh(multi(2,@0/**,@1/**))".into(),
+            keys: vec![
+                pb::KeyOriginInfo {
+                    root_fingerprint: crate::keystore::root_fingerprint().unwrap(),
+                    keypath: keypath_account.to_vec(),
+                    xpub: Some(crate::keystore::get_xpub(keypath_account).unwrap().into()),
+                },
+                pb::KeyOriginInfo {
+                    root_fingerprint: vec![],
+                    keypath: vec![],
+                    xpub: Some(parse_xpub("xpub6Eu7xJRyXRCi4eLYhJPnfZVjgAQtM7qFaEZwUhvgxGf4enEZMxevGzWvZTawCj9USP2MFTEhKQAwnqHwoaPHetTLqGuvq5r5uaLKyGx5QDZ").unwrap()),
+                },
+            ],
+        };
+
+        // Register policy.
+        let policy_hash = super::super::policies::get_hash(pb::BtcCoin::Tbtc, &policy).unwrap();
+        bitbox02::memory::multisig_set_by_hash(&policy_hash, "test policy account name").unwrap();
+
+        let result = block_on(process(
+            &transaction
+                .borrow()
+                .init_request_policy(policy, keypath_account),
+        ));
+        match result {
+            Ok(Response::BtcSignNext(next)) => {
+                assert!(next.has_signature);
+                assert_eq!(&next.signature, b"\x57\x36\xb8\xee\xc7\x59\x4a\xd9\x06\xda\xf8\xd3\xfa\xc6\x4d\x58\xae\xd3\x5f\xc5\x07\x26\xb0\xed\x6d\x5f\xb1\xc8\x01\x9f\xca\xb0\x60\x6c\xed\x7d\x09\xbc\x9a\x75\xfa\xdf\x5b\xa4\x5c\xc9\x5d\xc1\x5f\xb6\x79\x69\x97\x46\x67\x39\xa9\xf6\x38\x3b\xd1\x59\xda\xe4");
+            }
+            _ => panic!("wrong result"),
+        }
+        assert_eq!(
+            unsafe { UI_COUNTER },
+            transaction.borrow().total_confirmations
+        );
+    }
+
+    #[test]
+    fn test_policy_wrong_account_keypath() {
+        let transaction = alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new_policy()));
+        mock_host_responder(transaction.clone());
+
+        static mut UI_COUNTER: u32 = 0;
+        mock_default_ui();
+
+        mock_unlocked_using_mnemonic(
+            "sudden tenant fault inject concert weather maid people chunk youth stumble grit",
+            "",
+        );
+        // For the policy registration below.
+        mock_memory();
+
+        let keypath_account = &[48 + HARDENED, 1 + HARDENED, 0 + HARDENED, 3 + HARDENED];
+        let wrong_keypath_account = &[48 + HARDENED, 1 + HARDENED, 0 + HARDENED, 4 + HARDENED];
+
+        let policy = pb::btc_script_config::Policy {
+            policy: "wsh(multi(2,@0/**,@1/**))".into(),
+            keys: vec![
+                pb::KeyOriginInfo {
+                    root_fingerprint: crate::keystore::root_fingerprint().unwrap(),
+                    keypath: keypath_account.to_vec(),
+                    xpub: Some(crate::keystore::get_xpub(keypath_account).unwrap().into()),
+                },
+                pb::KeyOriginInfo {
+                    root_fingerprint: vec![],
+                    keypath: vec![],
+                    xpub: Some(parse_xpub("xpub6Eu7xJRyXRCi4eLYhJPnfZVjgAQtM7qFaEZwUhvgxGf4enEZMxevGzWvZTawCj9USP2MFTEhKQAwnqHwoaPHetTLqGuvq5r5uaLKyGx5QDZ").unwrap()),
+                },
+            ],
+        };
+
+        // Register policy.
+        let policy_hash = super::super::policies::get_hash(pb::BtcCoin::Tbtc, &policy).unwrap();
+        bitbox02::memory::multisig_set_by_hash(&policy_hash, "test policy account name").unwrap();
+
+        assert_eq!(
+            block_on(process(
+                &transaction
+                    .borrow()
+                    .init_request_policy(policy, wrong_keypath_account)
+            )),
+            Err(Error::InvalidInput)
+        );
+    }
+
+    /// Avoid change keypaths with a too high address index.
+    #[test]
+    fn test_policy_wrong_change_keypath() {
+        let transaction = alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new_policy()));
+        transaction.borrow_mut().outputs[0].keypath[5] = 10000; // Too high change address index.
+        mock_host_responder(transaction.clone());
+
+        static mut UI_COUNTER: u32 = 0;
+        mock_default_ui();
+
+        mock_unlocked_using_mnemonic(
+            "sudden tenant fault inject concert weather maid people chunk youth stumble grit",
+            "",
+        );
+        // For the policy registration below.
+        mock_memory();
+
+        let keypath_account = &[48 + HARDENED, 1 + HARDENED, 0 + HARDENED, 3 + HARDENED];
+
+        let policy = pb::btc_script_config::Policy {
+            policy: "wsh(multi(2,@0/**,@1/**))".into(),
+            keys: vec![
+                pb::KeyOriginInfo {
+                    root_fingerprint: crate::keystore::root_fingerprint().unwrap(),
+                    keypath: keypath_account.to_vec(),
+                    xpub: Some(crate::keystore::get_xpub(keypath_account).unwrap().into()),
+                },
+                pb::KeyOriginInfo {
+                    root_fingerprint: vec![],
+                    keypath: vec![],
+                    xpub: Some(parse_xpub("xpub6Eu7xJRyXRCi4eLYhJPnfZVjgAQtM7qFaEZwUhvgxGf4enEZMxevGzWvZTawCj9USP2MFTEhKQAwnqHwoaPHetTLqGuvq5r5uaLKyGx5QDZ").unwrap()),
+                },
+            ],
+        };
+
+        // Register policy.
+        let policy_hash = super::super::policies::get_hash(pb::BtcCoin::Tbtc, &policy).unwrap();
+        bitbox02::memory::multisig_set_by_hash(&policy_hash, "test policy account name").unwrap();
+
+        assert_eq!(
+            block_on(process(
+                &transaction
+                    .borrow()
+                    .init_request_policy(policy, keypath_account)
+            )),
+            Err(Error::InvalidInput)
+        );
     }
 }

--- a/src/rust/bitbox02-rust/src/shiftcrypto.bitbox02.rs
+++ b/src/rust/bitbox02-rust/src/shiftcrypto.bitbox02.rs
@@ -621,6 +621,7 @@ pub struct BtcScriptConfigRegistration {
     pub coin: i32,
     #[prost(message, optional, tag = "2")]
     pub script_config: ::core::option::Option<BtcScriptConfig>,
+    /// Unused for policy registrations.
     #[prost(uint32, repeated, tag = "3")]
     pub keypath: ::prost::alloc::vec::Vec<u32>,
 }

--- a/src/rust/util/src/bip32.rs
+++ b/src/rust/util/src/bip32.rs
@@ -18,10 +18,8 @@ extern crate alloc;
 use alloc::string::String;
 use alloc::vec::Vec;
 
-/// Turn a keypath represented as a list of u32 to a string, e.g. "m/84'/0'/0'". Hardened elements
-/// are bigger or equal to `HARDENED`
-pub fn to_string(keypath: &[u32]) -> String {
-    let s = keypath
+pub fn to_string_no_prefix(keypath: &[u32]) -> String {
+    keypath
         .iter()
         .map(|&el| {
             if el >= HARDENED {
@@ -31,9 +29,13 @@ pub fn to_string(keypath: &[u32]) -> String {
             }
         })
         .collect::<Vec<_>>()
-        .join("/");
-    // Prepend "m/".
-    format!("m/{}", s)
+        .join("/")
+}
+
+/// Turn a keypath represented as a list of u32 to a string, e.g. "m/84'/0'/0'". Hardened elements
+/// are bigger or equal to `HARDENED`
+pub fn to_string(keypath: &[u32]) -> String {
+    format!("m/{}", to_string_no_prefix(keypath))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
There is a example CLI that works with this PR which:

- creates a miniscript policy
- registers it on the BB02
- generates a receive address
- signs a tx
- verifies that all steps are correct

https://github.com/digitalbitbox/bitbox02-api-go/pull/82

Run with `go run cmd/miniscript/main.go`.

The first commit here is the same as https://github.com/digitalbitbox/bitbox02-firmware/pull/1087