### PR TITLE
simulator: print simulator msgs only in simulator, not in unit tests

### DIFF
--- a/src/rust/bitbox02-rust/src/workflow/confirm.rs
+++ b/src/rust/bitbox02-rust/src/workflow/confirm.rs
@@ -31,7 +31,5 @@ pub async fn confirm(params: &Params<'_>) -> Result<(), UserAbort> {
         };
     });
     component.screen_stack_push();
-    #[cfg(feature = "c-unit-testing")]
-    bitbox02::print_stdout(&format!("CONFIRM SCREEN START\nTITLE: {}\nBODY: {}\nCONFIRM SCREEN END\n", params.title, params.body));
     option_no_screensaver(&result).await
 }

--- a/src/rust/bitbox02-rust/src/workflow/status.rs
+++ b/src/rust/bitbox02-rust/src/workflow/status.rs
@@ -21,7 +21,5 @@ pub async fn status(title: &str, status_success: bool) {
         *result.borrow_mut() = Some(());
     });
     component.screen_stack_push();
-    #[cfg(feature = "c-unit-testing")]
-    bitbox02::print_stdout(&format!("STATUS SCREEN START\nTITLE: {}\nSTATUS SCREEN END\n", title));
     option_no_screensaver(&result).await
 }

--- a/src/rust/bitbox02-rust/src/workflow/trinary_input_string.rs
+++ b/src/rust/bitbox02-rust/src/workflow/trinary_input_string.rs
@@ -49,8 +49,6 @@ pub async fn enter(
         bitbox02::ui::trinary_input_string_set_input(&mut component, preset);
     }
     component.screen_stack_push();
-    #[cfg(feature = "c-unit-testing")]
-    bitbox02::print_stdout(&format!("ENTER SCREEN START\nTITLE: {}\nENTER SCREEN END\n", params.title));
     option(&result)
         .await
         .or(Err(super::cancel::Error::Cancelled))

--- a/src/rust/bitbox02/src/lib.rs
+++ b/src/rust/bitbox02/src/lib.rs
@@ -20,7 +20,14 @@
 #[macro_use]
 extern crate std;
 
+// allow unused as we use format!() only in some build configs (for
+// the simulator), but replicating the conditions under which it is
+// used here is not worth it.
+#[allow(unused_imports)]
+// for `format!`
+#[macro_use]
 extern crate alloc;
+
 use alloc::string::String;
 
 #[cfg(feature = "testing")]

--- a/src/rust/bitbox02/src/ui.rs
+++ b/src/rust/bitbox02/src/ui.rs
@@ -16,7 +16,10 @@
 mod types;
 
 #[cfg_attr(feature = "testing", path = "ui/ui_stub.rs")]
-#[cfg_attr(not(feature = "testing"), cfg_attr(feature = "c-unit-testing", path = "ui/ui_stub_c_unit_tests.rs"))]
+#[cfg_attr(
+    not(feature = "testing"),
+    cfg_attr(feature = "c-unit-testing", path = "ui/ui_stub_c_unit_tests.rs")
+)]
 // We don't actually use ui::ui anywhere, we re-export below.
 #[allow(clippy::module_inception)]
 mod ui;

--- a/src/rust/bitbox02/src/ui/ui_stub_c_unit_tests.rs
+++ b/src/rust/bitbox02/src/ui/ui_stub_c_unit_tests.rs
@@ -48,13 +48,18 @@ impl<'a> Drop for Component<'a> {
 }
 
 pub fn trinary_input_string_create<'a, F>(
-    _params: &TrinaryInputStringParams,
+    params: &TrinaryInputStringParams,
     mut confirm_callback: F,
     _cancel_callback: Option<ContinueCancelCb<'a>>,
 ) -> Component<'a>
 where
     F: FnMut(SafeInputString) + 'a,
 {
+    crate::print_stdout(&format!(
+        "ENTER SCREEN START\nTITLE: {}\nENTER SCREEN END\n",
+        params.title
+    ));
+
     confirm_callback(SafeInputString::new());
     Component {
         is_pushed: false,
@@ -62,10 +67,15 @@ where
     }
 }
 
-pub fn confirm_create<'a, F>(_params: &ConfirmParams, mut result_callback: F) -> Component<'a>
+pub fn confirm_create<'a, F>(params: &ConfirmParams, mut result_callback: F) -> Component<'a>
 where
     F: FnMut(bool) + 'a,
 {
+    crate::print_stdout(&format!(
+        "CONFIRM SCREEN START\nTITLE: {}\nBODY: {}\nCONFIRM SCREEN END\n",
+        params.title, params.body
+    ));
+
     result_callback(true);
     Component {
         is_pushed: false,
@@ -75,10 +85,14 @@ where
 
 pub fn screen_process() {}
 
-pub fn status_create<'a, F>(_text: &str, _status_success: bool, mut callback: F) -> Component<'a>
+pub fn status_create<'a, F>(text: &str, _status_success: bool, mut callback: F) -> Component<'a>
 where
     F: FnMut() + 'a,
 {
+    crate::print_stdout(&format!(
+        "STATUS SCREEN START\nTITLE: {}\nSTATUS SCREEN END\n",
+        text,
+    ));
     callback();
     Component {
         is_pushed: false,


### PR DESCRIPTION
The `c-unit-testing` is also active in Rust unit tests, so the simulator msgs were printed there. This commit moves the stdout prints to `ui_stub_c_unit_tests.rs`, which is only used in the simulator.