### PR TITLE
show mnemonic: Disclaimer before recovery words

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ customers cannot upgrade their bootloader, its changes are recorded separately.
 ### [Unreleased]
 - Disable screensaver when displaying a receive address, confirming a transaction, and other interactive actions
 - Add Sepolia testnet for Ethereum
+- Added a disclaimer screen before the recovery words are displayed
 
 ### 9.15.0
 - Security bugfix: check index of an input's previous output to prevent the fee attack originally

--- a/src/rust/bitbox02-rust/src/hww/api/show_mnemonic.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/show_mnemonic.rs
@@ -78,6 +78,14 @@ pub async fn process() -> Result<Response, Error> {
     let mnemonic_sentence = keystore::get_bip39_mnemonic()?;
 
     confirm::confirm(&confirm::Params {
+        title: "Warning",
+        body: "DO NOT share your\nrecovery words with\nanyone!",
+        accept_is_nextarrow: true,
+        ..Default::default()
+    })
+    .await?;
+
+    confirm::confirm(&confirm::Params {
         title: "Recovery\nwords",
         body: "Please write down\nthe following words",
         accept_is_nextarrow: true,


### PR DESCRIPTION
When the user wanted to see their recovery words, the only requirement is unlocking the device and then confirming writing down the recovery words. However, because of the scammers around like in Telegram, we wanted to show an additional confirmation screen telling user not to share their recovery words with anyone. Now it is implemented as another step before showing the words and the user has to accept this step also.