### PR TITLE
screen_process: ifdef out unused function

### DIFF
--- a/src/ui/screen_process.c
+++ b/src/ui/screen_process.c
@@ -67,6 +67,7 @@ static void _screen_draw(component_t* component)
     screen_frame_cnt++;
 }
 
+#ifndef TESTING
 /**
  * Detects if the screen component being displayed has changed
  * since the last time this function was called.
@@ -83,6 +84,7 @@ static bool _screen_has_changed(const component_t* current_component)
     }
     return false;
 }
+#endif
 
 void screen_process(void)
 {


### PR DESCRIPTION
To be able to compile this file for tests the code that was calling this function was commented out. Ifdef out this function as well since it isn't used anywhere else.