### PR TITLE
bitcoin/policy: fix btc formatting in test

### DIFF
--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin/signtx.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin/signtx.rs
@@ -2857,7 +2857,7 @@ mod tests {
                             address,
                             "tb1qtxyqynfxwsk8f5gu8v5g8e6hs3njtglkywhvyztk6v8znvx5kddsmhuve2"
                         );
-                        assert_eq!(amount, "0.0009 TBTC");
+                        assert_eq!(amount, "0.00090000 TBTC");
                     }
                     _ => panic!("unexpected UI dialog"),
                 }


### PR DESCRIPTION
Fixes btc formatting in a policy unit test 