### PR TITLE
simulator: shutdown connection

### DIFF
--- a/test/simulator/README.md
+++ b/test/simulator/README.md
@@ -1,0 +1,6 @@
+# Simulator
+
+## Signals
+
+The simulator can be forcefully shutdown with SIGTERM. It can also be told to
+disconnect from the client using SIGHUP.


### PR DESCRIPTION
TCP is fun. If the server initiates the closing of the TCP connection the socket needs to stay alive for some time according to the protocol so that out-of-order and delayed packets have a chance to arrive. When the simulator gets shut down those packets doesn't matter. Luckily there is a way around, by setting SO_LINGER on the socket the connection is closed with a "RESET" instead and the socket is immediately released in the OS.

This commit also switches from signal(2) to sigaction(2) so that we can avoid setting SA_RESTART so that signals interrupt blocking syscalls like read.

It also introduces support for "SIGHUP" that can be used to simply disconnect the client.