### PR TITLE
rust/bitbox02-rust: remove arrayvec dep

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -98,7 +98,6 @@ dependencies = [
 name = "bitbox02-rust"
 version = "0.1.0"
 dependencies = [
- "arrayvec",
  "async-recursion",
  "bech32",
  "binascii",

--- a/src/rust/bitbox02-rust/Cargo.toml
+++ b/src/rust/bitbox02-rust/Cargo.toml
@@ -51,12 +51,6 @@ hmac = "0.11.0"
 miniscript = { version = "10.0.0", default-features = false, features = ["no-std"] }
 bitcoin = { version = "0.30.0", default-features = false, features = ["no-std"] }
 
-# For stack allocated strings
-[dependencies.arrayvec]
-version  = "0.5.1"
-# Disable the "std" feature
-default-features = false
-
 [dependencies.prost]
 # keep version in sync with tools/prost-build/Cargo.toml.
 version = "0.11.5"

--- a/src/rust/bitbox02-rust/src/general/screen.rs
+++ b/src/rust/bitbox02-rust/src/general/screen.rs
@@ -37,10 +37,8 @@ pub fn print_debug_internal(duration: Duration, msg: &str) {
 #[macro_export]
 macro_rules! print_debug {
     ($duration:expr, $($arg:tt)*) => ({
-        use core::fmt::Write;
+        extern crate alloc;
         let duration = core::time::Duration::from_millis($duration);
-        let mut buf = $crate::arrayvec::ArrayString::<[_; 256]>::new();
-        let _ = write!(buf, $($arg)*);
-        $crate::general::screen::print_debug_internal(duration, &buf);
+        $crate::general::screen::print_debug_internal(duration, &alloc::format!($($arg)*));
     })
 }

--- a/src/rust/bitbox02-rust/src/lib.rs
+++ b/src/rust/bitbox02-rust/src/lib.rs
@@ -46,9 +46,6 @@ extern crate alloc;
 #[macro_use]
 extern crate lazy_static;
 
-// reexport arrayvec because it is used in our macro "print_debug"
-pub extern crate arrayvec;
-
 #[cfg(test)]
 mod test {
     use super::*;


### PR DESCRIPTION
Only used in one case where a heap allocated string will do.