### PR TITLE
disable sceensaver on confirm screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ customers cannot upgrade their bootloader, its changes are recorded separately.
 - Updated BTC/LTC amount formatting to display the trailing zeroes
 - Bitcoin: allow marking non-change transaction outputs as internal
 - Allow ETH transactions with empty data + zero value
+- Disable screensaver when displaying a receive address, confirming a transaction, and other interactive actions
 
 ### 9.14.1
 - Improved security: keep seed encrypted in RAM

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -346,6 +346,8 @@ add_custom_target(rust-bindgen
     --allowlist-function ui_screen_stack_push
     --allowlist-function ui_screen_stack_pop
     --allowlist-function ui_screen_stack_pop_all
+    --allowlist-function screen_saver_disable
+    --allowlist-function screen_saver_enable
     --allowlist-function screen_process
     --allowlist-function label_create
     --allowlist-function confirm_create

--- a/src/rust/bitbox02-rust/src/bb02_async.rs
+++ b/src/rust/bitbox02-rust/src/bb02_async.rs
@@ -44,6 +44,14 @@ impl<O> core::future::Future for AsyncOption<'_, O> {
     }
 }
 
+/// Disables the screensaver while waiting for an option to contain a value. Afterwards, it returns that value
+pub async fn option_no_screensaver<O>(opt: &RefCell<Option<O>>) -> O {
+    bitbox02::screen_saver::screen_saver_disable();
+    let result = option(opt).await;
+    bitbox02::screen_saver::screen_saver_enable();
+    result
+}
+
 /// Waits for an option to contain a value and returns that value, leaving `None` in its place.
 /// E.g. `assert_eq!(option(&Some(42)).await, 42)`.
 pub fn option<O>(option: &RefCell<Option<O>>) -> AsyncOption<O> {

--- a/src/rust/bitbox02-rust/src/workflow/cancel.rs
+++ b/src/rust/bitbox02-rust/src/workflow/cancel.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::bb02_async::option;
+use crate::bb02_async::option_no_screensaver;
 use core::cell::RefCell;
 
 use super::confirm;
@@ -49,7 +49,7 @@ pub async fn with_cancel<R>(
 ) -> Result<R, Error> {
     component.screen_stack_push();
     loop {
-        let result = option(result_cell).await;
+        let result = option_no_screensaver(result_cell).await;
         if let Err(Error::Cancelled) = result {
             let params = confirm::Params {
                 title,

--- a/src/rust/bitbox02-rust/src/workflow/confirm.rs
+++ b/src/rust/bitbox02-rust/src/workflow/confirm.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::bb02_async::option;
+use crate::bb02_async::option_no_screensaver;
 
 pub use bitbox02::ui::{ConfirmParams as Params, Font};
 
@@ -31,5 +31,5 @@ pub async fn confirm(params: &Params<'_>) -> Result<(), UserAbort> {
         };
     });
     component.screen_stack_push();
-    option(&result).await
+    option_no_screensaver(&result).await
 }

--- a/src/rust/bitbox02-rust/src/workflow/menu.rs
+++ b/src/rust/bitbox02-rust/src/workflow/menu.rs
@@ -14,7 +14,7 @@
 
 pub use super::cancel::Error as CancelError;
 
-use crate::bb02_async::option;
+use crate::bb02_async::option_no_screensaver;
 
 use alloc::boxed::Box;
 use core::cell::RefCell;
@@ -34,5 +34,5 @@ pub async fn pick(words: &[&str], title: Option<&str>) -> Result<u8, CancelError
         })),
     });
     component.screen_stack_push();
-    option(&result).await
+    option_no_screensaver(&result).await
 }

--- a/src/rust/bitbox02-rust/src/workflow/status.rs
+++ b/src/rust/bitbox02-rust/src/workflow/status.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::bb02_async::option;
+use crate::bb02_async::option_no_screensaver;
 use core::cell::RefCell;
 
 pub async fn status(title: &str, status_success: bool) {
@@ -21,5 +21,5 @@ pub async fn status(title: &str, status_success: bool) {
         *result.borrow_mut() = Some(());
     });
     component.screen_stack_push();
-    option(&result).await
+    option_no_screensaver(&result).await
 }

--- a/src/rust/bitbox02-rust/src/workflow/transaction.rs
+++ b/src/rust/bitbox02-rust/src/workflow/transaction.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::bb02_async::option;
+use crate::bb02_async::option_no_screensaver;
 use core::cell::RefCell;
 
 use alloc::boxed::Box;
@@ -30,7 +30,7 @@ pub async fn verify_recipient(recipient: &str, amount: &str) -> Result<(), UserA
         }),
     );
     component.screen_stack_push();
-    option(&result).await
+    option_no_screensaver(&result).await
 }
 
 pub async fn verify_total_fee(
@@ -52,7 +52,7 @@ pub async fn verify_total_fee(
         }),
     );
     component.screen_stack_push();
-    option(&result).await?;
+    option_no_screensaver(&result).await?;
 
     if let Some(fee_percentage) = fee_percentage {
         match super::confirm::confirm(&super::confirm::Params {

--- a/src/rust/bitbox02-rust/src/workflow/trinary_choice.rs
+++ b/src/rust/bitbox02-rust/src/workflow/trinary_choice.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::bb02_async::option;
+use crate::bb02_async::option_no_screensaver;
 use core::cell::RefCell;
 
 use alloc::boxed::Box;
@@ -38,5 +38,5 @@ pub async fn choose(
         }),
     );
     component.screen_stack_push();
-    option(&result).await
+    option_no_screensaver(&result).await
 }

--- a/src/rust/bitbox02-sys/wrapper.h
+++ b/src/rust/bitbox02-sys/wrapper.h
@@ -44,6 +44,7 @@
 #include <ui/graphics/lock_animation.h>
 #include <ui/oled/oled.h>
 #include <ui/screen_process.h>
+#include <ui/screen_saver.h>
 #include <ui/screen_stack.h>
 #include <ui/ugui/ugui.h>
 #include <util.h>

--- a/src/rust/bitbox02/src/lib.rs
+++ b/src/rust/bitbox02/src/lib.rs
@@ -39,6 +39,7 @@ pub mod input;
 pub mod keystore;
 pub mod memory;
 pub mod random;
+pub mod screen_saver;
 pub mod sd;
 pub mod secp256k1;
 pub mod securechip;

--- a/src/rust/bitbox02/src/screen_saver.rs
+++ b/src/rust/bitbox02/src/screen_saver.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 Shift Crypto AG
+// Copyright 2023 Shift Crypto AG
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,14 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::bb02_async::option_no_screensaver;
-use core::cell::RefCell;
+/// calls the C function in screen_saver.c to enable the screen saver
+pub fn screen_saver_enable() {
+    unsafe {
+        bitbox02_sys::screen_saver_enable();
+    }
+}
 
-pub async fn sdcard(insert: bool) {
-    let result = RefCell::new(None);
-    let mut component = bitbox02::ui::sdcard_create(insert, || {
-        *result.borrow_mut() = Some(());
-    });
-    component.screen_stack_push();
-    option_no_screensaver(&result).await
+// calls the C function in screen_saver.c to disable the screen saver
+pub fn screen_saver_disable() {
+    unsafe {
+        bitbox02_sys::screen_saver_disable();
+    }
 }

--- a/src/ui/screen_saver.c
+++ b/src/ui/screen_saver.c
@@ -29,6 +29,7 @@
 
 static uint32_t _counter = 0;
 static bool _is_active = false;
+static bool _disabled = false;
 
 component_t* screen_saver_get(void)
 {
@@ -47,7 +48,7 @@ component_t* screen_saver_get(void)
 
 void screen_saver_process(void)
 {
-    if (!_is_active) {
+    if (!_is_active && !_disabled) {
         _counter++;
         if (_counter > ACTIVE_AFTER) {
             _is_active = true;
@@ -73,4 +74,15 @@ void screen_saver_reset(void)
         _is_active = false;
     }
     _counter = 0;
+}
+
+void screen_saver_disable(void)
+{
+    screen_saver_reset();
+    _disabled = true;
+}
+
+void screen_saver_enable(void)
+{
+    _disabled = false;
 }

--- a/src/ui/screen_saver.h
+++ b/src/ui/screen_saver.h
@@ -35,4 +35,14 @@ void screen_saver_process(void);
  */
 void screen_saver_reset(void);
 
+/**
+ * disables the screensaver until enabled with `screen_saver_enable`.
+ */
+void screen_saver_disable(void);
+
+/**
+ * re-enables the screensaver.
+ */
+void screen_saver_enable(void);
+
 #endif


### PR DESCRIPTION
resolves #856 

First of all, thank you for the dev device!

Tested the receive and send screens with this change, the screen saver doesn't appear there any more.
Since the receive screen uses the `confirm` Component, other confirms have the screen saver disabled as well.

Since I'm far away from C/C++, I'm not sure if the position of the enable / disable are correct there.

