### PR TITLE
(changelog): move screensaver change to unreleased section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ customers cannot upgrade their bootloader, its changes are recorded separately.
 ## Firmware
 
 ### [Unreleased]
--
+- Disable screensaver when displaying a receive address, confirming a transaction, and other interactive actions
 
 ### 9.15.0
 - Security bugfix: check index of an input's previous output to prevent the fee attack originally
@@ -17,7 +17,6 @@ customers cannot upgrade their bootloader, its changes are recorded separately.
 - Updated BTC/LTC amount formatting to display the trailing zeroes
 - Bitcoin: allow marking non-change transaction outputs as internal
 - Allow ETH transactions with empty data + zero value
-- Disable screensaver when displaying a receive address, confirming a transaction, and other interactive actions
 
 ### 9.14.1
 - Improved security: keep seed encrypted in RAM


### PR DESCRIPTION
Accidentally added the screen saver change to 9.15.0