### PR TITLE
keystore: fewer securechip calls when checking password

### DIFF
--- a/src/rust/bitbox02-rust/src/hww/api/show_mnemonic.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/show_mnemonic.rs
@@ -149,7 +149,7 @@ mod tests {
             block_on(process(&mut mock_hal)),
             Ok(Response::Success(pb::Success {}))
         );
-        assert_eq!(bitbox02::securechip::fake_event_counter(), 7);
+        assert_eq!(bitbox02::securechip::fake_event_counter(), 6);
 
         assert_eq!(
             mock_hal.ui.screens,


### PR DESCRIPTION
The sanity check to see if the seed has changed does not need a securechip operation, it can use the retained seed hash instead, same as `unlock_bip39()`. This reduces the number of securechip operations needed to do a password check, which reduces the risk of running into the Optiga throttling security mechanism.

This is based on https://github.com/BitBoxSwiss/bitbox02-firmware/pull/1621 so the reduction can be seen in the show_mnemonic unit test too