### PR TITLE
py/bitbox02: parse eth eip-712 uints as hex

### DIFF
--- a/py/bitbox02/bitbox02/bitbox02/bitbox02.py
+++ b/py/bitbox02/bitbox02/bitbox02/bitbox02.py
@@ -949,7 +949,10 @@ class BitBox02(BitBoxCommonAPI):
                 return value
             if typ.type == eth.ETHSignTypedMessageRequest.DataType.UINT:
                 if isinstance(value, str):
-                    value = int(value)
+                    if value[:2].lower() == "0x":
+                        value = int(value[2:], 16)
+                    else:
+                        value = int(value)
                 assert isinstance(value, int)
                 return value.to_bytes(typ.size, "big")
             if typ.type == eth.ETHSignTypedMessageRequest.DataType.INT:

--- a/py/send_message.py
+++ b/py/send_message.py
@@ -1036,7 +1036,8 @@ class SendMessage:
         ],
         "Person": [
             { "name": "name", "type": "string" },
-            { "name": "wallet", "type": "address" }
+            { "name": "wallet", "type": "address" },
+            { "name": "age", "type": "uint8" }
         ],
         "Mail": [
             { "name": "from", "type": "Person" },
@@ -1055,11 +1056,13 @@ class SendMessage:
     "message": {
         "from": {
             "name": "Cow",
-            "wallet": "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"
+            "wallet": "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826",
+            "age": 20
         },
         "to": {
             "name": "Bob",
-            "wallet": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+            "wallet": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+            "age": "0x1e"
         },
         "contents": "Hello, Bob!",
         "attachments": [{ "contents": "attachment1" }, { "contents": "attachment2" }]


### PR DESCRIPTION
Some apps use EIP-712 typed messages but provide uints in hex format instead of decimal format.