### PR TITLE
bitcoin: don't warn about "unusual" sequence numbers in tx inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ customers cannot upgrade their bootloader, its changes are recorded separately.
 - Added a disclaimer screen before the recovery words are displayed
 - Verifiable seed generation: when restoring from 12 or 18 recovery words, for the final word, restrict input to the valid candidate words which result in a valid checksum.
   For 24 words, this feature was already introduced in 9.4.0.
-
+- Bitcoin: don't warn about "unusual" sequence numbers in transactions anymore
 
 ### 9.15.0
 - Security bugfix: check index of an input's previous output to prevent the fee attack originally


### PR DESCRIPTION
With support for wallet policies (miniscript), we officially support timelocks, so the comment does not apply anymore.

Furthermore, one warning per input is too much of a UX burden if a user has a transaction with many inputs.