### PR TITLE
simulator : build configuration update and multiple sequential client…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@
 
 .DEFAULT_GOAL := firmware
 SANITIZE ?= ON
+simulator: SANITIZE = OFF
 
 bootstrap:
 	git submodule update --init --recursive


### PR DESCRIPTION
… support

Since simulator and c unit tests use the same build script(build-build), sanitization options defined for c unit tests were also passed to simulator and this was causing more dependencies for simulator binary. Of course this contributes to more size. Simulator now has this sanitization options set to false to automatically avoid including them.

Another issue that was faced while implementing HWI integration was multiple client support. In HWI, one client could access to simulator for initialization and then disconnect, while newer clients could connect and directly test the functionalities of wallet API, assuming that the device is already initialized. Parallel handling of clients are still not supported, also not expected from HWI.