### PR TITLE
gdb: Add `bootload` function

### DIFF
--- a/scripts/jlink.gdb
+++ b/scripts/jlink.gdb
@@ -11,12 +11,16 @@ monitor reset
 # load the firmware into ROM
 load
 
-# Set VTOR (Vector Table Offset Register) to where the firmware is located
-set *(uint32_t*)0xE000ED08=0x10000
-# Set stack pointer to initial stack pointer according to exception table.
-set $sp = *(uint32_t*)0x10000
-# Set the program counter to the reset handler (second item in exception table)
-set $pc = *(uint32_t*)0x10004
+define bootload
+  monitor reset
+  # Set VTOR (Vector Table Offset Register) to where the firmware is located
+  set *(uint32_t*)0xE000ED08=0x10000
+  # Set stack pointer to initial stack pointer according to exception table.
+  set $sp = *(uint32_t*)0x10000
+  # Set the program counter to the reset handler (second item in exception table)
+  set $pc = *(uint32_t*)0x10004
+end
+bootload
 
 #break Reset_Handler
 #break HardFault_Handler


### PR DESCRIPTION
The `bootload` function resets the MCU and boots from application offset. Useful to restart firmware when ran with debugger.