### PR TITLE
bitcoin/signtx: stricter index checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ customers cannot upgrade their bootloader, its changes are recorded separately.
 ## Firmware
 
 ### [Unreleased]
+-
+
+### 9.15.0
+- Security bugfix: check index of an input's previous output to prevent the fee attack originally
+  reported by Saleem Rashid
 - Allow exporting the xpub at any keypath after user confirmation
 - Support for Miniscript wallet policies of the form `wsh(<miniscript expression>)`
 - Updated BTC/LTC amount formatting to display the trailing zeroes

--- a/py/send_message.py
+++ b/py/send_message.py
@@ -115,7 +115,7 @@ def _btc_demo_inputs_outputs(
             "prev_out_hash": binascii.unhexlify(
                 "c58b7e3f1200e0c0ec9a5e81e925baface2cc1d4715514f2d8205be2508b48ee"
             ),
-            "prev_out_index": 1,
+            "prev_out_index": 0,
             "prev_out_value": int(1e8 * 0.60005),
             "sequence": 0xFFFFFFFF,
             "keypath": [49 + HARDENED, 0 + HARDENED, bip44_account, 0, 1],


### PR DESCRIPTION
The send_message.py example had an invalid index which should have resulted in an InvalidInput error. This fixes the example and the check.