### PR TITLE
Dockerfile: fix installation of bindgen-cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -129,8 +129,8 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | CARGO_HOME=/opt/
 RUN rustup target add thumbv7em-none-eabi
 RUN rustup component add rustfmt
 RUN rustup component add clippy
-RUN CARGO_HOME=/opt/cargo cargo install cbindgen --version 0.24.3
-RUN CARGO_HOME=/opt/cargo cargo install bindgen-cli --version 0.65.1
+RUN CARGO_HOME=/opt/cargo cargo install cbindgen --version 0.24.3 --locked
+RUN CARGO_HOME=/opt/cargo cargo install bindgen-cli --version 0.65.1 --locked
 
 COPY tools/prost-build-proto prost-build-proto
 RUN CARGO_HOME=/opt/cargo cargo install --path prost-build-proto --locked


### PR DESCRIPTION
Errored with

```
error: failed to compile `bindgen-cli v0.65.1`, intermediate artifacts can be found at `/tmp/cargo-installmxLBVh`

Caused by:
  package `clap_lex v0.5.1` cannot be built because it requires rustc 1.70.0 or newer, while the currently active rustc version is 1.69.0
  Try re-running cargo install with `--locked`
Error: error building at STEP "RUN CARGO_HOME=/opt/cargo cargo install bindgen-cli --version 0.65.1": error while running runtime: exit status 101
```

We do the same fix for cbindgen so that deps don't update unexpectedly.