### PR TITLE
keystore: call rust keystore_unlock from C

### DIFF
--- a/src/keystore.c
+++ b/src/keystore.c
@@ -336,7 +336,7 @@ keystore_error_t keystore_encrypt_and_store_seed(
     if (memory_is_initialized()) {
         return KEYSTORE_ERR_MEMORY;
     }
-    keystore_lock();
+    rust_keystore_lock();
     if (!_validate_seed_length(seed_length)) {
         return KEYSTORE_ERR_SEED_SIZE;
     }

--- a/src/reset.c
+++ b/src/reset.c
@@ -22,6 +22,7 @@
 #include "memory/smarteeprom.h"
 #include "system.h"
 #include "uart.h"
+#include <rust/rust.h>
 #include <screen.h>
 
 #ifndef TESTING
@@ -64,7 +65,7 @@ void reset_ble(void)
 
 void reset_reset(bool status)
 {
-    keystore_lock();
+    rust_keystore_lock();
 #if !defined(TESTING)
     bool sc_result_reset_keys = false;
     for (int retries = 0; retries < 5; retries++) {

--- a/src/rust/bitbox02-rust/src/keystore.rs
+++ b/src/rust/bitbox02-rust/src/keystore.rs
@@ -255,6 +255,11 @@ pub fn stretch_retained_seed_encryption_key(
     Ok(zeroize::Zeroizing::new(stretched.to_vec()))
 }
 
+#[unsafe(no_mangle)]
+pub extern "C" fn rust_keystore_lock() {
+    lock()
+}
+
 /// # Safety
 ///
 /// `encryption_key` must refer to a 32-byte buffer and `out` must have space for 32 bytes.


### PR DESCRIPTION
Small fix: since keystore.rs::lock() does more than just call the C function since a recent commit, C invocations to lock must call the Rust function instead.