### PR TITLE
releases/build.sh: apply patch to fix reproducible build for v9.15.0

### DIFF
--- a/releases/build.sh
+++ b/releases/build.sh
@@ -18,8 +18,27 @@ cd temp;
 # work.
 git fetch --tags;
 
+# For v9.15.0, the reproducible build using this script failed with this error:
+# ```
+# error: failed to compile `bindgen-cli v0.65.1`, intermediate artifacts can be found at `/tmp/cargo-installmxLBVh`
+#
+# Caused by:
+#   package `clap_lex v0.5.1` cannot be built because it requires rustc 1.70.0 or newer, while the currently active rustc version is 1.69.0
+#   Try re-running cargo install with `--locked`
+# Error: error building at STEP "RUN CARGO_HOME=/opt/cargo cargo install bindgen-cli --version 0.65.1": error while running runtime: exit status 101
+# ```
+# The following patches the Dockerfile to fix the build accordingly.
+# Note: the same patch is likely necessary for previous versions as well. Apply the below patch as needed.
+if [[ "$1" == "firmware-btc-only/v9.15.0" || "$1" == "firmware/v9.15.0" ]]; then
+  sed -i 's/RUN CARGO_HOME=\/opt\/cargo cargo install bindgen-cli --version 0.65.1/RUN CARGO_HOME=\/opt\/cargo cargo install bindgen-cli --version 0.65.1 --locked/' Dockerfile
+fi
+
+
 # Build the Docker image (this can take a while):
 docker build --pull --force-rm --no-cache -t bitbox02-firmware .
+
+# Revert the above local patch to the Dockerfile again to have a clean state.
+git checkout -- Dockerfile
 
 # Build the firmware.
 #


### PR DESCRIPTION
See the diff for the exact issue that is solved.

The patch is in build.sh so that the documented way (see ./releases/README.md) of reproducing the firmware continues to work. The change is small and well-documented and only applies to v9.15.0, so build.sh continues to be easy to audit.