### PR TITLE
rust: add c-unit-testing feature

### DIFF
--- a/src/rust/bitbox02-rust-c/Cargo.toml
+++ b/src/rust/bitbox02-rust-c/Cargo.toml
@@ -59,7 +59,8 @@ target-c-unit-tests = [
   # enable these features
   "app-bitcoin",
   "app-ethereum",
-  "firmware"
+  "firmware",
+  "c-unit-testing",
 ]
 
 platform-bitbox02 = []
@@ -67,8 +68,11 @@ platform-bitbox02 = []
 bootloader = []
 firmware = ["bitbox02-rust", "bitbox02", "bitbox02-noise", "sha2"]
 
-# Only to be enabled in unit tests.
+# Only to be enabled in Rust unit tests.
 testing = ["bitbox02-rust/testing", "bitbox02/testing"]
+
+# Active when the Rust code is compiled to be linked into the C unit tests and simulator.
+c-unit-testing = ["bitbox02-rust/c-unit-testing", "bitbox02/c-unit-testing"]
 
 app-ethereum = [
   # enable this dep

--- a/src/rust/bitbox02-rust/Cargo.toml
+++ b/src/rust/bitbox02-rust/Cargo.toml
@@ -116,3 +116,5 @@ testing = [
   # enable these features
   "bitbox02/testing"
 ]
+
+c-unit-testing = []

--- a/src/rust/bitbox02/Cargo.toml
+++ b/src/rust/bitbox02/Cargo.toml
@@ -29,6 +29,8 @@ lazy_static = { version = "1.4.0", optional = true }
 [features]
 # Only to be enabled in unit tests.
 testing = ["lazy_static"]
+# Active when the Rust code is compiled to be linked into the C unit tests and simulator.
+c-unit-testing = []
 
 app-ethereum = []
 app-bitcoin = []

--- a/src/rust/bitbox02/src/lib.rs
+++ b/src/rust/bitbox02/src/lib.rs
@@ -176,7 +176,7 @@ pub fn reboot() -> ! {
     panic!("reboot called")
 }
 
-#[cfg(feature = "testing")]
+#[cfg(any(feature = "testing", feature = "c-unit-testing"))]
 pub fn print_stdout(msg: &str) {
     unsafe {
         bitbox02_sys::printf(crate::util::str_to_cstr_vec(msg).unwrap().as_ptr());


### PR DESCRIPTION
The `testing` feature is enabled for *Rust* unit tests, but not for the Rust code when compiled to be linked to the *C* unit tests.

We want to add a simulator in the unit-test directory (as C unit tests are already standalone host binaries that link the full C/Rust firmware code), but need a way to change behavior for the simulator only. The `testing` flag is not enabled there as mentioned above.

We add a `c-unit-testing` feature that is active only in Rust code when linked to the C unit tests (including the simulator) for this purpose.

We wanted to simply enable `testing` there as well, but ran into compilation problems when compiling the Rust unit tests:

```
/usr/bin/ld:
.../build-build-rust-unit-tests/src/../lib/libbitbox_merged.a(bitbox02_rust_c-06ac99f37ae6bb45.bitbox02_rust_c.ff44fdfedc2996e0-cgu.0.rcgu.o):(.init_array.00099+0x0):
multiple definition of `std::sys::unix::args::imp::ARGV_INIT_ARRAY';
.../build-build-rust-unit-tests/src/rust/target/all-features/release/deps/bitbox02-5ad04c78e548693d.bitbox02.5d97720ccc25f2c4-cgu.0.rcgu.o:(.init_array.00099+0x0):
first defined here
```