### PR TITLE
update from C99 to C11

### DIFF
--- a/.ci/check-tidy
+++ b/.ci/check-tidy
@@ -55,7 +55,6 @@ for dir in build build-build; do
 	fi
 
 	echo "Checking $(echo ${SOURCES} | wc -w) files with clang-tidy"
-
 	# The list of tidy checks must stay in sync with scripts/tidy
-	${CLANGTIDY} -quiet -p ${dir} -checks=-*,clang-analyzer-*,-clang-analyzer-cplusplus*,bugprone-*,performance-*,portability-*,readability-*,-readability-braces-around-statements,-readability-magic-numbers,-readability-isolate-declaration,-readability-identifier-length,-readability-function-cognitive-complexity,-bugprone-reserved-identifier,-bugprone-easily-swappable-parameters,-bugprone-narrowing-conversions,-performance-no-int-to-ptr -warnings-as-errors=* -header-filter '.*' ${SOURCES}
+	${CLANGTIDY} -quiet -p ${dir} -checks=-*,clang-analyzer-*,-clang-analyzer-cplusplus*,bugprone-*,performance-*,portability-*,readability-*,-readability-braces-around-statements,-readability-magic-numbers,-readability-isolate-declaration,-readability-identifier-length,-readability-function-cognitive-complexity,-bugprone-reserved-identifier,-bugprone-easily-swappable-parameters,-bugprone-narrowing-conversions,-performance-no-int-to-ptr,-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling -warnings-as-errors=* -header-filter '.*' ${SOURCES}
 done

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,7 +213,7 @@ configure_file(src/bootloader/bootloader_version.h.in src/bootloader/bootloader_
 #-----------------------------------------------------------------------------
 # Set the default compiler options (Only set global options that truly are necessary for all files)
 
-string(APPEND CMAKE_C_FLAGS " -std=c99 -pipe")
+string(APPEND CMAKE_C_FLAGS " -std=c11 -pipe")
 if(CMAKE_CROSSCOMPILING)
   set(CMAKE_C_FLAGS "\
     ${CMAKE_C_FLAGS} -mcpu=cortex-m4 -mthumb -mlong-calls \

--- a/src/bootloader/bootloader.c
+++ b/src/bootloader/bootloader.c
@@ -36,6 +36,8 @@
 #include <usb/usb_processing.h>
 #include <util.h>
 
+#include <assert.h>
+
 #define BOOT_OP_LEN 2u // 1 byte op code and 1 byte parameter
 #define BOOTLOADER_CMD (HID_VENDOR_FIRST + 0x03) // Hardware wallet command
 
@@ -129,14 +131,7 @@ typedef union {
 
 #pragma GCC diagnostic pop
 // Be sure to not overflow boot data area
-#if (                                                                            \
-    10 + /* hardawre_version + is_initialized + pad + signing_pubkeys_version */ \
-        BOOT_PUBKEY_LEN * BOOT_NUM_FIRMWARE_SIGNING_KEYS +                       \
-        BOOT_SIG_LEN * BOOT_NUM_ROOT_SIGNING_KEYS +                              \
-        BOOT_SIG_LEN * BOOT_NUM_FIRMWARE_SIGNING_KEYS + 4 /* firware_version */  \
-    > FLASH_BOOTDATA_LEN)
-#error "incompatible bootloader data macro"
-#endif
+static_assert(sizeof(((boot_data_t*)0)->fields) <= FLASH_BOOTDATA_LEN, "boot_data_t too large");
 // Be sure signing pubkey data fits within a single chunk
 #if (                                                                               \
     1 + 4 + /* op code + signing_pubkeys_version */                                 \

--- a/src/memory/memory.c
+++ b/src/memory/memory.c
@@ -32,6 +32,8 @@
 #include <mock_memory.h>
 #endif
 
+#include <assert.h>
+
 /********* Definitions and read/write helper functions ****************/
 
 // Documentation of all appData chunks and their contents.  A chunk is defined as
@@ -75,6 +77,8 @@ typedef union {
     uint8_t bytes[CHUNK_SIZE];
 } chunk_0_t;
 
+static_assert(sizeof(((chunk_0_t*)0)->fields) <= (size_t)CHUNK_SIZE, "chunk too large");
+
 // CHUNK_1: Firmware system data
 #define CHUNK_1 (1)
 typedef union {
@@ -94,6 +98,8 @@ typedef union {
     uint8_t bytes[CHUNK_SIZE];
 } chunk_1_t;
 
+static_assert(sizeof(((chunk_1_t*)0)->fields) <= (size_t)CHUNK_SIZE, "chunk too large");
+
 typedef struct __attribute__((__packed__)) {
     // version fixed at 0xFF for now - can be repurposed to turn this struct into an union to
     // support other types of data.
@@ -111,6 +117,9 @@ typedef union {
     } fields;
     uint8_t bytes[CHUNK_SIZE];
 } chunk_2_t;
+
+static_assert(sizeof(((chunk_2_t*)0)->fields) <= (size_t)CHUNK_SIZE, "chunk too large");
+
 #pragma GCC diagnostic pop
 
 #define BITMASK_SEEDED ((uint8_t)(1u << 0u))
@@ -119,7 +128,7 @@ typedef union {
 
 static void _clean_chunk(uint8_t** chunk_bytes)
 {
-    util_zero(*chunk_bytes, CHUNK_SIZE);
+    util_zero(*chunk_bytes, (size_t)CHUNK_SIZE);
 }
 
 #define CLEANUP_CHUNK(var)                                                                    \
@@ -311,7 +320,7 @@ bool memory_cleanup_smarteeprom(void)
 {
     // Erase all SmartEEPROM data chunks.
     for (size_t i = 0; i < SMARTEEPROM_ALLOCATED_BLOCKS; ++i) {
-        uint32_t w_offset = i * CHUNK_SIZE;
+        uint32_t w_offset = i * (size_t)CHUNK_SIZE;
         if (!_write_to_address(FLASH_SMARTEEPROM_START, w_offset, NULL)) {
             return false;
         }


### PR DESCRIPTION
This change does not modify the resulting images at all, the hashes stay the same. It allows however to use C11 features in future commits, such as static
asserts (https://en.cppreference.com/w/c/language/_Static_assert), which can help improve some compile time checks.