### PR TITLE
bitbox02-sys/build.rs: remove unused funcs

### DIFF
--- a/src/rust/bitbox02-sys/build.rs
+++ b/src/rust/bitbox02-sys/build.rs
@@ -76,8 +76,6 @@ const ALLOWLIST_FNS: &[&str] = &[
     "fake_securechip_event_counter",
     "gmtime",
     "keystore_bip39_mnemonic_to_seed",
-    "keystore_copy_bip39_seed",
-    "keystore_copy_seed",
     "keystore_encrypt_and_store_seed",
     "keystore_get_bip39_word",
     "keystore_secp256k1_nonce_commit",


### PR DESCRIPTION
Re-introduced in a rebase error in bf923f7d64a918e4fa975a03d3a3f424c5075f1fad607ccffc62f9b89b637e32.