### PR TITLE
bitcoin/signtx: allow non-change internal outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ customers cannot upgrade their bootloader, its changes are recorded separately.
 - Allow exporting the xpub at any keypath after user confirmation
 - Support for Miniscript wallet policies of the form `wsh(<miniscript expression>)`
 - Updated BTC/LTC amount formatting to display the trailing zeroes
+- Bitcoin: allow marking non-change transaction outputs as internal
 - Allow ETH transactions with empty data + zero value
 
 ### 9.14.1

--- a/py/send_message.py
+++ b/py/send_message.py
@@ -513,6 +513,41 @@ class SendMessage:
         for input_index, sig in sigs:
             print("Signature for input {}: {}".format(input_index, sig.hex()))
 
+    def _sign_btc_send_to_self(
+        self,
+        format_unit: "bitbox02.btc.BTCSignInitRequest.FormatUnit.V" = bitbox02.btc.BTCSignInitRequest.FormatUnit.DEFAULT,
+    ) -> None:
+        # pylint: disable=no-member
+        bip44_account: int = 0 + HARDENED
+        inputs, outputs = _btc_demo_inputs_outputs(bip44_account)
+        outputs[1] = bitbox02.BTCOutputInternal(
+            keypath=[84 + HARDENED, 0 + HARDENED, bip44_account, 0, 0],
+            value=int(1e8 * 0.2),
+            script_config_index=0,
+        )
+        sigs = self._device.btc_sign(
+            bitbox02.btc.BTC,
+            [
+                bitbox02.btc.BTCScriptConfigWithKeypath(
+                    script_config=bitbox02.btc.BTCScriptConfig(
+                        simple_type=bitbox02.btc.BTCScriptConfig.P2WPKH
+                    ),
+                    keypath=[84 + HARDENED, 0 + HARDENED, bip44_account],
+                ),
+                bitbox02.btc.BTCScriptConfigWithKeypath(
+                    script_config=bitbox02.btc.BTCScriptConfig(
+                        simple_type=bitbox02.btc.BTCScriptConfig.P2WPKH_P2SH
+                    ),
+                    keypath=[49 + HARDENED, 0 + HARDENED, bip44_account],
+                ),
+            ],
+            inputs=inputs,
+            outputs=outputs,
+            format_unit=format_unit,
+        )
+        for input_index, sig in sigs:
+            print("Signature for input {}: {}".format(input_index, sig.hex()))
+
     def _sign_btc_high_fee(self) -> None:
         # pylint: disable=no-member
         bip44_account: int = 0 + HARDENED
@@ -784,6 +819,7 @@ class SendMessage:
                     format_unit=bitbox02.btc.BTCSignInitRequest.FormatUnit.SAT
                 ),
             ),
+            ("Send to self", self._sign_btc_send_to_self),
             ("High fee warning", self._sign_btc_high_fee),
             ("Multiple change outputs", self._sign_btc_multiple_changes),
             ("Locktime/RBF", self._sign_btc_locktime_rbf),


### PR DESCRIPTION
Outputs of a btc transaction can be marked internal ("ours") or
external.

Before now, internal ones were forced to be change outputs, and the
keypath was validated to be a change keypath.

This commit changes this so that the output can be marked internal and
not be a change output, but a regular output of the same account.

The reason for this change is that some wallets supply the keypath
information to PSBTs even for non-change outputs of the same
account. Until now, e.g. in HWI, we checked if the keypath was
available for an output, and stripped it if it was a change keypath,
so the BitBox02 would not error out. With miniscript, such a check
becomes very difficult, as the change keypath does not need to be on
`/1/*`, but could be anywhere, e.g. in a policy like
`wsh(pk/@0/<10;11>/*))`, where the change output is at `/11/*`.

