### PR TITLE
eth: allow signing transactions with empty data and 0 value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ customers cannot upgrade their bootloader, its changes are recorded separately.
 - Allow exporting the xpub at any keypath after user confirmation
 - Support for Miniscript wallet policies of the form `wsh(<miniscript expression>)`
 - Updated BTC/LTC amount formatting to display the trailing zeroes
+- Allow ETH transactions with empty data + zero value
 
 ### 9.14.1
 - Improved security: keep seed encrypted in RAM

--- a/src/rust/bitbox02-rust/src/hww/api/ethereum/sign.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/ethereum/sign.rs
@@ -128,11 +128,6 @@ async fn verify_standard_transaction(
     request: &pb::EthSignRequest,
     params: &Params,
 ) -> Result<(), Error> {
-    if request.data.is_empty() && request.value.is_empty() {
-        // Must transfer non-zero value, unless there is data (contract invocation).
-        return Err(Error::InvalidInput);
-    }
-
     let recipient = parse_recipient(&request.recipient)?;
 
     if !request.data.is_empty() {


### PR DESCRIPTION
This is especially useful for signing mock transactions on all supported mainnets and testnets on different EVM networks, such as testing WalletConnect integration