### PR TITLE
rust: inherit deps from the workspace to keep versions in sync

### DIFF
--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -23,6 +23,15 @@ members = [
     "bitbox02-sys",
 ]
 
+[workspace.dependencies]
+bitcoin = { version = "0.31.0", default-features = false, features = ["no-std"] }
+hex = { version = "0.4", default-features = false, features = ["alloc"] }
+lazy_static = { version = "1.4.0" }
+num-bigint = { version = "0.4.3", default-features = false }
+sha2 = { version = "0.10.8", default-features = false }
+sha3 = { version = "0.10.8", default-features = false }
+zeroize = "1.6.0"
+
 [profile.release]
 # This only affects the .elf output. Debug info is stripped from the final .bin.
 # Paths to source code can still appear in the final bin, as they are part of the panic!() output.

--- a/src/rust/bitbox02-rust-c/Cargo.toml
+++ b/src/rust/bitbox02-rust-c/Cargo.toml
@@ -27,10 +27,10 @@ bitbox02-rust = { path = "../bitbox02-rust", optional = true }
 bitbox02 = { path = "../bitbox02", optional = true }
 bitbox02-noise = { path = "../bitbox02-noise", optional = true }
 util = { path = "../util" }
-hex = { version = "0.4", default-features = false }
-sha2 = { version = "0.10.8", default-features = false, optional = true }
-sha3 = { version = "0.10.8", default-features = false, optional = true }
-bitcoin = { version = "0.31.0", default-features = false, features = ["no-std"], optional = true }
+hex = { workspace = true }
+sha2 = { workspace = true, optional = true }
+sha3 = { workspace = true, optional = true }
+bitcoin = { workspace = true, optional = true }
 
 [features]
 # Only one of the "target-" should be activated, which in turn defines/activates the dependent features.

--- a/src/rust/bitbox02-rust/Cargo.toml
+++ b/src/rust/bitbox02-rust/Cargo.toml
@@ -30,12 +30,12 @@ bitbox02 = {path = "../bitbox02"}
 util = {path = "../util"}
 binascii = { version = "0.1.4", default-features = false, features = ["encode"] }
 bitbox02-noise = {path = "../bitbox02-noise"}
-hex = { version = "0.4", default-features = false, features = ["alloc"] }
-sha2 = { version = "0.10.8", default-features = false }
-sha3 = { version = "0.10.8", default-features = false, optional = true }
+hex = { workspace = true }
+sha2 = { workspace = true }
+sha3 = { workspace = true, optional = true }
 digest = "0.10.6"
-zeroize = "1.6.0"
-num-bigint = { version = "0.4.3", default-features = false, optional = true }
+zeroize = { workspace = true }
+num-bigint = { workspace = true, optional = true }
 num-traits = { version = "0.2", default-features = false, optional = true }
 # If you change this, also change src/rust/.cargo/config.toml.
 bip32-ed25519 = { git = "https://github.com/digitalbitbox/rust-bip32-ed25519", tag = "v0.1.2", optional = true }
@@ -44,11 +44,11 @@ blake2 = { version = "0.10.6", default-features = false, optional = true }
 minicbor = { version = "0.20.0", default-features = false, features = ["alloc"], optional = true }
 crc = { version = "3.0.1", optional = true }
 ed25519-dalek = { version = "2.0.0", default-features = false, features = ["hazmat"], optional = true }
-lazy_static = { version = "1.4.0", optional = true }
+lazy_static = { workspace = true, optional = true }
 hmac = { version = "0.12.1", default-features = false, features = ["reset"] }
 
 miniscript = { version = "11.0.0", default-features = false, features = ["no-std"], optional = true }
-bitcoin = { version = "0.31.0", default-features = false, features = ["no-std"], optional = true }
+bitcoin = { workspace = true, optional = true }
 # We don't rely on this dep directly, the miniscript/bitcoin deps do. We list it here to enable the
 # small-hash feature to reduce the binary size, saving around 2784 bytes (as measured at time of
 # writing, this might fluctuate over time).

--- a/src/rust/bitbox02/Cargo.toml
+++ b/src/rust/bitbox02/Cargo.toml
@@ -23,8 +23,8 @@ license = "Apache-2.0"
 [dependencies]
 bitbox02-sys = {path="../bitbox02-sys"}
 util = {path = "../util"}
-zeroize = "1.6.0"
-lazy_static = { version = "1.4.0", optional = true }
+zeroize = { workspace = true }
+lazy_static = { workspace = true, optional = true }
 
 [features]
 # Only to be enabled in unit tests.

--- a/src/rust/util/Cargo.toml
+++ b/src/rust/util/Cargo.toml
@@ -20,4 +20,4 @@ edition = "2018"
 license = "Apache-2.0"
 
 [dependencies]
-num-bigint = { version = "0.4.3", default-features = false }
+num-bigint = { workspace = true, default-features = false }


### PR DESCRIPTION
Specify the dep and its version only once.

https://doc.rust-lang.org/cargo/reference/workspaces.html#the-dependencies-table