### PR TITLE
U2F: remove option to cancel u2f flows

### DIFF
--- a/src/rust/bitbox02-rust-c/src/workflow.rs
+++ b/src/rust/bitbox02-rust-c/src/workflow.rs
@@ -62,6 +62,7 @@ pub unsafe extern "C" fn rust_workflow_spawn_confirm(
         CONFIRM_PARAMS = Some(confirm::Params {
             title: CONFIRM_TITLE.as_ref().unwrap(),
             body: CONFIRM_BODY.as_ref().unwrap(),
+            accept_only: true,
             ..Default::default()
         });
 


### PR DESCRIPTION
In the U2F architecture it isn't possible for the device to "cancel" a user presence check because the browser can always just ask again. The only way to cancel it is from the OS/browser.