### PR TITLE
btc: enable Test Merchant for payment requests in the simulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ customers cannot upgrade their bootloader, its changes are recorded separately.
 - Change title when entering recovery words to `1 of 24`, `2 of 24`, etc.
 - Unlock is now faster after password/passphrase entry (shorter unlock animation)
 - Remove option to restore from 18 recovery words
+- simulator: enable Test Merchant for payment requests
 
 ### 9.23.1
 - EVM: add HyperEVM (HYPE) and SONIC (S) to known networks

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,8 +95,8 @@ endif()
 #
 # Versions MUST contain three parts and start with lowercase 'v'.
 # Example 'v1.0.0'. They MUST not contain a pre-release label such as '-beta'.
-set(FIRMWARE_VERSION "v9.23.1")
-set(FIRMWARE_BTC_ONLY_VERSION "v9.23.1")
+set(FIRMWARE_VERSION "v9.24.0")
+set(FIRMWARE_BTC_ONLY_VERSION "v9.24.0")
 set(BOOTLOADER_VERSION "v1.1.2")
 
 find_package(PythonInterp 3.6 REQUIRED)

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin/payment_request.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin/payment_request.rs
@@ -44,7 +44,7 @@ const IDENTITIES: &[Identity] = &[
         name: "POCKET",
         public_key: b"\x02\x29\x02\xb4\xed\xe4\x82\xa9\x07\xce\x16\xa1\xc6\x34\x14\x5e\x72\x8f\x1d\xe4\xf2\x49\x04\x3a\x8b\xe4\x7d\xf2\x7d\xb9\x32\x0c\x2c",
     },
-    #[cfg(feature = "testing")]
+    #[cfg(any(feature = "testing", feature = "c-unit-testing"))]
     Identity {
         name: "Test Merchant",
         // private_key: b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"


### PR DESCRIPTION
So we can add integration tests against the simulator for payment requests.