### PR TITLE
api/bluetooth: use protected write

### DIFF
--- a/src/rust/bitbox02-rust/src/hww/api/bluetooth.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bluetooth.rs
@@ -106,7 +106,7 @@ async fn _process_upgrade(
             firmware_checksum ^= byte;
         }
 
-        spi_mem::write(inactive_ble_fw_address + chunk_offset, &chunk)
+        spi_mem::write_protected(inactive_ble_fw_address + chunk_offset, &chunk)
             .map_err(|_| Error::Memory)?;
 
         // Update progress.

--- a/src/rust/bitbox02-sys/build.rs
+++ b/src/rust/bitbox02-sys/build.rs
@@ -114,7 +114,7 @@ const ALLOWLIST_FNS: &[&str] = &[
     "memory_get_platform",
     "memory_get_securechip_type",
     "memory_spi_get_active_ble_firmware_version",
-    "spi_mem_write",
+    "spi_mem_protected_area_write",
     "menu_create",
     "mock_memory_factoryreset",
     "spi_mem_full_erase",

--- a/src/rust/bitbox02/src/spi_mem.rs
+++ b/src/rust/bitbox02/src/spi_mem.rs
@@ -20,8 +20,9 @@ pub use bitbox02_sys::MEMORY_SPI_BLE_FIRMWARE_MAX_SIZE as BLE_FIRMWARE_MAX_SIZE;
 
 use alloc::string::String;
 
-pub fn write(address: u32, data: &[u8]) -> Result<(), ()> {
-    match unsafe { bitbox02_sys::spi_mem_write(address, data.as_ptr(), data.len()) } {
+pub fn write_protected(address: u32, data: &[u8]) -> Result<(), ()> {
+    match unsafe { bitbox02_sys::spi_mem_protected_area_write(address, data.as_ptr(), data.len()) }
+    {
         true => Ok(()),
         false => Err(()),
     }


### PR DESCRIPTION
We introduced a write lock in the SPI mem, so we need to use the appropriate function to be able to write to the protected area.