### PR TITLE
rust: add zeroizing str to cstr util function

### DIFF
--- a/src/rust/bitbox02/src/keystore.rs
+++ b/src/rust/bitbox02/src/keystore.rs
@@ -75,7 +75,7 @@ pub fn _unlock(password: &str) -> Result<zeroize::Zeroizing<Vec<u8>>, Error> {
     let mut seed_len: usize = 0;
     match unsafe {
         bitbox02_sys::keystore_unlock(
-            crate::util::str_to_cstr_vec(password)
+            crate::util::str_to_cstr_vec_zeroizing(password)
                 .unwrap()
                 .as_ptr()
                 .cast(),


### PR DESCRIPTION
Not using CString as it did not look to me like it was actually preallocating for the null terminator, and reallocation would leave unzeroed copies.