### PR TITLE
factorysetup: Let BLE chip store bond db

### DIFF
--- a/src/da14531/da14531_handler.c
+++ b/src/da14531/da14531_handler.c
@@ -75,6 +75,15 @@ extern bool bootloader_pairing_request;
 extern uint8_t bootloader_pairing_code_bytes[4];
 #endif
 
+#if FACTORYSETUP == 1
+bool _bond_db_set = false;
+
+bool da14531_handler_bond_db_set(void)
+{
+    return _bond_db_set;
+}
+#endif
+
 static void _ctrl_handler(struct da14531_ctrl_frame* frame, struct ringbuffer* queue)
 {
     switch (frame->cmd) {
@@ -135,6 +144,9 @@ static void _ctrl_handler(struct da14531_ctrl_frame* frame, struct ringbuffer* q
             break;
         }
         memory_set_ble_bond_db(&frame->cmd_data[0], frame->payload_length - 1);
+#if FACTORYSETUP == 1
+        _bond_db_set = true;
+#endif
         break;
     case CTRL_CMD_PAIRING_CODE: {
         if (frame->payload_length < 5) {

--- a/src/da14531/da14531_handler.h
+++ b/src/da14531/da14531_handler.h
@@ -16,10 +16,15 @@
 #define DA14531_HANDLER_H
 
 #include "da14531_protocol.h"
+#include <platform/platform_config.h>
 #include <utils_ringbuffer.h>
 
 extern volatile const uint8_t* da14531_handler_current_product;
 extern volatile uint16_t da14531_handler_current_product_len;
+
+#if FACTORYSETUP == 1
+bool da14531_handler_bond_db_set(void);
+#endif
 
 void da14531_handler(struct da14531_protocol_frame* frame, struct ringbuffer* queue);
 

--- a/src/memory/memory_shared.c
+++ b/src/memory/memory_shared.c
@@ -166,6 +166,11 @@ bool memory_ble_enabled(void)
 
 int16_t memory_get_ble_bond_db(uint8_t* data)
 {
+#if FACTORYSETUP == 1
+    // Always return "empty bond db" in factory setup to ensure idempotency. This will force the BLE
+    // chip to always set the bond db when it has booted.
+    return -1;
+#endif
     chunk_shared_t chunk = {0};
     memory_read_shared_bootdata(&chunk);
     int16_t len = chunk.fields.ble_bond_db_len;


### PR DESCRIPTION
Let the BLE chip store the bond db during execution of the factory setup firmware.