### PR TITLE
ui/waiting: start with logo, not lockscreen

### DIFF
--- a/src/ui/components/waiting.c
+++ b/src/ui/components/waiting.c
@@ -52,6 +52,7 @@ component_t* waiting_create(void)
         Abort("Error: malloc waiting data");
     }
     memset(data, 0, sizeof(data_t));
+    data->show_logo = true;
 
     component_t* waiting = malloc(sizeof(component_t));
     if (!waiting) {
@@ -65,7 +66,16 @@ component_t* waiting_create(void)
     waiting->position.left = 0;
     waiting->data = data;
 
-    ui_util_add_sub_component(waiting, lockscreen_create());
+    image_logo_data_t logo = image_logo_data();
+    component_t* bb2_logo = image_create(
+        logo.buffer.data,
+        logo.buffer.len,
+        logo.dimensions.width,
+        logo.dimensions.height,
+        CENTER,
+        waiting);
+
+    ui_util_add_sub_component(waiting, bb2_logo);
 
     return waiting;
 }
@@ -96,4 +106,23 @@ void waiting_switch_to_logo(component_t* component)
         component);
 
     component->sub_components.sub_components[0] = bb2_logo;
+}
+
+void waiting_switch_to_lockscreen(component_t* component)
+{
+    data_t* data = (data_t*)component->data;
+    if (!data->show_logo) {
+        return;
+    }
+    data->show_logo = false;
+
+    if (component->sub_components.amount != 1) {
+        // Sanity check to avoid memory bugs, should never happen.
+        Abort("waiting_switch_to_lockscreen");
+        return;
+    }
+
+    ui_util_component_cleanup(component->sub_components.sub_components[0]);
+
+    component->sub_components.sub_components[0] = lockscreen_create();
 }

--- a/src/ui/components/waiting.h
+++ b/src/ui/components/waiting.h
@@ -18,8 +18,8 @@
 #include <ui/component.h>
 
 /**
- * Creates a waiting screen. It starts out with a lockscreen (see lockscreen.c). Once
- * `waiting_switch_to_logo()` is called, the waiting screen will switch to showing the logo image.
+ * Creates a waiting screen. It starts out with the logo. Use `waiting_switch_to_lockscreen()` and
+ * `waiting_switch_to_logo()` to change the display between logo and lockscreen.
  */
 component_t* waiting_create(void);
 
@@ -27,5 +27,10 @@ component_t* waiting_create(void);
  * Switch the waiting screen to show the BitBox logo instead.
  */
 void waiting_switch_to_logo(component_t* component);
+
+/**
+ * Switch the waiting screen to show the lockscreen instead (see lockscreen.c).
+ */
+void waiting_switch_to_lockscreen(component_t* component);
 
 #endif

--- a/src/ui/screen_process.c
+++ b/src/ui/screen_process.c
@@ -49,6 +49,11 @@ void screen_process_waiting_switch_to_logo(void)
     waiting_switch_to_logo(_get_waiting_screen());
 }
 
+void screen_process_waiting_switch_to_lockscreen(void)
+{
+    waiting_switch_to_lockscreen(_get_waiting_screen());
+}
+
 component_t* screen_process_get_top_component(void)
 {
     component_t* saver = screen_saver_get();

--- a/src/ui/screen_process.h
+++ b/src/ui/screen_process.h
@@ -33,6 +33,11 @@ component_t* screen_process_get_top_component(void);
 void screen_process_waiting_switch_to_logo(void);
 
 /**
+ * Wraps `waiting_switch_to_lockscreen()` for the waiting screen.
+ */
+void screen_process_waiting_switch_to_lockscreen(void);
+
+/**
  * Runs the UI once.
  *
  * This function will update the screen (if needed)

--- a/src/workflow/orientation_screen.c
+++ b/src/workflow/orientation_screen.c
@@ -25,6 +25,7 @@
 #include <screen.h>
 #include <ui/components/lockscreen.h>
 #include <ui/components/orientation_arrows.h>
+#include <ui/screen_process.h>
 #include <ui/screen_stack.h>
 #include <usb/usb.h>
 #include <utils_ringbuffer.h>
@@ -73,6 +74,7 @@ static void _idle_timer_cb(const struct timer_task* const timer_task)
     }
 
     usb_start();
+    screen_process_waiting_switch_to_lockscreen();
 }
 #endif
 


### PR DESCRIPTION
40d150132797a2c5185fbbb9bf1926b24571780d refactored and introduced a bug:

old behavior (before above commit)

logo -> lockscreen -> host connects -> logo

above commit changed to this by accident, skipping the logo at the start:

lockscreen -> host connects -> logo

This commit restores the original behavior.