### PR TITLE
rust: make workdirs more coherent amongst various cargo invocations

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -252,16 +252,22 @@ else()
   set(RUST_TARGET_ARCH_DIR .)
 endif()
 
-set(RUST_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/rust/target)
+set(RUST_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/rust)
 set(LIBBITBOX02_RUST_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/rust/bitbox02-rust-c)
 set(LIBBITBOX02_RUST ${LIBBITBOX02_RUST} PARENT_SCOPE)
 
 # Generate c-headers for the rust library
+# Working dir must be set to the rust workspace so that cargo finds the
+# configuration for vendoring sources
 add_custom_target(rust-cbindgen
   # cbindgen can automatically create the metadata, but it does so without the `--offline` flag.
   # The workaround is to manually create and pass the metadata.
   COMMAND
-    ${CARGO} metadata --offline >  ${CMAKE_CURRENT_BINARY_DIR}/rust-metadata
+    ${CARGO}
+      metadata
+      --offline
+      --manifest-path ${LIBBITBOX02_RUST_SOURCE_DIR}/Cargo.toml
+      > ${CMAKE_CURRENT_BINARY_DIR}/rust-metadata
   COMMAND
     ${CBINDGEN}
       --quiet
@@ -270,9 +276,12 @@ add_custom_target(rust-cbindgen
       --profile release
       --metadata ${CMAKE_CURRENT_BINARY_DIR}/rust-metadata
       ${LIBBITBOX02_RUST_SOURCE_DIR}
-  WORKING_DIRECTORY ${LIBBITBOX02_RUST_SOURCE_DIR}
+  WORKING_DIRECTORY
+    ${CMAKE_CURRENT_SOURCE_DIR}/rust
   BYPRODUCTS
     ${CMAKE_CURRENT_BINARY_DIR}/rust/rust.h
+  COMMENT
+    "Generating ${CMAKE_CURRENT_BINARY_DIR}/rust/rust.h"
 )
 
 # Test rust crates that contain business logic. Avoid testing crates that depend on hardware.
@@ -290,15 +299,23 @@ if(NOT CMAKE_CROSSCOMPILING)
         FIRMWARE_VERSION_SHORT=${FIRMWARE_VERSION}
         RUSTFLAGS="${RUSTFLAGS_TESTS}"
         # only one test thread because of unsafe concurrent access to `SafeData`, `mock_sd()` and `mock_memory()`. Using mutexes instead leads to mutex poisoning and very messy output in case of a unit test failure.
-        ${CARGO} test $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:-v> --all-features --target-dir ${RUST_BINARY_DIR}/all-features ${RUST_CARGO_FLAGS} -- --nocapture --test-threads 1
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/rust/
+        ${CARGO}
+          test
+          $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:-v>
+          --all-features
+          --manifest-path ${CMAKE_CURRENT_SOURCE_DIR}/rust/Cargo.toml
+          --target-dir ${RUST_BINARY_DIR}/all-features
+          --
+          --nocapture
+          --test-threads 1
+    WORKING_DIRECTORY
+      ${CMAKE_CURRENT_SOURCE_DIR}/rust
+    DEPENDS
+      ${CMAKE_CURRENT_BINARY_DIR}/rust/rust.h
     )
   add_dependencies(rust-test generate-protobufs bitbox_merged fatfs)
 
   add_custom_target(rust-clippy
-    COMMAND
-      # Force clippy to fully re-run. It is bad at figuring out when to run again and when to use caches.
-      ${CARGO} clean --target-dir ${RUST_BINARY_DIR}
     COMMAND
       ${CMAKE_COMMAND} -E env
         CMAKE_SYSROOT=${CMAKE_SYSROOT}
@@ -307,7 +324,8 @@ if(NOT CMAKE_CROSSCOMPILING)
         ${CARGO} clippy
           $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:-v>
           --all-features
-          --target-dir ${RUST_BINARY_DIR}/all-features
+          --manifest-path ${CMAKE_CURRENT_SOURCE_DIR}/rust/Cargo.toml
+          --target-dir ${RUST_BINARY_DIR}/clippy
           --release
           --tests
           -- # disabled linters:
@@ -322,7 +340,8 @@ if(NOT CMAKE_CROSSCOMPILING)
             -A clippy::enum_variant_names
             -A clippy::derive_partial_eq_without_eq
             -A clippy::forget_non_drop
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/rust/
+    WORKING_DIRECTORY
+      ${CMAKE_CURRENT_SOURCE_DIR}/rust
     )
   add_dependencies(rust-clippy generate-protobufs)
 endif()
@@ -397,13 +416,23 @@ foreach(type ${RUST_LIBS})
       FIRMWARE_VERSION_SHORT=${FIRMWARE_VERSION}
       $<$<BOOL:${SCCACHE_PROGRAM}>:RUSTC_WRAPPER=${SCCACHE_PROGRAM}>
       RUSTC_BOOTSTRAP=1
-      ${CARGO} build $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:-vv> --offline --features target-${type}$<$<OR:$<STREQUAL:${CMAKE_BUILD_TYPE},DEBUG>,$<STREQUAL:${type},factory-setup>>:,rtt> --target-dir ${RUST_BINARY_DIR}/feature-${type} ${RUST_CARGO_FLAGS} ${RUST_TARGET_ARCH_ARG}
+      ${CARGO}
+        build
+        $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:-vv>
+        --offline
+        --features target-${type}$<$<OR:$<STREQUAL:${CMAKE_BUILD_TYPE},DEBUG>,$<STREQUAL:${type},factory-setup>>:,rtt>
+        --manifest-path ${LIBBITBOX02_RUST_SOURCE_DIR}/Cargo.toml
+        --target-dir ${RUST_BINARY_DIR}/feature-${type}
+        ${RUST_CARGO_FLAGS}
+        ${RUST_TARGET_ARCH_ARG}
     COMMAND
       ${CMAKE_COMMAND} -E copy_if_different ${lib} ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}/lib${type}_rust_c.a
     # DEPFILES are only supported with the Ninja build tool
     #DEPFILE ${RUST_BINARY_DIR}/feature-${type}/${RUST_TARGET_ARCH_DIR}/${RUST_PROFILE}/libbitbox02_rust_c.d
-    WORKING_DIRECTORY ${LIBBITBOX02_RUST_SOURCE_DIR}
+    WORKING_DIRECTORY
+      ${CMAKE_CURRENT_SOURCE_DIR}/rust
     COMMENT "Building Rust library lib${type}_rust_c.a"
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/rust/rust.h
   )
   add_custom_target(${type}-rust-target DEPENDS ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}/lib${type}_rust_c.a)
   add_library(${type}_rust_c STATIC IMPORTED GLOBAL)
@@ -423,7 +452,8 @@ if(CMAKE_CROSSCOMPILING)
       ${CARGO} doc --document-private-items --target-dir ${CMAKE_BINARY_DIR}/docs-rust --target thumbv7em-none-eabi
     COMMAND
       ${CMAKE_COMMAND} -E echo "See docs at file://${CMAKE_BINARY_DIR}/docs-rust/thumbv7em-none-eabi/doc/bitbox02_rust/index.html"
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/rust
+    WORKING_DIRECTORY
+      ${CMAKE_CURRENT_SOURCE_DIR}/rust
   )
 
   set(STACK_SIZE "0x10000" CACHE STRING "Specify stack size for bootloader/firmware")


### PR DESCRIPTION
* Always execute cargo from the same place so that relative paths to CWD always are the same.
* Always use the "same depth" target dir, so that relative paths to the c-sources and files built by cmake stays the same.
* Give clippy its own target dir so that we don't have to wipe it before every run