### PR TITLE
bootloader: improve exec function

### DIFF
--- a/src/bootloader/bootloader.c
+++ b/src/bootloader/bootloader.c
@@ -408,10 +408,8 @@ static size_t _api_write_chunk(const uint8_t* buf, uint8_t chunknum, uint8_t* ou
 
     // Erase is handled inside of flash_write
     if (flash_write(
-            &FLASH_0,
-            FLASH_APP_START + (chunknum * FIRMWARE_CHUNK_LEN),
-            (const uint8_t*)buf,
-            FIRMWARE_CHUNK_LEN) != ERR_NONE) {
+            &FLASH_0, FLASH_APP_START + (chunknum * FIRMWARE_CHUNK_LEN), buf, FIRMWARE_CHUNK_LEN) !=
+        ERR_NONE) {
         return _report_status(OP_STATUS_ERR_WRITE, output);
     }
 


### PR DESCRIPTION
Add some comments about what every assembly line does. Mark which c-variables are used and which registers are used so that GCC doesn't do the wrong optimizations.

I think we are a bit naive when we read `r0`, expecting the value of `l_code_addr` to be there. According to the ARM calling convention, the first argument should be there. But since we don't even have "noinline", this whole function could be inlined. And the compiler is free to move around ASM blocks (with some constraints) as noted in the quote below.

References:

* https://gcc.gnu.org/onlinedocs/gcc-8.3.0/gcc/Extended-Asm.html
* https://gcc.gnu.org/onlinedocs/gcc-8.3.0/gcc/Basic-Asm.html

Re "Basic ASM" (that we use today)

> Safely accessing C data and calling functions from basic asm is more complex than it may appear. To access C data, it is better to use extended asm.
> 
> Do not expect a sequence of asm statements to remain perfectly consecutive after compilation. If certain instructions need to remain consecutive in the output, put them in a single multi-instruction asm statement. Note that GCC’s optimizers can move asm statements relative to other code, including across jumps. 
> [...]
> GCC does not parse basic asm’s AssemblerInstructions, which means there is no way to communicate to the compiler what is happening inside them. GCC has no visibility of symbols in the asm and may discard them as unreferenced. It also does not know about side effects of the assembler code, such as modifications to memory or registers. Unlike some compilers, GCC assumes that no changes to general purpose registers occur. This assumption may change in a future release. 

### Considerations

* Perhaps the "noinline" is not necessary.
* todo: We should probably also add "memory" to the clobber list.