### PR TITLE
maintenance: Rename "callback param" to "user data"

### DIFF
--- a/src/ui/components/confirm.c
+++ b/src/ui/components/confirm.c
@@ -28,14 +28,14 @@
 
 typedef struct {
     void (*callback)(bool, void* param);
-    void* callback_param;
+    void* user_data;
 } data_t;
 
 static void _dispatch_confirm(component_t* self)
 {
     data_t* data = (data_t*)self->data;
     if (data->callback) {
-        data->callback(true, data->callback_param);
+        data->callback(true, data->user_data);
         data->callback = NULL;
     }
 }
@@ -58,7 +58,7 @@ static void _on_cancel(component_t* component)
     component_t* self = component->parent;
     data_t* data = (data_t*)self->data;
     if (data->callback) {
-        data->callback(false, data->callback_param);
+        data->callback(false, data->user_data);
         data->callback = NULL;
     }
 }
@@ -78,8 +78,8 @@ static const component_functions_t _component_functions = {
 
 component_t* confirm_create(
     const confirm_params_t* params,
-    void (*callback)(bool, void* param),
-    void* callback_param)
+    void (*callback)(bool result, void* user_data),
+    void* user_data)
 {
     if (!callback) {
         Abort("confirm_create callback missing");
@@ -96,7 +96,7 @@ component_t* confirm_create(
     }
     memset(data, 0, sizeof(data_t));
     data->callback = callback;
-    data->callback_param = callback_param;
+    data->user_data = user_data;
 
     confirm->data = data;
     confirm->f = &_component_functions;

--- a/src/ui/components/confirm.h
+++ b/src/ui/components/confirm.h
@@ -47,11 +47,11 @@ typedef struct {
  * @param[in] params see confirm_params_t for details.
  * @param[in] callback The callback triggered when the user accepts or rejects. Will be called at
  * most once.
- * @param[in] callback_param passed through to the callback.
+ * @param[in] user_data passed through to the callback.
  */
 component_t* confirm_create(
     const confirm_params_t* params,
-    void (*callback)(bool, void* param),
-    void* callback_param);
+    void (*callback)(bool result, void* user_data),
+    void* user_data);
 
 #endif

--- a/src/ui/components/confirm_transaction.c
+++ b/src/ui/components/confirm_transaction.c
@@ -33,8 +33,8 @@ typedef struct {
     bool has_address;
     // accepted: true means the user accepted the info shown, false means the user rejected the
     // info.
-    void (*callback)(bool accepted, void* param);
-    void* callback_param;
+    void (*callback)(bool accepted, void* user_data);
+    void* user_data;
 } data_t;
 
 static void _render(component_t* component)
@@ -55,7 +55,7 @@ static void _on_event(const event_t* event, component_t* component)
     if (event->id == EVENT_CONFIRM) {
         data_t* data = (data_t*)component->data;
         if (data->callback) {
-            data->callback(true, data->callback_param);
+            data->callback(true, data->user_data);
             data->callback = NULL;
         }
     }
@@ -66,7 +66,7 @@ static void _cancel(component_t* cancel_button)
     component_t* component = cancel_button->parent;
     data_t* data = (data_t*)component->data;
     if (data->callback != NULL) {
-        data->callback(false, data->callback_param);
+        data->callback(false, data->user_data);
         data->callback = NULL;
     }
 }
@@ -90,8 +90,8 @@ static component_t* _confirm_transaction_create(
     const char* fee,
     bool verify_total, /* if true, verify total and fee, otherwise verify amount and address */
     bool longtouch,
-    void (*callback)(bool, void*),
-    void* callback_param)
+    void (*callback)(bool accepted, void* user_data),
+    void* user_data)
 {
     if (address && fee) {
         Abort("Error: confirm btc does not support displaying both address and fee");
@@ -112,7 +112,7 @@ static component_t* _confirm_transaction_create(
 
     data->has_address = strlens(address);
     data->callback = callback;
-    data->callback_param = callback_param;
+    data->user_data = user_data;
     confirm->data = data;
     confirm->f = &_component_functions;
     confirm->dimension.width = SCREEN_WIDTH;
@@ -153,20 +153,18 @@ static component_t* _confirm_transaction_create(
 component_t* confirm_transaction_address_create(
     const char* amount,
     const char* address,
-    void (*callback)(bool accepted, void* param),
-    void* callback_param)
+    void (*callback)(bool accepted, void* user_data),
+    void* user_data)
 {
-    return _confirm_transaction_create(
-        amount, address, NULL, false, false, callback, callback_param);
+    return _confirm_transaction_create(amount, address, NULL, false, false, callback, user_data);
 }
 
 component_t* confirm_transaction_fee_create(
     const char* amount,
     const char* fee,
     bool longtouch,
-    void (*callback)(bool accepted, void* param),
-    void* callback_param)
+    void (*callback)(bool accepted, void* user_data),
+    void* user_data)
 {
-    return _confirm_transaction_create(
-        amount, NULL, fee, true, longtouch, callback, callback_param);
+    return _confirm_transaction_create(amount, NULL, fee, true, longtouch, callback, user_data);
 }

--- a/src/ui/components/confirm_transaction.h
+++ b/src/ui/components/confirm_transaction.h
@@ -23,13 +23,13 @@
  * @param[in] address to send coins
  * @param[in] callback The callback triggered when the user accepts or rejects. Is called at most
  * once.
- * @param[in] callback_param Passed to `callback`.
+ * @param[in] user_data Passed to `callback`.
  */
 component_t* confirm_transaction_address_create(
     const char* amount,
     const char* address,
-    void (*callback)(bool accepted, void* param),
-    void* callback_param);
+    void (*callback)(bool accepted, void* user_data),
+    void* user_data);
 
 /**
  * Creates a confirm screen.
@@ -39,13 +39,13 @@ component_t* confirm_transaction_address_create(
  * next-arrow is shown.
  * @param[in] callback The callback triggered when the user accepts or rejects. Is called at most
  * once.
- * @param[in] callback_param Passed to `callback`.
+ * @param[in] user_data Passed to `callback`.
  */
 component_t* confirm_transaction_fee_create(
     const char* amount,
     const char* fee,
     bool longtouch,
-    void (*callback)(bool accepted, void* param),
-    void* callback_param);
+    void (*callback)(bool accepted, void* user_data),
+    void* user_data);
 
 #endif

--- a/src/ui/components/sdcard.c
+++ b/src/ui/components/sdcard.c
@@ -23,8 +23,8 @@
 #include <ui/screen_stack.h>
 
 typedef struct {
-    void (*callback)(bool, void*);
-    void* callback_param;
+    void (*callback)(bool inserted, void* user_data);
+    void* user_data;
     // TODO: use a TIMER interrupt to get a more accurate timer.
     // 250 is ~0.5 sec. Unit: rendering rate.
     int check_interval;
@@ -35,7 +35,7 @@ static void _insert_poll_callback(component_t* component)
 {
     data_t* data = (data_t*)component->data;
     if (data->callback && sd_card_inserted()) {
-        data->callback(true, data->callback_param);
+        data->callback(true, data->user_data);
         data->callback = NULL;
         return;
     }
@@ -68,12 +68,12 @@ static void _cancel_callback(component_t* component)
 {
     data_t* data = (data_t*)component->parent->data;
     if (data->callback) {
-        data->callback(false, data->callback_param);
+        data->callback(false, data->user_data);
         data->callback = NULL;
     }
 }
 
-component_t* sdcard_create(void (*callback)(bool, void*), void* callback_param)
+component_t* sdcard_create(void (*callback)(bool inserted, void* user_data), void* user_data)
 {
     component_t* component = malloc(sizeof(component_t));
     if (!component) {
@@ -87,7 +87,7 @@ component_t* sdcard_create(void (*callback)(bool, void*), void* callback_param)
     memset(component, 0, sizeof(component_t));
 
     data->callback = callback;
-    data->callback_param = callback_param;
+    data->user_data = user_data;
     data->check_interval = 250;
     data->count = 0;
     component->data = data;

--- a/src/ui/components/sdcard.h
+++ b/src/ui/components/sdcard.h
@@ -22,6 +22,6 @@
  * @param[in] insert if true, the user is asked to insert the sdcard. Otherwise the user is asked to
  *            remove it.
  */
-component_t* sdcard_create(void (*callback)(bool, void*), void* callback_param);
+component_t* sdcard_create(void (*callback)(bool inserted, void* user_data), void* user_data);
 
 #endif

--- a/src/ui/components/status.c
+++ b/src/ui/components/status.c
@@ -26,8 +26,8 @@
 typedef struct {
     bool status;
     int counter;
-    void (*callback)(void*);
-    void* callback_param;
+    void (*callback)(void* user_data);
+    void* user_data;
 } status_data_t;
 
 static void _render(component_t* component)
@@ -41,7 +41,7 @@ static void _render(component_t* component)
     }
     if (data->callback != NULL) {
         if (data->counter == STATUS_DEFAULT_DELAY) {
-            data->callback(data->callback_param);
+            data->callback(data->user_data);
             data->callback = NULL;
             data->counter = 0;
         }
@@ -63,8 +63,8 @@ static const component_functions_t _component_functions = {
 component_t* status_create(
     const char* text,
     bool status_success,
-    void (*callback)(void*),
-    void* callback_param)
+    void (*callback)(void* user_data),
+    void* user_data)
 {
     component_t* status = malloc(sizeof(component_t));
     if (!status) {
@@ -79,7 +79,7 @@ component_t* status_create(
 
     data->status = status_success;
     data->callback = callback;
-    data->callback_param = callback_param;
+    data->user_data = user_data;
     status->data = data;
     status->f = &_component_functions;
     status->dimension.width = SCREEN_WIDTH;

--- a/src/ui/components/status.h
+++ b/src/ui/components/status.h
@@ -29,7 +29,7 @@
 component_t* status_create(
     const char* text,
     bool status_success,
-    void (*callback)(void*),
-    void* callback_param);
+    void (*callback)(void* user_data),
+    void* user_data);
 
 #endif

--- a/src/ui/components/trinary_input_string.c
+++ b/src/ui/components/trinary_input_string.c
@@ -72,10 +72,10 @@ typedef struct {
     bool hide;
     // use hold gesture vs. simple tap to confirm.
     bool longtouch;
-    void (*confirm_cb)(const char* string, void* param);
-    void* confirm_callback_param;
-    void (*cancel_cb)(void* param);
-    void* cancel_callback_param;
+    void (*confirm_cb)(const char* string, void* confirm_user_data);
+    void* confirm_user_data;
+    void (*cancel_cb)(void* cancel_user_data);
+    void* cancel_user_data;
 
     // Internals follow.
 
@@ -343,7 +343,7 @@ static void _on_event(const event_t* event, component_t* component)
 
     if (event->id == EVENT_CONFIRM && data->can_confirm) {
         if (data->confirm_cb) {
-            data->confirm_cb(data->string, data->confirm_callback_param);
+            data->confirm_cb(data->string, data->confirm_user_data);
             data->confirm_cb = NULL;
         }
         return;
@@ -366,7 +366,7 @@ static void _on_event(const event_t* event, component_t* component)
         if (data->string_index == 0) {
             // Back button is cancel.
             if (data->cancel_cb != NULL) {
-                data->cancel_cb(data->cancel_callback_param);
+                data->cancel_cb(data->cancel_user_data);
             }
             return;
         }
@@ -394,7 +394,7 @@ static void _cancel(component_t* cancel_button)
     component_t* component = cancel_button->parent;
     data_t* data = (data_t*)component->data;
     if (data->cancel_cb != NULL) {
-        data->cancel_cb(data->cancel_callback_param);
+        data->cancel_cb(data->cancel_user_data);
     }
 }
 
@@ -435,10 +435,10 @@ static const component_functions_t component_functions = {
 
 component_t* trinary_input_string_create(
     const trinary_input_string_params_t* params,
-    void (*confirm_cb)(const char* input, void* param),
-    void* confirm_callback_param,
-    void (*cancel_cb)(void* param),
-    void* cancel_callback_param)
+    void (*confirm_cb)(const char* input, void* confirm_user_data),
+    void* confirm_user_data,
+    void (*cancel_cb)(void* cancel_user_data),
+    void* cancel_user_data)
 {
     component_t* component = malloc(sizeof(component_t));
     if (!component) {
@@ -456,9 +456,9 @@ component_t* trinary_input_string_create(
     }
 
     data->confirm_cb = confirm_cb;
-    data->confirm_callback_param = confirm_callback_param;
+    data->confirm_user_data = confirm_user_data;
     data->cancel_cb = cancel_cb;
-    data->cancel_callback_param = cancel_callback_param;
+    data->cancel_user_data = cancel_user_data;
     data->wordlist = params->wordlist;
     data->wordlist_size = params->wordlist_size;
     data->number_input = params->number_input;

--- a/src/ui/components/trinary_input_string.h
+++ b/src/ui/components/trinary_input_string.h
@@ -54,10 +54,10 @@ typedef struct {
  */
 component_t* trinary_input_string_create(
     const trinary_input_string_params_t* params,
-    void (*confirm_cb)(const char* input, void* param),
-    void* confirm_callback_param,
-    void (*cancel_cb)(void* param),
-    void* cancel_callback_param);
+    void (*confirm_cb)(const char* input, void* confirm_user_data),
+    void* confirm_user_data,
+    void (*cancel_cb)(void* cancel_user_data),
+    void* cancel_user_data);
 
 /**
  * Only applicable in wordlist-mode.


### PR DESCRIPTION
"user data" is the conventional term for the user provided pointer that is returned in a callback.