### PR TITLE
screen: remove warning about unused param

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -51,6 +51,8 @@ void screen_print_debug(const char* message, int duration)
     UG_SendBuffer();
 #ifndef TESTING
     if (duration > 0) delay_ms(duration);
+#else
+    (void)duration;
 #endif
 }
 


### PR DESCRIPTION
In testing, the `duration` param is unused.