### PR TITLE
Add support for optional sccache in build system

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -179,3 +179,12 @@ make coverage # or make -C build-build coverage
 ```sh
 make -C build-build coverage-lcovr
 ```
+
+### SCCache / CCache
+
+The build systems supports sccache/ccache, you just need to have it available in your path. You can
+install it into your dev container with the following commands:
+
+```
+docker exec -u 0 -it bitbox02-firmware-dev bash -c 'apt update && apt install -y libssl-dev && CARGO_HOME=/opt/cargo cargo install --locked sccache'
+```

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,14 @@ if(
   message(FATAL_ERROR "Invalid CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE}")
 endif()
 
+find_program(SCCACHE_PROGRAM sccache)
+find_program(CCACHE_PROGRAM ccache)
+if(SCCACHE_PROGRAM)
+  set(CMAKE_C_COMPILER_LAUNCHER "${SCCACHE_PROGRAM}")
+elseif(CCACHE_PROGRAM)
+  set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+endif()
+
 project(bitbox02 C)
 
 # nosys is set in arm.cmake so that `project(c)` above works. Remove it since it interferes with compile options
@@ -257,6 +265,7 @@ message(STATUS "Processor:              ${CMAKE_SYSTEM_PROCESSOR}")
 message(STATUS "             - Build -")
 message(STATUS "Compiler version:       ${CMAKE_C_COMPILER_ID} ${C_COMPILER_VERSION}")
 message(STATUS "Compiler:               ${CMAKE_C_COMPILER}")
+message(STATUS "Compiler cache:         ${CMAKE_C_COMPILER_LAUNCHER}")
 message(STATUS "Linker:                 ${CMAKE_LINKER}")
 message(STATUS "Archiver:               ${CMAKE_AR}")
 message(STATUS "Default CFLAGS:         ${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_${CMAKE_BUILD_TYPE}}")

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -2,7 +2,10 @@ include(ExternalProject)
 
 if(CMAKE_CROSSCOMPILING)
   set(CONFIGURE_FLAGS
-    --host=${CMAKE_SYSTEM_PROCESSOR}-none-eabi --build=${CMAKE_HOST_SYSTEM_PROCESSOR}-linux-gnu)
+    --host=${CMAKE_SYSTEM_PROCESSOR}-none-eabi
+    --build=${CMAKE_HOST_SYSTEM_PROCESSOR}-linux-gnu
+    "$<$<BOOL:${CMAKE_C_COMPILER_LAUNCHER}>:CC=${CMAKE_C_COMPILER_LAUNCHER} ${CMAKE_C_COMPILER}>"
+  )
 endif()
 
 # Remove parameters to make build identical to older build

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -508,6 +508,7 @@ foreach(type ${RUST_LIBS})
       CMAKE_CURRENT_BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR}
       RUSTFLAGS=${RUSTFLAGS}
       FIRMWARE_VERSION_SHORT=${FIRMWARE_VERSION}
+      $<$<BOOL:${SCCACHE_PROGRAM}>:RUSTC_WRAPPER=${SCCACHE_PROGRAM}>
       ${CARGO} build $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:-v> --features target-${type} --target-dir ${RUST_BINARY_DIR}/feature-${type} ${RUST_CARGO_FLAG} ${RUST_TARGET_ARCH_ARG}
     COMMAND
       ${CMAKE_COMMAND} -E copy_if_different ${lib} ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}/lib${type}_rust_c.a


### PR DESCRIPTION
sccache is a binary cache that wraps all calls to gcc/rustc and caches build output in `~/.cache`. This speeds up a build after `make clean` by about 3x. I choose not to put it in the dev dockerfile by default since caching might have unexpected side effects? But I put documentation in the build docs of how to install it.