### PR TITLE
CI: build tags, publish elf/map, print sha256

### DIFF
--- a/.github/workflows/ci-common.yml
+++ b/.github/workflows/ci-common.yml
@@ -189,6 +189,9 @@ jobs:
       - name: Clone the repo
         uses: actions/checkout@v4
         with:
+          # Github action is broken: https://github.com/actions/checkout/issues/1638
+          # Remove the below line when the issue is resolved
+          ref: ${{ github.ref }}
           fetch-depth: 0
           fetch-tags: true
           submodules: recursive
@@ -203,12 +206,18 @@ jobs:
         if: matrix.target == 'firmware' && !cancelled()
         run: ./.ci/check-unwanted-symbols
 
+      - name: Print hashes
+        run: sha256sum build*/bin/*
+
       - name: Upload artifact
         if: github.event_name == 'push' && !cancelled()
         uses: actions/upload-artifact@v4
         with:
           name: ${{matrix.target}}-${{github.sha}}.bin
-          path: build*/bin/*.bin
+          path: |
+            build*/bin/*.bin
+            build*/bin/*.elf
+            build*/bin/*.map
 
   doc:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches:
       - master
+    tags:
+      - bootloader/v*
+      - firmware/v*
+      - firmware-btc-only/v*
 
 jobs:
   dev-container:

--- a/scripts/get_version
+++ b/scripts/get_version
@@ -7,6 +7,10 @@ We only support annotated tags, you can check the signature with --verify.
 NOTE: annotated tags have "taggerdate" and "objecttype==tag"
       unannotated tags will have "objecttype==commit" since they are metadataless
 
+NOTE: If this is called from github action, ensure github action hasn't
+      replaced the tag during checkout:
+      https://github.com/actions/checkout/issues/1638
+
 Requires python3.6
 """
 


### PR DESCRIPTION
Nice to have a reproduction of the tagged versions.