### PR TITLE
memory: persist attestation bootloader hash

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -298,6 +298,7 @@ add_custom_target(rust-bindgen
     --allowlist-function memory_is_seeded
     --allowlist-function memory_is_mnemonic_passphrase_enabled
     --allowlist-function memory_get_attestation_pubkey_and_certificate
+    --allowlist-function memory_get_attestation_bootloader_hash
     --allowlist-function memory_bootloader_hash
     --allowlist-function memory_get_noise_static_private_key
     --allowlist-function memory_check_noise_remote_static_pubkey

--- a/src/factorysetup.c
+++ b/src/factorysetup.c
@@ -147,6 +147,10 @@ static void _api_msg(const Packet* in_packet, Packet* out_packet, const size_t m
     switch (input[0]) {
     case OP_BOOTLOADER_HASH:
         memory_bootloader_hash(output + 2);
+        // This is the hash that will be used for the attestation, persist for later use.
+        if (!memory_set_attestation_bootloader_hash()) {
+            screen_print_debug("setting attestation bootloader hash failed", 0);
+        }
         out_len = 2 + 32;
         break;
     case OP_GENKEY: {

--- a/src/memory/memory.h
+++ b/src/memory/memory.h
@@ -147,6 +147,17 @@ void memory_get_authorization_key(uint8_t* key_out);
 void memory_get_encryption_key(uint8_t* key_out);
 
 /**
+ * Persists the current bootloader hash, which is part of the attestation sighash.
+ */
+USE_RESULT bool memory_set_attestation_bootloader_hash(void);
+
+/**
+ * Retreives the bootloader hash that is part of the attestation sighash.
+ * @param[out] hash_out must be 32 bytes and will contain the result.
+ */
+void memory_get_attestation_bootloader_hash(uint8_t* hash_out);
+
+/**
  * Persists the given attestation device pubkey.
  * @param[in] attestation_device_pubkey P256 NIST ECC pubkey (X and Y coordinates).
  * @return false if there was a write error or if the attestation setup was

--- a/src/rust/bitbox02-rust/src/attestation.rs
+++ b/src/rust/bitbox02-rust/src/attestation.rs
@@ -36,7 +36,7 @@ pub fn perform(host_challenge: [u8; 32]) -> Result<Data, ()> {
         &mut result.root_pubkey_identifier,
     )?;
     let hash: [u8; 32] = Sha256::digest(host_challenge).into();
-    bitbox02::memory::bootloader_hash(&mut result.bootloader_hash);
+    result.bootloader_hash = bitbox02::memory::get_attestation_bootloader_hash();
     bitbox02::securechip::attestation_sign(&hash, &mut result.challenge_signature)?;
     Ok(result)
 }

--- a/src/rust/bitbox02/src/memory.rs
+++ b/src/rust/bitbox02/src/memory.rs
@@ -65,6 +65,14 @@ pub fn is_mnemonic_passphrase_enabled() -> bool {
     unsafe { bitbox02_sys::memory_is_mnemonic_passphrase_enabled() }
 }
 
+pub fn get_attestation_bootloader_hash() -> [u8; 32] {
+    let mut hash = [0u8; 32];
+    unsafe {
+        bitbox02_sys::memory_get_attestation_bootloader_hash(hash.as_mut_ptr());
+    }
+    hash
+}
+
 pub fn get_attestation_pubkey_and_certificate(
     device_pubkey: &mut [u8; 64],
     certificate: &mut [u8; 64],
@@ -79,12 +87,6 @@ pub fn get_attestation_pubkey_and_certificate(
     } {
         true => Ok(()),
         false => Err(()),
-    }
-}
-
-pub fn bootloader_hash(out: &mut [u8; 32]) {
-    unsafe {
-        bitbox02_sys::memory_bootloader_hash(out.as_mut_ptr());
     }
 }
 
@@ -155,5 +157,16 @@ pub fn multisig_get_by_hash(hash: &[u8]) -> Option<String> {
                 .into(),
         ),
         false => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_attestation_bootloader_hash() {
+        let expected: [u8; 32] = *b"\x71\x3d\xf0\xd5\x8c\x71\x7d\x40\x31\x78\x7c\xdc\x8f\xa3\x5b\x90\x25\x82\xbe\x6a\xb6\xa2\x2e\x09\xde\x44\x77\xd3\x0e\x22\x30\xfc";
+        assert_eq!(get_attestation_bootloader_hash(), expected);
     }
 }

--- a/test/simulator/framework/mock_memory.c
+++ b/test/simulator/framework/mock_memory.c
@@ -51,24 +51,35 @@ static uint8_t* _get_memory(uint32_t base)
 bool memory_write_to_address_mock(uint32_t base, uint32_t addr, const uint8_t* chunk)
 {
     if (chunk == NULL) {
-        memset(_get_memory(base) + addr, 0xff, CHUNK_SIZE);
+        memset(_get_memory(base) + addr, 0xff, (size_t)CHUNK_SIZE);
     } else {
-        memcpy(_get_memory(base) + addr, chunk, CHUNK_SIZE);
+        memcpy(_get_memory(base) + addr, chunk, (size_t)CHUNK_SIZE);
     }
     return true;
 }
 
 bool memory_write_chunk_mock(uint32_t chunk_num, const uint8_t* chunk)
 {
-    return memory_write_to_address_mock(FLASH_APPDATA_START, chunk_num * CHUNK_SIZE, chunk);
+    return memory_write_to_address_mock(FLASH_APPDATA_START, chunk_num * (size_t)CHUNK_SIZE, chunk);
 }
 
 void memory_read_chunk_mock(uint32_t chunk_num, uint8_t* chunk_out)
 {
-    memcpy(chunk_out, _memory_app_data + chunk_num * CHUNK_SIZE, CHUNK_SIZE);
+    memcpy(chunk_out, _memory_app_data + chunk_num * (size_t)CHUNK_SIZE, (size_t)CHUNK_SIZE);
 }
 
 void memory_read_shared_bootdata_mock(uint8_t* chunk_out)
 {
-    memcpy(chunk_out, _memory_shared_data, FLASH_SHARED_DATA_LEN);
+    memcpy(chunk_out, _memory_shared_data, (size_t)FLASH_SHARED_DATA_LEN);
+}
+
+// Arbitrary value.
+static uint8_t _bootloader_hash[32] =
+    "\x71\x3d\xf0\xd5\x8c\x71\x7d\x40\x31\x78\x7c\xdc\x8f\xa3\x5b\x90\x25\x82\xbe\x6a\xb6\xa2\x2e"
+    "\x09\xde\x44\x77\xd3\x0e\x22\x30\xfc";
+
+void memory_bootloader_hash_mock(uint8_t* hash_out)
+{
+    // NOLINTNEXTLINE(bugprone-not-null-terminated-result)
+    memcpy(hash_out, _bootloader_hash, 32);
 }

--- a/test/unit-test/framework/includes/mock_memory.h
+++ b/test/unit-test/framework/includes/mock_memory.h
@@ -27,4 +27,6 @@ void memory_read_chunk_mock(uint32_t chunk_num, uint8_t* chunk_out);
 // Size: `FLASH_SHARED_DATA_LEN`.
 void memory_read_shared_bootdata_mock(uint8_t* chunk_out);
 void mock_memory_set_salt_root(const uint8_t* salt_root);
+void memory_bootloader_hash_mock(uint8_t* hash_out);
+void memory_set_bootloader_hash_mock(const uint8_t* mock_hash);
 #endif

--- a/test/unit-test/framework/mock_memory.c
+++ b/test/unit-test/framework/mock_memory.c
@@ -52,26 +52,26 @@ static uint8_t* _get_memory(uint32_t base)
 bool memory_write_to_address_mock(uint32_t base, uint32_t addr, const uint8_t* chunk)
 {
     if (chunk == NULL) {
-        memset(_get_memory(base) + addr, 0xff, CHUNK_SIZE);
+        memset(_get_memory(base) + addr, 0xff, (size_t)CHUNK_SIZE);
     } else {
-        memcpy(_get_memory(base) + addr, chunk, CHUNK_SIZE);
+        memcpy(_get_memory(base) + addr, chunk, (size_t)CHUNK_SIZE);
     }
     return true;
 }
 
 bool memory_write_chunk_mock(uint32_t chunk_num, const uint8_t* chunk)
 {
-    return memory_write_to_address_mock(FLASH_APPDATA_START, chunk_num * CHUNK_SIZE, chunk);
+    return memory_write_to_address_mock(FLASH_APPDATA_START, chunk_num * (size_t)CHUNK_SIZE, chunk);
 }
 
 void memory_read_chunk_mock(uint32_t chunk_num, uint8_t* chunk_out)
 {
-    memcpy(chunk_out, _memory_app_data + chunk_num * CHUNK_SIZE, CHUNK_SIZE);
+    memcpy(chunk_out, _memory_app_data + chunk_num * (size_t)CHUNK_SIZE, (size_t)CHUNK_SIZE);
 }
 
 void memory_read_shared_bootdata_mock(uint8_t* chunk_out)
 {
-    memcpy(chunk_out, _memory_shared_data, FLASH_SHARED_DATA_LEN);
+    memcpy(chunk_out, _memory_shared_data, (size_t)FLASH_SHARED_DATA_LEN);
 }
 
 bool __wrap_memory_is_initialized(void)
@@ -131,4 +131,20 @@ bool __wrap_memory_get_salt_root(uint8_t* salt_root_out)
 {
     memcpy(salt_root_out, _salt_root, 32);
     return true;
+}
+
+// Arbitrary value.
+static uint8_t _bootloader_hash[32] =
+    "\x71\x3d\xf0\xd5\x8c\x71\x7d\x40\x31\x78\x7c\xdc\x8f\xa3\x5b\x90\x25\x82\xbe\x6a\xb6\xa2\x2e"
+    "\x09\xde\x44\x77\xd3\x0e\x22\x30\xfc";
+
+void memory_bootloader_hash_mock(uint8_t* hash_out)
+{
+    memcpy(hash_out, _bootloader_hash, 32);
+}
+
+void memory_set_bootloader_hash_mock(const uint8_t* mock_hash)
+{
+    // NOLINTNEXTLINE(bugprone-not-null-terminated-result)
+    memcpy(_bootloader_hash, mock_hash, sizeof(_bootloader_hash));
 }

--- a/test/unit-test/test_memory.c
+++ b/test/unit-test/test_memory.c
@@ -114,8 +114,8 @@ static const memory_interface_functions_t _ifs = {
 
 static void _expect_reset(uint8_t* empty_chunk1, uint8_t* empty_chunk2)
 {
-    // Reset all
-    for (uint32_t write_calls = 0; write_calls < FLASH_APP_DATA_LEN / CHUNK_SIZE - 1;
+    // Reset all except first and last chunk.
+    for (uint32_t write_calls = 0; write_calls < FLASH_APP_DATA_LEN / CHUNK_SIZE - 2;
          write_calls++) {
         expect_value(__wrap_memory_write_chunk_mock, chunk_num, write_calls + 1);
         expect_value(__wrap_memory_write_chunk_mock, chunk, NULL);


### PR DESCRIPTION
And use it in the attestation check.

`bootloader_hash_set` is added just in case the memory is unexpectedly not `0xFF` everywhere (the default value for unused/erased memory).