### PR TITLE
rust/miniscript: make deps optional, enable by features

### DIFF
--- a/src/rust/bitbox02-rust-c/Cargo.toml
+++ b/src/rust/bitbox02-rust-c/Cargo.toml
@@ -30,7 +30,7 @@ util = { path = "../util" }
 hex = { version = "0.4", default-features = false }
 sha2 = { version = "0.9.2", default-features = false, optional = true }
 sha3 = { version = "0.9.1", default-features = false, optional = true }
-bitcoin = { version = "0.30.0", default-features = false, features = ["no-std"] }
+bitcoin = { version = "0.30.0", default-features = false, features = ["no-std"], optional = true }
 
 [features]
 # Only one of the "target-" should be activated, which in turn defines/activates the dependent features.
@@ -43,9 +43,24 @@ target-bootloader-btc-development = ["bootloader", "platform-bitbox02"]
 target-bootloader-btc-production = ["bootloader", "platform-bitbox02"]
 target-firmware = ["firmware", "platform-bitbox02", "app-bitcoin", "app-litecoin", "app-ethereum", "app-u2f", "app-cardano"]
 target-firmware-btc = ["firmware", "platform-bitbox02", "app-bitcoin"]
-target-factory-setup = ["firmware", "platform-bitbox02"]
+target-factory-setup = [
+  # enable these features in dependencies
+  # enable the bitcoin dep as workaround, because the bitbox02-rust::bip32 crate etc. are not
+  # currently needed in the factorysetup, but not explicitly excluded from compilation.
+  "bitbox02-rust/bitcoin",
+  # enable these features
+  "firmware",
+  "platform-bitbox02",
+]
 # add Rust features which are called in the C unit tests (currently there is only one target for C tests).
-target-c-unit-tests = ["app-bitcoin", "app-ethereum", "firmware"]
+target-c-unit-tests = [
+  # enable this dependency
+  "bitcoin", # for rust_base58_encode_check()
+  # enable these features
+  "app-bitcoin",
+  "app-ethereum",
+  "firmware"
+]
 
 platform-bitbox02 = []
 

--- a/src/rust/bitbox02-rust-c/src/util.rs
+++ b/src/rust/bitbox02-rust-c/src/util.rs
@@ -119,6 +119,7 @@ pub unsafe extern "C" fn rust_util_bytes_mut(buf: *mut c_uchar, len: usize) -> B
 ///
 /// #Safety
 /// buf and out must not be NULL and point to valid memory areas.
+#[cfg(feature = "bitcoin")]
 #[no_mangle]
 pub unsafe extern "C" fn rust_base58_encode_check(buf: Bytes, mut out: BytesMut) -> bool {
     if buf.len == 0 {

--- a/src/rust/bitbox02-rust/Cargo.toml
+++ b/src/rust/bitbox02-rust/Cargo.toml
@@ -47,8 +47,8 @@ lazy_static = { version = "1.4.0", optional = true }
 async-recursion = "1.0.4"
 hmac = "0.11.0"
 
-miniscript = { version = "10.0.0", default-features = false, features = ["no-std"] }
-bitcoin = { version = "0.30.0", default-features = false, features = ["no-std"] }
+miniscript = { version = "10.0.0", default-features = false, features = ["no-std"], optional = true }
+bitcoin = { version = "0.30.0", default-features = false, features = ["no-std"], optional = true }
 
 [dependencies.prost]
 # keep version in sync with tools/prost-build/Cargo.toml.
@@ -75,6 +75,8 @@ app-ethereum = [
 app-bitcoin = [
   # enable these dependencies
   "bech32",
+  "miniscript",
+  "bitcoin",
   # enable this feature in the deps
   "bitbox02/app-bitcoin",
 ]

--- a/src/rust/bitbox02-rust/src/lib.rs
+++ b/src/rust/bitbox02-rust/src/lib.rs
@@ -36,6 +36,7 @@ pub mod keystore;
 mod version;
 mod waker_fn;
 pub mod workflow;
+#[cfg(any(feature = "app-bitcoin", feature = "app-litecoin"))]
 mod xpubcache;
 
 // for `format!`


### PR DESCRIPTION
The bitcoin/miniscript deps don't need to be compiled for all targets.

xpubcache was marked as unused in a warning when compiling
factory-setup, so we guard this also by the features only enabled in
the firmware editions.

