### PR TITLE
py/bitbox02: allow infering version/edition from OP_INFO

### DIFF
--- a/py/bitbox02/bitbox02/communication/bitbox_api_protocol.py
+++ b/py/bitbox02/bitbox02/communication/bitbox_api_protocol.py
@@ -526,24 +526,34 @@ class BitBoxCommonAPI:
 
     # pylint: disable=too-many-public-methods,too-many-arguments
     def __init__(
-        self, transport: TransportLayer, device_info: DeviceInfo, noise_config: BitBoxNoiseConfig
+        self,
+        transport: TransportLayer,
+        device_info: Optional[DeviceInfo],
+        noise_config: BitBoxNoiseConfig,
     ):
         """
         Can raise LibraryVersionOutdatedException. check_min_version() should be called following
         the instantiation.
+        If device_info is None, it is infered using the OP_INFO API call, available since
+        firmware version v5.0.0.
         """
         self.debug = False
-        serial_number = device_info["serial_number"]
 
-        if device_info["product_string"] == BITBOX02MULTI:
-            self.edition = BitBox02Edition.MULTI
-        elif device_info["product_string"] == BITBOX02BTC:
-            self.edition = BitBox02Edition.BTCONLY
+        if device_info is not None:
+            version = device_info["serial_number"]
+            if device_info["product_string"] == BITBOX02MULTI:
+                edition = BitBox02Edition.MULTI
+            elif device_info["product_string"] == BITBOX02BTC:
+                edition = BitBox02Edition.BTCONLY
+        else:
+            version, _, edition, _ = self.get_info(transport)
 
-        self.version = parse_device_version(serial_number)
-        if self.version is None:
+        self.edition = edition
+        try:
+            self.version = parse_device_version(version)
+        except:
             transport.close()
-            raise ValueError(f"Could not parse version from {serial_number}")
+            raise
 
         # Delete the prelease part, as it messes with the comparison (e.g. 3.0.0-pre < 3.0.0 is
         # True, but the 3.0.0-pre has already the same API breaking changes like 3.0.0...).

--- a/py/bitbox02/bitbox02/communication/devices.py
+++ b/py/bitbox02/bitbox02/communication/devices.py
@@ -157,9 +157,9 @@ def get_any_bitbox02_bootloader() -> DeviceInfo:
     return devices[0]
 
 
-def parse_device_version(serial_number: str) -> semver.VersionInfo:
-    match = re.search(r"v([0-9]+\.[0-9]+\.[0-9]+.*)", serial_number)
+def parse_device_version(version: str) -> semver.VersionInfo:
+    match = re.search(r"v([0-9]+\.[0-9]+\.[0-9]+.*)", version)
     if match is None:
-        raise Exception(f"Could not parse version string from serial_number: {serial_number}")
+        raise ValueError(f"Could not parse version string from string: {version}")
 
     return semver.VersionInfo.parse(match.group(1))

--- a/py/send_message.py
+++ b/py/send_message.py
@@ -1604,16 +1604,10 @@ def connect_to_simulator_bitbox(debug: bool) -> int:
             self.client_socket.close()
 
     simulator = Simulator()
-
-    device_info: devices.DeviceInfo = {
-        "serial_number": "v9.16.0",
-        "path": b"",
-        "product_string": "BitBox02BTC",
-    }
     noise_config = bitbox_api_protocol.BitBoxNoiseConfig()
     bitbox_connection = bitbox02.BitBox02(
         transport=u2fhid.U2FHid(simulator),
-        device_info=device_info,
+        device_info=None,
         noise_config=noise_config,
     )
     try:


### PR DESCRIPTION
For when no USB descriptor is available, where we normally get the info from. We need this now to connect to the simulator with the right params. OP_INFO is available since v5.0.0, and the created after that, so for the simulator this will always work.