### PR TITLE
scripts/format: exclude rust vendor folder

### DIFF
--- a/scripts/format
+++ b/scripts/format
@@ -18,6 +18,7 @@ command -v ${CLANGFORMAT} >/dev/null 2>&1 || { echo >&2 "${CLANGFORMAT} is missi
 FILES=$(find src/ test/ \
 	\( \
 		-path src/ui/fonts -o \
+		-path src/rust/vendor -o \
 		-name "ugui*" \
 	\) -prune -o \( -name "*.c" -o -name "*.h" \) -print)
 


### PR DESCRIPTION
We don't want to format C code found in the the rust vendor folder, which can contain C code (e.g. secp256k1).

Similar to 26dae596763b01b0ed22d15b6231371d320eae10.