### PR TITLE
time: Use `gmtime` instead of `localtime`

### DIFF
--- a/src/rust/bitbox02-sys/build.rs
+++ b/src/rust/bitbox02-sys/build.rs
@@ -86,7 +86,7 @@ const ALLOWLIST_FNS: &[&str] = &[
     "keystore_test_get_retained_seed_encrypted",
     "keystore_test_get_retained_bip39_seed_encrypted",
     "label_create",
-    "localtime",
+    "gmtime",
     "memory_set_salt_root",
     "memory_add_noise_remote_static_pubkey",
     "memory_bootloader_hash",

--- a/src/rust/bitbox02/src/lib.rs
+++ b/src/rust/bitbox02/src/lib.rs
@@ -175,12 +175,12 @@ impl Tm {
 pub fn get_datetime(timestamp: u32) -> Result<Tm, ()> {
     Ok(Tm {
         tm: unsafe {
-            let localtime = bitbox02_sys::localtime(&(timestamp as bitbox02_sys::time_t));
-            if localtime.is_null() {
+            let gmtime = bitbox02_sys::gmtime(&(timestamp as bitbox02_sys::time_t));
+            if gmtime.is_null() {
                 return Err(());
             }
 
-            *localtime
+            *gmtime
         },
     })
 }


### PR DESCRIPTION
`localtime` returns the time already adjusted with timezone. `gmtime` always returns time in UTC. Unit tests are failing for me as I don't have UTC as my timezone.