### PR TITLE
keystore: add timeout reset in keystore_encrypt_and_store_seed

### DIFF
--- a/src/keystore.c
+++ b/src/keystore.c
@@ -347,6 +347,9 @@ keystore_error_t keystore_encrypt_and_store_seed(
     if (!_validate_seed_length(seed_length)) {
         return KEYSTORE_ERR_SEED_SIZE;
     }
+
+    usb_processing_timeout_reset(LONG_TIMEOUT);
+
     if (securechip_init_new_password(password)) {
         return KEYSTORE_ERR_SECURECHIP;
     }


### PR DESCRIPTION
The duration of this function can go over the 500ms timeout duration, so we give more time so the create/restore API calls don't timeout.