### PR TITLE
messages: add backticks to proto docstring

### DIFF
--- a/messages/btc.proto
+++ b/messages/btc.proto
@@ -42,7 +42,7 @@ message BTCScriptConfig {
     }
 
     uint32 threshold = 1;
-    // xpubs are acount-level xpubs. Addresses are going to be derived from it using: m/<change>/<receive>.
+    // xpubs are acount-level xpubs. Addresses are going to be derived from it using: `m/<change>/<receive>`.
     // The number of xpubs defines the number of cosigners.
     repeated XPub xpubs = 2;
     // Index to the xpub of our keystore in xpubs. The keypath to it is provided via


### PR DESCRIPTION
These docs make their way into generated code in downstream libs like bitbox-api-rs, where these end up in Rust code interpreted as markdown. `<..>` are then interpreted as illegal/unclosed tags.