### PR TITLE
9.23.2 -> master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ customers cannot upgrade their bootloader, its changes are recorded separately.
 - Add API call to fetch multiple xpubs at once
 - Add the option for the simulator to write its memory to file.
 
+### 9.23.2
+- Improve touch sensor reliability when the sdcard is inserted
+
 ### 9.23.1
 - EVM: add HyperEVM (HYPE) and SONIC (S) to known networks
 - U2F: fix macos/safari macos/firefox support

--- a/src/sd.c
+++ b/src/sd.c
@@ -315,7 +315,6 @@ bool sd_card_inserted(void)
     return true;
 #else
     sd_mmc_err_t err = sd_mmc_check(0);
-    sd_mmc_pause_clock();
     /* If initialization is ongoing, wait up to 1 second for it to initialize */
     if (err == SD_MMC_INIT_ONGOING) {
         for (int i = 0; i < 10; ++i) {
@@ -326,6 +325,7 @@ bool sd_card_inserted(void)
             }
         }
     }
+    sd_mmc_pause_clock();
 #if !defined(NDEBUG)
     switch (err) {
     case SD_MMC_OK:


### PR DESCRIPTION
When the sdcard is inserted, the sdcard check runs into the retry loop. In that case, the clock was not paused, which could lead to touch issues.