### PR TITLE
HAL/SecureChip: add kdf()

### DIFF
--- a/src/rust/bitbox02-rust/src/hww.rs
+++ b/src/rust/bitbox02-rust/src/hww.rs
@@ -552,7 +552,7 @@ mod tests {
                 ]
             );
 
-            let seed = crate::keystore::copy_seed().unwrap();
+            let seed = crate::keystore::copy_seed(&mut mock_hal).unwrap();
             assert_eq!(seed.len(), host_entropy.len());
             mock_hal.ui = crate::workflow::testing::TestingWorkflows::new();
             assert!(matches!(
@@ -718,7 +718,7 @@ mod tests {
             );
 
             // Restored seed is the same as the seed that was backed up.
-            assert_eq!(seed, crate::keystore::copy_seed().unwrap());
+            assert_eq!(seed, crate::keystore::copy_seed(&mut mock_hal).unwrap());
         }
     }
 }

--- a/src/rust/bitbox02-rust/src/hww/api.rs
+++ b/src/rust/bitbox02-rust/src/hww/api.rs
@@ -184,7 +184,7 @@ async fn process_api(hal: &mut impl crate::hal::Hal, request: &Request) -> Resul
         Request::RestoreBackup(request) => restore::from_file(hal, request).await,
         Request::ShowMnemonic(_) => show_mnemonic::process(hal).await,
         Request::RestoreFromMnemonic(request) => restore::from_mnemonic(hal, request).await,
-        Request::ElectrumEncryptionKey(request) => electrum::process(request).await,
+        Request::ElectrumEncryptionKey(request) => electrum::process(hal, request).await,
 
         #[cfg(feature = "app-ethereum")]
         Request::Eth(pb::EthRequest {

--- a/src/rust/bitbox02-rust/src/hww/api/backup.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/backup.rs
@@ -30,7 +30,7 @@ pub async fn check(
         return Err(Error::InvalidInput);
     }
 
-    let seed = crate::keystore::copy_seed()?;
+    let seed = crate::keystore::copy_seed(hal)?;
     let id = backup::id(&seed);
     let (backup_data, metadata) = backup::load(hal, &id).await?;
     if seed.as_slice() != backup_data.get_seed() {
@@ -102,7 +102,7 @@ pub async fn create(
     let seed = if is_initialized {
         unlock::unlock_keystore(hal, "Unlock device", unlock::CanCancel::Yes).await?
     } else {
-        let seed = crate::keystore::copy_seed()?;
+        let seed = crate::keystore::copy_seed(hal)?;
         // Yield now to give executor a chance to process USB/BLE communication, as copy_seed() causes
         // some delay.
         futures_lite::future::yield_now().await;

--- a/src/rust/bitbox02-rust/src/hww/api/bip85.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bip85.rs
@@ -121,7 +121,7 @@ async fn process_bip39(hal: &mut impl crate::hal::Hal) -> Result<(), Error> {
         })
         .await?;
 
-    let mnemonic = keystore::bip85_bip39(num_words, index)?;
+    let mnemonic = keystore::bip85_bip39(hal, num_words, index)?;
     let words: Vec<&str> = mnemonic.split(' ').collect();
     hal.ui().show_and_confirm_mnemonic(&words).await?;
 
@@ -151,7 +151,7 @@ async fn process_ln(
         })
         .await?;
 
-    Ok(keystore::bip85_ln(account_number)
+    Ok(keystore::bip85_ln(hal, account_number)
         .map_err(|_| Error::Generic)?
         .to_vec())
 }

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin/multisig.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin/multisig.rs
@@ -259,7 +259,11 @@ pub async fn confirm_extended(
 /// - no two xpubs are the same.
 ///
 /// keypath: account-level keypath, e.g. m/48'/0'/10'/2'
-pub fn validate(multisig: &Multisig, keypath: &[u32]) -> Result<(), Error> {
+pub fn validate(
+    hal: &mut impl crate::hal::Hal,
+    multisig: &Multisig,
+    keypath: &[u32],
+) -> Result<(), Error> {
     if multisig.xpubs.len() < 2 || multisig.xpubs.len() > MAX_SIGNERS {
         return Err(Error::InvalidInput);
     }
@@ -270,7 +274,7 @@ pub fn validate(multisig: &Multisig, keypath: &[u32]) -> Result<(), Error> {
         return Err(Error::InvalidInput);
     }
 
-    let our_xpub = crate::keystore::get_xpub_once(keypath)?.serialize(None)?;
+    let our_xpub = crate::keystore::get_xpub_once(hal, keypath)?.serialize(None)?;
     let maybe_our_xpub =
         bip32::Xpub::from(&multisig.xpubs[multisig.our_xpub_index as usize]).serialize(None)?;
     if our_xpub != maybe_our_xpub {
@@ -589,18 +593,20 @@ mod tests {
             script_type: ScriptType::P2wsh as _,
         };
 
+        let mut mock_hal = crate::hal::testing::TestingHal::new();
+
         // Keystore locked.
         crate::keystore::lock();
-        assert!(validate(&multisig, keypath).is_err());
+        assert!(validate(&mut mock_hal, &multisig, keypath).is_err());
 
         // Ok.
         mock_unlocked_using_mnemonic(
             "sudden tenant fault inject concert weather maid people chunk youth stumble grit",
             "",
         );
-        assert!(validate(&multisig, keypath).is_ok());
+        assert!(validate(&mut mock_hal, &multisig, keypath).is_ok());
         // Ok at arbitrary keypath.
-        assert!(validate(&Multisig {
+        assert!(validate(&mut mock_hal,&Multisig {
             threshold: 1,
             xpubs: vec![
                 parse_xpub("xpub6FMWuwbCA9KhoRzAMm63ZhLspk5S2DM5sePo8J8mQhcS1xyMbAqnc7Q7UescVEVFCS6qBMQLkEJWQ9Z3aDPgBov5nFUYxsJhwumsxM4npSo").unwrap(),
@@ -633,7 +639,7 @@ mod tests {
                 "xpub6ECHc4kmTC2tQg2ZoAoazwyag9C4V6yFsZEhjwMJixdVNsUibot6uEvsZY38ZLVqWCtyc9gbzFEwHQLHCT8EiDDKSNNsFAB8NQYRgkiAQwu",
                 "xpub6F7CaxXzBCtvXwpRi61KYyhBRkgT1856ujHV5AbJK6ySCUYoDruBH6Pnsi6eHkDiuKuAJ2tSc9x3emP7aax9Dc3u7nP7RCQXEjLKihQu6w1",
             ].iter().map(|s| parse_xpub(s).unwrap()).collect();
-            assert!(validate(&invalid, keypath).is_err());
+            assert!(validate(&mut mock_hal, &invalid, keypath).is_err());
         }
 
         {
@@ -641,21 +647,21 @@ mod tests {
 
             let mut invalid = multisig.clone();
             invalid.xpubs = vec![];
-            assert!(validate(&invalid, keypath).is_err());
+            assert!(validate(&mut mock_hal, &invalid, keypath).is_err());
             invalid.our_xpub_index = 0;
             invalid.xpubs = vec![parse_xpub(our_xpub_str).unwrap()];
-            assert!(validate(&invalid, keypath).is_err());
+            assert!(validate(&mut mock_hal, &invalid, keypath).is_err());
         }
 
         {
             // threshold larger than number of cosigners
             let mut invalid = multisig.clone();
             invalid.threshold = 3;
-            assert!(validate(&invalid, keypath).is_err());
+            assert!(validate(&mut mock_hal, &invalid, keypath).is_err());
 
             // threshold zero
             invalid.threshold = 0;
-            assert!(validate(&invalid, keypath).is_err());
+            assert!(validate(&mut mock_hal, &invalid, keypath).is_err());
         }
 
         {
@@ -663,7 +669,7 @@ mod tests {
             // bounds).
             let mut invalid = multisig.clone();
             invalid.our_xpub_index = 2;
-            assert!(validate(&invalid, keypath).is_err());
+            assert!(validate(&mut mock_hal, &invalid, keypath).is_err());
         }
 
         {
@@ -671,7 +677,7 @@ mod tests {
 
             let mut invalid = multisig.clone();
             invalid.xpubs[1] = parse_xpub("xpub6FNT7x2ZEBMhs4jvZJSEBV2qBCBnRidNsyqe7inT9V2wmEn4sqidTEudB4dVSvEjXz2NytcymwWJb8PPYExRycNf9SH8fAHzPWUsQJAmbR3").unwrap();
-            assert!(validate(&invalid, keypath).is_err());
+            assert!(validate(&mut mock_hal, &invalid, keypath).is_err());
         }
 
         {
@@ -679,7 +685,7 @@ mod tests {
 
             let mut invalid = multisig.clone();
             invalid.xpubs[0] = invalid.xpubs[1].clone();
-            assert!(validate(&invalid, keypath).is_err());
+            assert!(validate(&mut mock_hal, &invalid, keypath).is_err());
         }
     }
 

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin/registration.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin/registration.rs
@@ -123,7 +123,7 @@ pub async fn process_register_script_config(
             let coin = BtcCoin::try_from(*coin)?;
             let coin_params = params::get(coin);
             let name = get_name(hal, request).await?;
-            super::multisig::validate(multisig, keypath)?;
+            super::multisig::validate(hal, multisig, keypath)?;
             let xpub_type = XPubType::try_from(request.xpub_type)?;
             super::multisig::confirm_extended(
                 hal,
@@ -158,7 +158,7 @@ pub async fn process_register_script_config(
             let coin = BtcCoin::try_from(*coin)?;
             let coin_params = params::get(coin);
             let name = get_name(hal, request).await?;
-            let parsed = super::policies::parse(policy, coin)?;
+            let parsed = super::policies::parse(hal, policy, coin)?;
             parsed
                 .confirm(
                     hal,

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin/script_configs.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin/script_configs.rs
@@ -120,6 +120,7 @@ mod tests {
 
     #[test]
     fn test_self_transfer_representation_policy() {
+        let mut mock_hal = crate::hal::testing::TestingHal::new();
         let keypath = &[48 + HARDENED, 1 + HARDENED, 0 + HARDENED, 3 + HARDENED];
         let policy = pb::btc_script_config::Policy {
             policy: "wsh(multi(2,@0/**,@1/**))".into(),
@@ -127,7 +128,7 @@ mod tests {
                 pb::KeyOriginInfo {
                     root_fingerprint: crate::keystore::root_fingerprint().unwrap(),
                     keypath: keypath.to_vec(),
-                    xpub: Some(crate::keystore::get_xpub_once(keypath).unwrap().into()),
+                    xpub: Some(crate::keystore::get_xpub_once(&mut mock_hal,keypath).unwrap().into()),
                 },
                 pb::KeyOriginInfo {
                     root_fingerprint: vec![],
@@ -137,7 +138,8 @@ mod tests {
             ],
         };
 
-        let parsed_policy = super::super::policies::parse(&policy, pb::BtcCoin::Btc).unwrap();
+        let parsed_policy =
+            super::super::policies::parse(&mut mock_hal, &policy, pb::BtcCoin::Btc).unwrap();
         let config = ValidatedScriptConfigWithKeypath {
             keypath,
             config: ValidatedScriptConfig::Policy {

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin/signmsg.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin/signmsg.rs
@@ -61,7 +61,7 @@ pub async fn process(
     }
 
     // Keypath and script_config are validated in address_simple().
-    let address = super::derive_address_simple(coin, simple_type, keypath)?;
+    let address = super::derive_address_simple(hal, coin, simple_type, keypath)?;
 
     let basic_info = format!("Coin: {}", super::params::get(coin).name);
     let confirm_params = confirm::Params {
@@ -98,7 +98,7 @@ pub async fn process(
         // Engage in the anti-klepto protocol if the host sends a host nonce commitment.
         Some(pb::AntiKleptoHostNonceCommitment { ref commitment }) => {
             let signer_commitment = keystore::secp256k1_nonce_commit(
-                keystore::secp256k1_get_private_key(keypath)?
+                keystore::secp256k1_get_private_key(hal, keypath)?
                     .as_slice()
                     .try_into()
                     .unwrap(),
@@ -118,7 +118,7 @@ pub async fn process(
     };
 
     let sign_result = keystore::secp256k1_sign(
-        keystore::secp256k1_get_private_key(keypath)?
+        keystore::secp256k1_get_private_key(hal, keypath)?
             .as_slice()
             .try_into()
             .unwrap(),

--- a/src/rust/bitbox02-rust/src/hww/api/cardano.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/cardano.rs
@@ -33,7 +33,7 @@ pub async fn process_api(
     request: &Request,
 ) -> Result<Response, Error> {
     match request {
-        Request::Xpubs(request) => xpubs::process(request),
+        Request::Xpubs(request) => xpubs::process(hal, request),
         Request::Address(request) => address::process(hal, request).await,
         Request::SignTransaction(request) => sign_transaction::process(hal, request).await,
     }

--- a/src/rust/bitbox02-rust/src/hww/api/cardano/xpubs.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/cardano/xpubs.rs
@@ -24,12 +24,15 @@ use super::keypath::validate_account_shelley;
 /// Return the xpub at the request keypath.
 ///
 /// 64 bytes: 32 bytes public key + 32 bytes chain code.
-pub fn process(request: &pb::CardanoXpubsRequest) -> Result<Response, Error> {
+pub fn process(
+    hal: &mut impl crate::hal::Hal,
+    request: &pb::CardanoXpubsRequest,
+) -> Result<Response, Error> {
     let mut xpubs: Vec<Vec<u8>> = Vec::with_capacity(request.keypaths.len());
     for pb::Keypath { keypath } in &request.keypaths {
         validate_account_shelley(keypath)?;
 
-        let xpub = crate::keystore::ed25519::get_xpub(keypath)?;
+        let xpub = crate::keystore::ed25519::get_xpub(hal, keypath)?;
         let mut xpub_bytes = Vec::with_capacity(64);
         xpub_bytes.extend_from_slice(xpub.pubkey_bytes());
         xpub_bytes.extend_from_slice(xpub.chain_code());
@@ -49,32 +52,41 @@ mod tests {
     fn test_process() {
         crate::keystore::lock();
         assert_eq!(
-            process(&pb::CardanoXpubsRequest { keypaths: vec![] }),
+            process(
+                &mut crate::hal::testing::TestingHal::new(),
+                &pb::CardanoXpubsRequest { keypaths: vec![] }
+            ),
             Ok(Response::Xpubs(pb::CardanoXpubsResponse { xpubs: vec![] })),
         );
 
         // Locked.
         assert_eq!(
-            process(&pb::CardanoXpubsRequest {
-                keypaths: vec![pb::Keypath {
-                    keypath: vec![1852 + HARDENED, 1815 + HARDENED, HARDENED]
-                }],
-            }),
+            process(
+                &mut crate::hal::testing::TestingHal::new(),
+                &pb::CardanoXpubsRequest {
+                    keypaths: vec![pb::Keypath {
+                        keypath: vec![1852 + HARDENED, 1815 + HARDENED, HARDENED]
+                    }],
+                }
+            ),
             Err(Error::Generic),
         );
 
         mock_unlocked();
         assert_eq!(
-            process(&pb::CardanoXpubsRequest {
-                keypaths: vec![
-                    pb::Keypath {
-                        keypath: vec![1852 + HARDENED, 1815 + HARDENED, HARDENED]
-                    },
-                    pb::Keypath {
-                        keypath: vec![1852 + HARDENED, 1815 + HARDENED, 1 + HARDENED]
-                    }
-                ],
-            }),
+            process(
+                &mut crate::hal::testing::TestingHal::new(),
+                &pb::CardanoXpubsRequest {
+                    keypaths: vec![
+                        pb::Keypath {
+                            keypath: vec![1852 + HARDENED, 1815 + HARDENED, HARDENED]
+                        },
+                        pb::Keypath {
+                            keypath: vec![1852 + HARDENED, 1815 + HARDENED, 1 + HARDENED]
+                        }
+                    ],
+                }
+            ),
             Ok(Response::Xpubs(pb::CardanoXpubsResponse {
                 xpubs: vec![
                     vec![
@@ -111,11 +123,14 @@ mod tests {
         ];
         for invalid_keypath in invalid_keypaths {
             assert_eq!(
-                process(&pb::CardanoXpubsRequest {
-                    keypaths: vec![pb::Keypath {
-                        keypath: invalid_keypath.to_vec(),
-                    },],
-                }),
+                process(
+                    &mut crate::hal::testing::TestingHal::new(),
+                    &pb::CardanoXpubsRequest {
+                        keypaths: vec![pb::Keypath {
+                            keypath: invalid_keypath.to_vec(),
+                        },],
+                    }
+                ),
                 Err(Error::InvalidInput),
             );
         }

--- a/src/rust/bitbox02-rust/src/hww/api/ethereum/pubrequest.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/ethereum/pubrequest.rs
@@ -45,7 +45,7 @@ async fn process_address(
     if !super::keypath::is_valid_keypath_address(&request.keypath) {
         return Err(Error::InvalidInput);
     }
-    let pubkey = crate::keystore::get_xpub_twice(&request.keypath)
+    let pubkey = crate::keystore::get_xpub_twice(hal, &request.keypath)
         .or(Err(Error::InvalidInput))?
         .pubkey_uncompressed()?;
     let address = super::address::from_pubkey(&pubkey);
@@ -70,7 +70,10 @@ async fn process_address(
     Ok(Response::Pub(pb::PubResponse { r#pub: address }))
 }
 
-fn process_xpub(request: &pb::EthPubRequest) -> Result<Response, Error> {
+fn process_xpub(
+    hal: &mut impl crate::hal::Hal,
+    request: &pb::EthPubRequest,
+) -> Result<Response, Error> {
     if request.display {
         // No xpub user verification for now.
         return Err(Error::InvalidInput);
@@ -79,7 +82,7 @@ fn process_xpub(request: &pb::EthPubRequest) -> Result<Response, Error> {
     if !super::keypath::is_valid_keypath_xpub(&request.keypath) {
         return Err(Error::InvalidInput);
     }
-    let xpub = keystore::get_xpub_twice(&request.keypath)
+    let xpub = keystore::get_xpub_twice(hal, &request.keypath)
         .or(Err(Error::InvalidInput))?
         .serialize_str(bip32::XPubType::Xpub)?;
 
@@ -93,7 +96,7 @@ pub async fn process(
     let output_type = OutputType::try_from(request.output_type)?;
     match output_type {
         OutputType::Address => process_address(hal, request).await,
-        OutputType::Xpub => process_xpub(request),
+        OutputType::Xpub => process_xpub(hal, request),
     }
 }
 

--- a/src/rust/bitbox02-rust/src/hww/api/ethereum/sign.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/ethereum/sign.rs
@@ -389,7 +389,7 @@ pub async fn _process(
         // Engage in the anti-klepto protocol if the host sends a host nonce commitment.
         Some(pb::AntiKleptoHostNonceCommitment { commitment }) => {
             let signer_commitment = keystore::secp256k1_nonce_commit(
-                &keystore::secp256k1_get_private_key(request.keypath())?
+                &keystore::secp256k1_get_private_key(hal, request.keypath())?
                     .as_slice()
                     .try_into()
                     .unwrap(),
@@ -408,7 +408,7 @@ pub async fn _process(
         None => [0; 32],
     };
     let sign_result = keystore::secp256k1_sign(
-        &keystore::secp256k1_get_private_key(request.keypath())?
+        &keystore::secp256k1_get_private_key(hal, request.keypath())?
             .as_slice()
             .try_into()
             .unwrap(),

--- a/src/rust/bitbox02-rust/src/hww/api/ethereum/sign_typed_msg.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/ethereum/sign_typed_msg.rs
@@ -563,7 +563,7 @@ pub async fn process(
     let host_nonce = match request.host_nonce_commitment {
         Some(pb::AntiKleptoHostNonceCommitment { ref commitment }) => {
             let signer_commitment = keystore::secp256k1_nonce_commit(
-                keystore::secp256k1_get_private_key(&request.keypath)?
+                keystore::secp256k1_get_private_key(hal, &request.keypath)?
                     .as_slice()
                     .try_into()
                     .unwrap(),
@@ -582,7 +582,7 @@ pub async fn process(
     };
 
     let sign_result = keystore::secp256k1_sign(
-        keystore::secp256k1_get_private_key(&request.keypath)?
+        keystore::secp256k1_get_private_key(hal, &request.keypath)?
             .as_slice()
             .try_into()
             .unwrap(),

--- a/src/rust/bitbox02-rust/src/hww/api/ethereum/signmsg.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/ethereum/signmsg.rs
@@ -67,7 +67,7 @@ pub async fn process(
         // Engage in the anti-klepto protocol if the host sends a host nonce commitment.
         Some(pb::AntiKleptoHostNonceCommitment { ref commitment }) => {
             let signer_commitment = keystore::secp256k1_nonce_commit(
-                keystore::secp256k1_get_private_key(&request.keypath)?
+                keystore::secp256k1_get_private_key(hal, &request.keypath)?
                     .as_slice()
                     .try_into()
                     .unwrap(),
@@ -87,7 +87,7 @@ pub async fn process(
     };
 
     let sign_result = keystore::secp256k1_sign(
-        keystore::secp256k1_get_private_key(&request.keypath)?
+        keystore::secp256k1_get_private_key(hal, &request.keypath)?
             .as_slice()
             .try_into()
             .unwrap(),

--- a/src/rust/bitbox02-rust/src/hww/api/restore.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/restore.rs
@@ -201,19 +201,21 @@ mod tests {
             Ok(Response::Success(pb::Success {}))
         );
         assert_eq!(mock_hal.securechip.get_event_counter(), 8);
-        drop(mock_hal); // to remove mutable borrow of counter
-        assert_eq!(counter, 2);
+
         assert!(!crate::keystore::is_locked());
         assert!(memory::is_initialized());
         // Seed of hardcoded phrase used in unit tests:
         // boring mistake dish oyster truth pigeon viable emerge sort crash wire portion cannon couple enact box walk height pull today solid off enable tide
         assert_eq!(
-            hex::encode(crate::keystore::copy_seed().unwrap()),
+            hex::encode(crate::keystore::copy_seed(&mut mock_hal).unwrap()),
             "19f1bcfccf3e9d497cd245cf864ff0d42216625258d4f68d56b571aceb329257"
         );
         assert_eq!(
-            hex::encode(crate::keystore::copy_bip39_seed().unwrap()),
+            hex::encode(crate::keystore::copy_bip39_seed(&mut mock_hal).unwrap()),
             "257724bccc8858cfe565b456b01263a4a6a45184fab4531f5c199649207a74e74c399a01d4f957258c05cee818369b31404c884a4b7a29ff6886bae6700fb56a"
         );
+
+        drop(mock_hal); // to remove mutable borrow of counter
+        assert_eq!(counter, 2);
     }
 }

--- a/src/rust/bitbox02-rust/src/hww/api/show_mnemonic.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/show_mnemonic.rs
@@ -31,7 +31,7 @@ pub async fn process(hal: &mut impl crate::hal::Hal) -> Result<Response, Error> 
         let seed = if bitbox02::memory::is_initialized() {
             unlock::unlock_keystore(hal, "Unlock device", unlock::CanCancel::Yes).await?
         } else {
-            crate::keystore::copy_seed()?
+            crate::keystore::copy_seed(hal)?
         };
 
         crate::bip39::mnemonic_from_seed(&seed)?

--- a/src/rust/bitbox02-rust/src/keystore.rs
+++ b/src/rust/bitbox02-rust/src/keystore.rs
@@ -20,8 +20,8 @@ use alloc::vec::Vec;
 
 use crate::bip32;
 use crate::hal::{Random, SecureChip};
+use bitbox02::keystore;
 pub use bitbox02::keystore::SignResult;
-use bitbox02::{keystore, securechip};
 
 use util::bip32::HARDENED;
 use util::cell::SyncCell;
@@ -102,17 +102,23 @@ struct RetainedEncryptedBuffer {
 
 impl RetainedEncryptedBuffer {
     fn from_buffer(
-        random: &mut impl crate::hal::Random,
+        hal: &mut impl crate::hal::Hal,
         data: &[u8],
         purpose: &'static str,
     ) -> Result<Self, Error> {
-        let rand: [u8; 32] = random.random_32_bytes().as_slice().try_into().unwrap();
+        let rand: [u8; 32] = hal
+            .random()
+            .random_32_bytes()
+            .as_slice()
+            .try_into()
+            .unwrap();
         let encryption_key = stretch_retained_seed_encryption_key(
+            hal,
             &rand,
             &format!("{}_in", purpose),
             &format!("{}_out", purpose),
         )?;
-        let iv_rand = random.random_32_bytes();
+        let iv_rand = hal.random().random_32_bytes();
         let iv: &[u8; 16] = iv_rand.first_chunk::<16>().unwrap();
         let encrypted = bitbox_aes::encrypt_with_hmac(iv, &encryption_key, data);
         Ok(RetainedEncryptedBuffer {
@@ -122,8 +128,12 @@ impl RetainedEncryptedBuffer {
         })
     }
 
-    fn decrypt(&self) -> Result<zeroize::Zeroizing<Vec<u8>>, Error> {
+    fn decrypt(
+        &self,
+        hal: &mut impl crate::hal::Hal,
+    ) -> Result<zeroize::Zeroizing<Vec<u8>>, Error> {
         let encryption_key = stretch_retained_seed_encryption_key(
+            hal,
             &self.unstretched_encryption_key,
             &format!("{}_in", self.purpose),
             &format!("{}_out", self.purpose),
@@ -183,9 +193,9 @@ fn hash_seed(seed: &[u8]) -> Result<[u8; 32], Error> {
     Ok(Hmac::<sha256::Hash>::from_engine(engine).to_byte_array())
 }
 
-fn retain_seed(random: &mut impl crate::hal::Random, seed: &[u8]) -> Result<(), Error> {
+fn retain_seed(hal: &mut impl crate::hal::Hal, seed: &[u8]) -> Result<(), Error> {
     RETAINED_SEED.write(Some(RetainedEncryptedBuffer::from_buffer(
-        random,
+        hal,
         seed,
         "keystore_retained_seed_access",
     )?));
@@ -193,9 +203,9 @@ fn retain_seed(random: &mut impl crate::hal::Random, seed: &[u8]) -> Result<(), 
     Ok(())
 }
 
-fn retain_bip39_seed(random: &mut impl crate::hal::Random, bip39_seed: &[u8]) -> Result<(), Error> {
+fn retain_bip39_seed(hal: &mut impl crate::hal::Hal, bip39_seed: &[u8]) -> Result<(), Error> {
     RETAINED_BIP39_SEED.write(Some(RetainedEncryptedBuffer::from_buffer(
-        random,
+        hal,
         bip39_seed,
         "keystore_retained_bip39_seed_access",
     )?));
@@ -237,7 +247,7 @@ fn encrypt_and_store_seed_internal(
         return Err(Error::Memory);
     }
 
-    retain_seed(hal.random(), seed)
+    retain_seed(hal, seed)
 }
 
 /// Restores a seed. This also unlocks the keystore with this seed.
@@ -267,13 +277,13 @@ pub fn re_encrypt_seed(
     // 1. The secure chip's internal keys are regenerated with the new password
     // 2. encrypt_and_store_seed_internal calls lock() which clears BIP39 seed and root fingerprint
     // 3. We want to avoid forcing the user to re-enter their BIP39 passphrase
-    let bip39_seed = copy_bip39_seed().map_err(|_| Error::InvalidState)?;
+    let bip39_seed = copy_bip39_seed(hal).map_err(|_| Error::InvalidState)?;
     let root_fingerprint = ROOT_FINGERPRINT.read().ok_or(Error::InvalidState)?;
 
     encrypt_and_store_seed_internal(hal, seed, new_password)?;
 
     // Re-retain the bip39 seed and root fingerprint
-    retain_bip39_seed(hal.random(), bip39_seed.as_slice())?;
+    retain_bip39_seed(hal, bip39_seed.as_slice())?;
     ROOT_FINGERPRINT.write(Some(root_fingerprint));
 
     Ok(())
@@ -346,7 +356,7 @@ pub fn unlock(
             panic!("Seed has suddenly changed. This should never happen.");
         }
     } else {
-        retain_seed(hal.random(), &seed)?;
+        retain_seed(hal, &seed)?;
     }
     bitbox02::memory::smarteeprom_reset_unlock_attempts();
     Ok(seed)
@@ -364,7 +374,7 @@ pub fn get_remaining_unlock_attempts() -> u8 {
 /// `mnemonic_passphrase` is the bip39 passphrase used in the derivation. Use the empty string if no
 /// passphrase is needed or provided.
 pub async fn unlock_bip39(
-    random: &mut impl crate::hal::Random,
+    hal: &mut impl crate::hal::Hal,
     seed: &[u8],
     mnemonic_passphrase: &str,
     yield_now: impl AsyncFn(),
@@ -381,7 +391,7 @@ pub async fn unlock_bip39(
         return Err(Error::Memory);
     }
 
-    retain_bip39_seed(random, bip39_seed.as_slice())?;
+    retain_bip39_seed(hal, bip39_seed.as_slice())?;
 
     // Store root fingerprint.
     ROOT_FINGERPRINT.write(Some(root_fingerprint));
@@ -389,16 +399,16 @@ pub async fn unlock_bip39(
 }
 
 /// Returns a copy of the retained seed. Errors if the keystore is locked.
-pub fn copy_seed() -> Result<zeroize::Zeroizing<Vec<u8>>, ()> {
-    RETAINED_SEED.read().ok_or(())?.decrypt().map_err(|_| ())
+pub fn copy_seed(hal: &mut impl crate::hal::Hal) -> Result<zeroize::Zeroizing<Vec<u8>>, ()> {
+    RETAINED_SEED.read().ok_or(())?.decrypt(hal).map_err(|_| ())
 }
 
 /// Returns a copy of the retained bip39 seed. Errors if the keystore is locked.
-pub fn copy_bip39_seed() -> Result<zeroize::Zeroizing<Vec<u8>>, ()> {
+pub fn copy_bip39_seed(hal: &mut impl crate::hal::Hal) -> Result<zeroize::Zeroizing<Vec<u8>>, ()> {
     RETAINED_BIP39_SEED
         .read()
         .ok_or(())?
-        .decrypt()
+        .decrypt(hal)
         .map_err(|_| ())
 }
 
@@ -437,12 +447,14 @@ pub fn create_and_store_seed(
 }
 
 /// Returns the keystore's seed encoded as a BIP-39 mnemonic.
-pub fn get_bip39_mnemonic() -> Result<zeroize::Zeroizing<String>, ()> {
-    crate::bip39::mnemonic_from_seed(&copy_seed()?)
+pub fn get_bip39_mnemonic(
+    hal: &mut impl crate::hal::Hal,
+) -> Result<zeroize::Zeroizing<String>, ()> {
+    crate::bip39::mnemonic_from_seed(&copy_seed(hal)?)
 }
 
-fn get_xprv(keypath: &[u32]) -> Result<bip32::Xprv, ()> {
-    let bip39_seed = copy_bip39_seed()?;
+fn get_xprv(hal: &mut impl crate::hal::Hal, keypath: &[u32]) -> Result<bip32::Xprv, ()> {
+    let bip39_seed = copy_bip39_seed(hal)?;
     let xprv: bip32::Xprv =
         bitcoin::bip32::Xpriv::new_master(bitcoin::NetworkKind::Main, &bip39_seed)
             .map_err(|_| ())?
@@ -455,17 +467,23 @@ fn get_xprv(keypath: &[u32]) -> Result<bip32::Xprv, ()> {
 }
 
 /// Get the private key at the keypath.
-pub fn secp256k1_get_private_key(keypath: &[u32]) -> Result<zeroize::Zeroizing<Vec<u8>>, ()> {
-    let xprv = get_xprv(keypath)?;
+pub fn secp256k1_get_private_key(
+    hal: &mut impl crate::hal::Hal,
+    keypath: &[u32],
+) -> Result<zeroize::Zeroizing<Vec<u8>>, ()> {
+    let xprv = get_xprv(hal, keypath)?;
     Ok(zeroize::Zeroizing::new(
         xprv.xprv.private_key.secret_bytes().to_vec(),
     ))
 }
 
 /// Get the private key at the keypath, computed twice to mitigate the risk of bitflips.
-pub fn secp256k1_get_private_key_twice(keypath: &[u32]) -> Result<zeroize::Zeroizing<Vec<u8>>, ()> {
-    let privkey = secp256k1_get_private_key(keypath)?;
-    if privkey == secp256k1_get_private_key(keypath)? {
+pub fn secp256k1_get_private_key_twice(
+    hal: &mut impl crate::hal::Hal,
+    keypath: &[u32],
+) -> Result<zeroize::Zeroizing<Vec<u8>>, ()> {
+    let privkey = secp256k1_get_private_key(hal, keypath)?;
+    if privkey == secp256k1_get_private_key(hal, keypath)? {
         Ok(privkey)
     } else {
         Err(())
@@ -475,8 +493,8 @@ pub fn secp256k1_get_private_key_twice(keypath: &[u32]) -> Result<zeroize::Zeroi
 /// Can be used only if the keystore is unlocked. Returns the derived xpub,
 /// using bip32 derivation. Derivation is done from the xprv master, so hardened
 /// derivation is allowed.
-pub fn get_xpub_once(keypath: &[u32]) -> Result<bip32::Xpub, ()> {
-    let xpriv = get_xprv(keypath)?;
+pub fn get_xpub_once(hal: &mut impl crate::hal::Hal, keypath: &[u32]) -> Result<bip32::Xpub, ()> {
+    let xpriv = get_xprv(hal, keypath)?;
     let xpub = bitcoin::bip32::Xpub::from_priv(SECP256K1, &xpriv.xprv);
     Ok(bip32::Xpub::from(xpub))
 }
@@ -484,9 +502,9 @@ pub fn get_xpub_once(keypath: &[u32]) -> Result<bip32::Xpub, ()> {
 /// Can be used only if the keystore is unlocked. Returns the derived xpub,
 /// using bip32 derivation. Derivation is done from the xprv master, so hardened
 /// derivation is allowed.
-pub fn get_xpub_twice(keypath: &[u32]) -> Result<bip32::Xpub, ()> {
-    let res1 = get_xpub_once(keypath)?;
-    let res2 = get_xpub_once(keypath)?;
+pub fn get_xpub_twice(hal: &mut impl crate::hal::Hal, keypath: &[u32]) -> Result<bip32::Xpub, ()> {
+    let res1 = get_xpub_once(hal, keypath)?;
+    let res2 = get_xpub_once(hal, keypath)?;
     if res1 != res2 {
         return Err(());
     }
@@ -495,7 +513,10 @@ pub fn get_xpub_twice(keypath: &[u32]) -> Result<bip32::Xpub, ()> {
 
 /// Gets multiple xpubs at once. This is better than multiple calls to `get_xpub_twice()` as it only
 /// uses two secure chip operations in total, instead of two per xpub.
-pub fn get_xpubs_twice(keypaths: &[&[u32]]) -> Result<Vec<bip32::Xpub>, ()> {
+pub fn get_xpubs_twice(
+    hal: &mut impl crate::hal::Hal,
+    keypaths: &[&[u32]],
+) -> Result<Vec<bip32::Xpub>, ()> {
     if is_locked() {
         return Err(());
     }
@@ -504,8 +525,8 @@ pub fn get_xpubs_twice(keypaths: &[&[u32]]) -> Result<Vec<bip32::Xpub>, ()> {
     }
     // We get the root xprv as a starting point (twice to mitigate bitflips), afterwards we don't
     // need the securechip anymore.
-    let xprv = get_xprv(&[])?;
-    let xprv2 = get_xprv(&[])?;
+    let xprv = get_xprv(hal, &[])?;
+    let xprv2 = get_xprv(hal, &[])?;
 
     let mut out = Vec::with_capacity(keypaths.len());
     for keypath in keypaths {
@@ -546,13 +567,14 @@ pub fn root_fingerprint() -> Result<Vec<u8>, ()> {
 /// Stretches the given encryption_key using the securechip. The resulting key is used to encrypt
 /// the retained seed or bip39 seed.
 pub fn stretch_retained_seed_encryption_key(
+    hal: &mut impl crate::hal::Hal,
     encryption_key: &[u8; 32],
     purpose_in: &str,
     purpose_out: &str,
 ) -> Result<zeroize::Zeroizing<Vec<u8>>, Error> {
     let salted_in = crate::salt::hash_data(encryption_key, purpose_in).map_err(|_| Error::Salt)?;
 
-    let kdf = securechip::kdf(salted_in.as_slice())?;
+    let kdf = hal.securechip().kdf(salted_in.as_slice())?;
 
     let salted_out =
         crate::salt::hash_data(encryption_key, purpose_out).map_err(|_| Error::Salt)?;
@@ -574,8 +596,11 @@ pub extern "C" fn rust_keystore_is_locked() -> bool {
     is_locked()
 }
 
-fn bip85_entropy(keypath: &[u32]) -> Result<zeroize::Zeroizing<Vec<u8>>, ()> {
-    let priv_key = secp256k1_get_private_key_twice(keypath)?;
+fn bip85_entropy(
+    hal: &mut impl crate::hal::Hal,
+    keypath: &[u32],
+) -> Result<zeroize::Zeroizing<Vec<u8>>, ()> {
+    let priv_key = secp256k1_get_private_key_twice(hal, keypath)?;
 
     let mut engine = HmacEngine::<sha512::Hash>::new(b"bip-entropy-from-k");
     engine.input(&priv_key);
@@ -588,7 +613,11 @@ fn bip85_entropy(keypath: &[u32]) -> Result<zeroize::Zeroizing<Vec<u8>>, ()> {
 /// https://github.com/bitcoin/bips/blob/master/bip-0085.mediawiki#bip39
 /// `words` must be 12, 18 or 24.
 /// `index` must be smaller than `bip32::HARDENED`.
-pub fn bip85_bip39(words: u32, index: u32) -> Result<zeroize::Zeroizing<String>, ()> {
+pub fn bip85_bip39(
+    hal: &mut impl crate::hal::Hal,
+    words: u32,
+    index: u32,
+) -> Result<zeroize::Zeroizing<String>, ()> {
     if index >= HARDENED {
         return Err(());
     }
@@ -608,7 +637,7 @@ pub fn bip85_bip39(words: u32, index: u32) -> Result<zeroize::Zeroizing<String>,
         index + HARDENED,
     ];
 
-    let entropy = bip85_entropy(&keypath)?;
+    let entropy = bip85_entropy(hal, &keypath)?;
     crate::bip39::mnemonic_from_seed(&entropy[..seed_size])
 }
 
@@ -617,7 +646,10 @@ pub fn bip85_bip39(words: u32, index: u32) -> Result<zeroize::Zeroizing<String>,
 /// 'LN'). https://github.com/bitcoin/bips/blob/master/bip-0085.mediawiki#bip39
 /// Restricted to 16 byte output entropy.
 /// `index` must be smaller than `bip32::HARDENED`.
-pub fn bip85_ln(index: u32) -> Result<zeroize::Zeroizing<Vec<u8>>, ()> {
+pub fn bip85_ln(
+    hal: &mut impl crate::hal::Hal,
+    index: u32,
+) -> Result<zeroize::Zeroizing<Vec<u8>>, ()> {
     if index >= HARDENED {
         return Err(());
     }
@@ -629,7 +661,7 @@ pub fn bip85_ln(index: u32) -> Result<zeroize::Zeroizing<Vec<u8>>, ()> {
         index + HARDENED,
     ];
 
-    let mut entropy = bip85_entropy(&keypath)?;
+    let mut entropy = bip85_entropy(hal, &keypath)?;
     entropy.truncate(16);
     Ok(entropy)
 }
@@ -689,12 +721,12 @@ pub fn secp256k1_nonce_commit(
 /// Sign a message using the private key at the keypath, which is optionally tweaked with the given
 /// tweak.
 pub fn secp256k1_schnorr_sign(
-    random: &mut impl crate::hal::Random,
+    hal: &mut impl crate::hal::Hal,
     keypath: &[u32],
     msg: &[u8; 32],
     tweak: Option<&[u8; 32]>,
 ) -> Result<[u8; 64], ()> {
-    let private_key = secp256k1_get_private_key(keypath)?;
+    let private_key = secp256k1_get_private_key(hal, keypath)?;
     let mut keypair =
         bitcoin::secp256k1::Keypair::from_seckey_slice(SECP256K1, &private_key).map_err(|_| ())?;
 
@@ -707,7 +739,7 @@ pub fn secp256k1_schnorr_sign(
             .map_err(|_| ())?;
     }
 
-    let aux_rand = random.random_32_bytes();
+    let aux_rand = hal.random().random_32_bytes();
     let sig = SECP256K1.sign_schnorr_with_aux_rand(
         &bitcoin::secp256k1::Message::from_digest(*msg),
         &keypair,
@@ -718,8 +750,8 @@ pub fn secp256k1_schnorr_sign(
 
 /// Get the seed to be used for u2f
 #[cfg(feature = "app-u2f")]
-pub fn get_u2f_seed() -> Result<zeroize::Zeroizing<Vec<u8>>, ()> {
-    let bip39_seed = copy_bip39_seed()?;
+pub fn get_u2f_seed(hal: &mut impl crate::hal::Hal) -> Result<zeroize::Zeroizing<Vec<u8>>, ()> {
+    let bip39_seed = copy_bip39_seed(hal)?;
 
     let mut engine = HmacEngine::<bitcoin::hashes::sha256::Hash>::new(&bip39_seed);
     // Null-terminator for backwards compatibility from the time when this was coded in C.
@@ -732,7 +764,7 @@ pub fn get_u2f_seed() -> Result<zeroize::Zeroizing<Vec<u8>>, ()> {
 #[cfg(feature = "app-u2f")]
 #[unsafe(no_mangle)]
 pub extern "C" fn rust_keystore_get_u2f_seed(mut seed_out: util::bytes::BytesMut) -> bool {
-    match get_u2f_seed() {
+    match get_u2f_seed(&mut crate::hal::BitBox02Hal::new()) {
         Ok(seed) => {
             seed_out.as_mut().copy_from_slice(&seed);
             true
@@ -745,7 +777,7 @@ pub extern "C" fn rust_keystore_get_u2f_seed(mut seed_out: util::bytes::BytesMut
 pub mod testing {
     /// This mocks an unlocked keystore with the given bip39 recovery words and bip39 passphrase.
     pub fn mock_unlocked_using_mnemonic(mnemonic: &str, passphrase: &str) {
-        let mut mock_hal = crate::hal::testing::TestingRandom::new();
+        let mut mock_hal = crate::hal::testing::TestingHal::new();
         let seed = crate::bip39::mnemonic_to_seed(mnemonic).unwrap();
         super::retain_seed(&mut mock_hal, &seed).unwrap();
         util::bb02_async::block_on(super::unlock_bip39(
@@ -770,7 +802,7 @@ pub mod testing {
 mod tests {
     use super::*;
 
-    use crate::hal::testing::{TestingHal, TestingRandom};
+    use crate::hal::testing::TestingHal;
     use hex_lit::hex;
 
     use bitbox02::testing::mock_memory;
@@ -781,13 +813,14 @@ mod tests {
 
     #[test]
     fn test_copy_seed() {
+        let mut mock_hal = TestingHal::new();
         // 12 words
         mock_unlocked_using_mnemonic(
             "trust cradle viable innocent stand equal little small junior frost laundry room",
             "",
         );
         assert_eq!(
-            copy_seed().unwrap().as_slice(),
+            copy_seed(&mut mock_hal).unwrap().as_slice(),
             b"\xe9\xa6\x3f\xcd\x3a\x4d\x48\x98\x20\xa6\x63\x79\x2b\xad\xf6\xdd",
         );
 
@@ -797,7 +830,7 @@ mod tests {
             "",
         );
         assert_eq!(
-            copy_seed().unwrap().as_slice(),
+            copy_seed(&mut mock_hal).unwrap().as_slice(),
             b"\xad\xf4\x07\x8e\x0e\x0c\xb1\x4c\x34\xd6\xd6\xf2\x82\x6a\x57\xc1\x82\x06\x6a\xbb\xcd\x95\x84\xcf",
         );
 
@@ -806,7 +839,7 @@ mod tests {
             "",
         );
         assert_eq!(
-            copy_seed().unwrap().as_slice(),
+            copy_seed(&mut mock_hal).unwrap().as_slice(),
             b"\xae\x45\xd4\x02\x3a\xfa\x4a\x48\x68\x77\x51\x69\xfe\xa5\xf5\xe4\x97\xf7\xa1\xa4\xd6\x22\x9a\xd0\x23\x9e\x68\x9b\x48\x2e\xd3\x5e",
         );
     }
@@ -864,7 +897,10 @@ mod tests {
             let mut hal = TestingHal::new();
             hal.random.mock_next(seed_random);
             assert!(create_and_store_seed(&mut hal, "password", &host_entropy[..size]).is_ok());
-            assert_eq!(copy_seed().unwrap().as_slice(), &expected_seed[..size]);
+            assert_eq!(
+                copy_seed(&mut hal).unwrap().as_slice(),
+                &expected_seed[..size]
+            );
             // Check the seed has been stored encrypted with the expected encryption key.
             // Decrypt and check seed.
             let cipher = bitbox02::memory::get_encrypted_seed_and_hmac().unwrap();
@@ -910,8 +946,7 @@ mod tests {
         let unlocked_seed = unlock(&mut mock_hal, "old_password").unwrap();
         assert_eq!(unlocked_seed.as_slice(), seed.as_slice());
 
-        let mut random = crate::hal::testing::TestingRandom::new();
-        assert!(block_on(unlock_bip39(&mut random, &seed, "", async || {})).is_ok());
+        assert!(block_on(unlock_bip39(&mut mock_hal, &seed, "", async || {})).is_ok());
 
         // Step 3: Re-encrypt with new password
         assert!(re_encrypt_seed(&mut mock_hal, &seed, "new_password").is_ok());
@@ -939,11 +974,10 @@ mod tests {
         // Initial setup
         assert!(encrypt_and_store_seed(&mut mock_hal, &seed, "password1").is_ok());
 
-        let mut random = crate::hal::testing::TestingRandom::new();
-        assert!(block_on(unlock_bip39(&mut random, &seed, "", async || {})).is_ok());
+        assert!(block_on(unlock_bip39(&mut mock_hal, &seed, "", async || {})).is_ok());
 
-        let seed_reference = copy_seed().unwrap();
-        let bip39_seed_reference = copy_bip39_seed().unwrap();
+        let seed_reference = copy_seed(&mut mock_hal).unwrap();
+        let bip39_seed_reference = copy_bip39_seed(&mut mock_hal).unwrap();
         let root_fingerprint_reference = root_fingerprint().unwrap();
 
         // Re-encrypt multiple times
@@ -952,9 +986,12 @@ mod tests {
             assert!(re_encrypt_seed(&mut mock_hal, &seed_reference, new_password).is_ok());
 
             // Verify everything is still there and correct
-            assert_eq!(copy_seed().unwrap().as_slice(), seed_reference.as_slice());
             assert_eq!(
-                copy_bip39_seed().unwrap().as_slice(),
+                copy_seed(&mut mock_hal).unwrap().as_slice(),
+                seed_reference.as_slice()
+            );
+            assert_eq!(
+                copy_bip39_seed(&mut mock_hal).unwrap().as_slice(),
                 bip39_seed_reference.as_slice()
             );
             assert_eq!(root_fingerprint().unwrap(), root_fingerprint_reference);
@@ -973,8 +1010,7 @@ mod tests {
         assert!(encrypt_and_store_seed(&mut mock_hal, &seed, "password").is_ok());
         unlock(&mut mock_hal, "password").unwrap();
 
-        let mut random = crate::hal::testing::TestingRandom::new();
-        assert!(block_on(unlock_bip39(&mut random, &seed, "", async || {})).is_ok());
+        assert!(block_on(unlock_bip39(&mut mock_hal, &seed, "", async || {})).is_ok());
 
         // Try to re-encrypt with invalid seed size
         assert!(matches!(
@@ -988,19 +1024,19 @@ mod tests {
         mock_memory();
         lock();
 
-        let mut random = crate::hal::testing::TestingRandom::new();
+        let mut mock_hal = TestingHal::new();
         let bip39_seed = hex!(
             "2b3c63de86f0f2b13cc6a36c1ba2314fbc1b40c77ab9cb64e96ba4d5c62fc204748ca6626a9f035e7d431bce8c9210ec0bdffc2e7db873dee56c8ac2153eee9a"
         );
 
         // Before retention, should not be available
-        assert!(copy_bip39_seed().is_err());
+        assert!(copy_bip39_seed(&mut mock_hal).is_err());
 
         // Retain the BIP39 seed
-        assert!(retain_bip39_seed(&mut random, &bip39_seed).is_ok());
+        assert!(retain_bip39_seed(&mut mock_hal, &bip39_seed).is_ok());
 
         // Should now be available
-        let retrieved = copy_bip39_seed().unwrap();
+        let retrieved = copy_bip39_seed(&mut mock_hal).unwrap();
         assert_eq!(retrieved.as_slice(), bip39_seed.as_slice());
     }
 
@@ -1008,7 +1044,7 @@ mod tests {
     fn test_retain_bip39_seed_overwrites_previous() {
         mock_memory();
         lock();
-        let mut random = crate::hal::testing::TestingRandom::new();
+        let mut mock_hal = TestingHal::new();
         let bip39_seed1 = hex!(
             "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
         );
@@ -1017,16 +1053,16 @@ mod tests {
         );
 
         // Retain first seed
-        assert!(retain_bip39_seed(&mut random, &bip39_seed1).is_ok());
+        assert!(retain_bip39_seed(&mut mock_hal, &bip39_seed1).is_ok());
         assert_eq!(
-            copy_bip39_seed().unwrap().as_slice(),
+            copy_bip39_seed(&mut mock_hal).unwrap().as_slice(),
             bip39_seed1.as_slice()
         );
 
         // Retain second seed (should overwrite)
-        assert!(retain_bip39_seed(&mut random, &bip39_seed2).is_ok());
+        assert!(retain_bip39_seed(&mut mock_hal, &bip39_seed2).is_ok());
         assert_eq!(
-            copy_bip39_seed().unwrap().as_slice(),
+            copy_bip39_seed(&mut mock_hal).unwrap().as_slice(),
             bip39_seed2.as_slice()
         );
     }
@@ -1044,19 +1080,22 @@ mod tests {
         assert!(encrypt_and_store_seed(&mut TestingHal::new(), &seed, "password").is_ok());
         // Create new (different) seed.
         assert!(encrypt_and_store_seed(&mut TestingHal::new(), &seed2, "password").is_ok());
-        assert_eq!(copy_seed().unwrap().as_slice(), &seed2);
+        assert_eq!(
+            copy_seed(&mut TestingHal::new()).unwrap().as_slice(),
+            &seed2
+        );
     }
 
     #[test]
     fn test_lock() {
-        let mut random = crate::hal::testing::TestingRandom::new();
+        let mut mock_hal = TestingHal::new();
         lock();
         assert!(is_locked());
 
         let seed = hex!("cb33c20cea62a5c277527e2002da82e6e2b37450a755143a540a54cea8da9044");
-        assert!(encrypt_and_store_seed(&mut TestingHal::new(), &seed, "password").is_ok());
+        assert!(encrypt_and_store_seed(&mut mock_hal, &seed, "password").is_ok());
         assert!(is_locked()); // still locked, it is only unlocked after unlock_bip39.
-        assert!(block_on(unlock_bip39(&mut random, &seed, "foo", async || {})).is_ok());
+        assert!(block_on(unlock_bip39(&mut mock_hal, &seed, "foo", async || {})).is_ok());
         assert!(!is_locked());
         lock();
         assert!(is_locked());
@@ -1127,7 +1166,7 @@ mod tests {
             // Still seeded.
             assert!(bitbox02::memory::is_seeded());
             // Wrong password does not lock the keystore again if already unlocked.
-            assert!(copy_seed().is_ok());
+            assert!(copy_seed(&mut mock_hal).is_ok());
         }
         // Last attempt, triggers reset.
         assert!(matches!(
@@ -1136,7 +1175,7 @@ mod tests {
         ));
         // Last wrong attempt locks & resets. There is no more seed.
         assert!(!bitbox02::memory::is_seeded());
-        assert!(copy_seed().is_err());
+        assert!(copy_seed(&mut mock_hal).is_err());
         assert!(matches!(
             unlock(&mut mock_hal, "password"),
             Err(Error::Unseeded)
@@ -1158,7 +1197,7 @@ mod tests {
         assert!(encrypt_and_store_seed(&mut mock_hal, &seed, "password").is_ok());
         lock();
         assert!(is_locked());
-        assert!(copy_seed().is_err());
+        assert!(copy_seed(&mut mock_hal).is_err());
 
         for attempt in 1..bitbox02::memory::MAX_UNLOCK_ATTEMPTS {
             assert!(matches!(
@@ -1171,7 +1210,7 @@ mod tests {
                 bitbox02::memory::MAX_UNLOCK_ATTEMPTS - attempt
             );
             assert!(is_locked());
-            assert!(copy_seed().is_err());
+            assert!(copy_seed(&mut mock_hal).is_err());
             assert!(bitbox02::memory::is_seeded());
         }
 
@@ -1180,7 +1219,7 @@ mod tests {
             Err(Error::MaxAttemptsExceeded)
         ));
         assert!(is_locked());
-        assert!(copy_seed().is_err());
+        assert!(copy_seed(&mut mock_hal).is_err());
         assert!(!bitbox02::memory::is_seeded());
         assert!(matches!(
             unlock(&mut mock_hal, "password"),
@@ -1219,7 +1258,7 @@ mod tests {
             Err(Error::MaxAttemptsExceeded)
         ));
         assert!(is_locked());
-        assert!(copy_seed().is_err());
+        assert!(copy_seed(&mut mock_hal).is_err());
         assert!(!bitbox02::memory::is_seeded());
     }
 
@@ -1252,16 +1291,16 @@ mod tests {
         }
 
         wrong_attempt(&mut mock_hal);
-        assert!(copy_seed().is_err());
+        assert!(copy_seed(&mut mock_hal).is_err());
 
         assert_eq!(unlock(&mut mock_hal, "password").unwrap().as_slice(), seed);
-        assert!(copy_seed().is_ok());
+        assert!(copy_seed(&mut mock_hal).is_ok());
 
         lock();
-        assert!(copy_seed().is_err());
+        assert!(copy_seed(&mut mock_hal).is_err());
 
         wrong_attempt(&mut mock_hal);
-        assert!(copy_seed().is_err());
+        assert!(copy_seed(&mut mock_hal).is_err());
         assert!(bitbox02::memory::is_seeded());
     }
 
@@ -1283,7 +1322,7 @@ mod tests {
         lock();
 
         assert_eq!(unlock(&mut mock_hal, "password").unwrap().as_slice(), seed);
-        assert!(copy_seed().is_ok());
+        assert!(copy_seed(&mut mock_hal).is_ok());
 
         fn wrong_attempt(hal: &mut impl crate::hal::Hal) {
             assert!(matches!(
@@ -1297,13 +1336,13 @@ mod tests {
         }
 
         wrong_attempt(&mut mock_hal);
-        assert!(copy_seed().is_ok());
+        assert!(copy_seed(&mut mock_hal).is_ok());
 
         assert_eq!(unlock(&mut mock_hal, "password").unwrap().as_slice(), seed);
-        assert!(copy_seed().is_ok());
+        assert!(copy_seed(&mut mock_hal).is_ok());
 
         wrong_attempt(&mut mock_hal);
-        assert!(copy_seed().is_ok());
+        assert!(copy_seed(&mut mock_hal).is_ok());
         assert!(bitbox02::memory::is_seeded());
     }
 
@@ -1324,7 +1363,7 @@ mod tests {
         // Incorrect seed passed
         assert!(
             block_on(unlock_bip39(
-                &mut crate::hal::testing::TestingRandom::new(),
+                &mut TestingHal::new(),
                 b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                 "foo",
                 async || {}
@@ -1332,15 +1371,15 @@ mod tests {
             .is_err()
         );
         // Correct seed passed.
-        let mut random = crate::hal::testing::TestingRandom::new();
+        let mut mock_hal = TestingHal::new();
         // Mock random value used for creating the unstretched bip39 seed encryption key.
-        random.mock_next(hex!(
+        mock_hal.random.mock_next(hex!(
             "9b44c7048893faaf6e2d7625d13d8f1cab0765fd61f159d9713e08155d06717c"
         ));
 
-        bitbox02::securechip::fake_event_counter_reset();
-        assert!(block_on(unlock_bip39(&mut random, &seed, "foo", async || {})).is_ok());
-        assert_eq!(bitbox02::securechip::fake_event_counter(), 1);
+        mock_hal.securechip.event_counter_reset();
+        assert!(block_on(unlock_bip39(&mut mock_hal, &seed, "foo", async || {})).is_ok());
+        assert_eq!(mock_hal.securechip.get_event_counter(), 1);
         assert_eq!(root_fingerprint(), Ok(vec![0xf1, 0xbc, 0x3c, 0x46]),);
 
         let expected_bip39_seed = hex!(
@@ -1348,7 +1387,7 @@ mod tests {
         );
 
         assert_eq!(
-            copy_bip39_seed().unwrap().as_slice(),
+            copy_bip39_seed(&mut mock_hal).unwrap().as_slice(),
             expected_bip39_seed.as_slice()
         );
 
@@ -1372,49 +1411,62 @@ mod tests {
     #[test]
     fn test_secp256k1_get_private_key() {
         lock();
+
+        let mut mock_hal = TestingHal::new();
+
         let keypath = &[84 + HARDENED, 0 + HARDENED, 0 + HARDENED, 0, 0];
-        assert!(secp256k1_get_private_key(keypath).is_err());
+        assert!(secp256k1_get_private_key(&mut mock_hal, keypath).is_err());
 
         mock_unlocked_using_mnemonic(
             "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
             "",
         );
 
-        bitbox02::securechip::fake_event_counter_reset();
+        mock_hal.securechip.event_counter_reset();
         assert_eq!(
-            secp256k1_get_private_key(keypath).unwrap().as_slice(),
+            secp256k1_get_private_key(&mut mock_hal, keypath)
+                .unwrap()
+                .as_slice(),
             hex!("4604b4b710fe91f584fff084e1a9159fe4f8408fff380596a604948474ce4fa3"),
         );
-        assert_eq!(bitbox02::securechip::fake_event_counter(), 1);
+        assert_eq!(mock_hal.securechip.get_event_counter(), 1);
     }
 
     #[test]
     fn test_secp256k1_get_private_key_twice() {
         lock();
+
+        let mut mock_hal = TestingHal::new();
+
         let keypath = &[84 + HARDENED, 0 + HARDENED, 0 + HARDENED, 0, 0];
-        assert!(secp256k1_get_private_key_twice(keypath).is_err());
+        assert!(secp256k1_get_private_key_twice(&mut mock_hal, keypath).is_err());
 
         mock_unlocked_using_mnemonic(
             "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
             "",
         );
 
-        bitbox02::securechip::fake_event_counter_reset();
+        mock_hal.securechip.event_counter_reset();
         assert_eq!(
-            secp256k1_get_private_key_twice(keypath).unwrap().as_slice(),
+            secp256k1_get_private_key_twice(&mut mock_hal, keypath)
+                .unwrap()
+                .as_slice(),
             hex!("4604b4b710fe91f584fff084e1a9159fe4f8408fff380596a604948474ce4fa3"),
         );
-        assert_eq!(bitbox02::securechip::fake_event_counter(), 2);
+        assert_eq!(mock_hal.securechip.get_event_counter(), 2);
     }
 
     #[test]
     fn test_get_bip39_mnemonic() {
         lock();
-        assert!(get_bip39_mnemonic().is_err());
+        assert!(get_bip39_mnemonic(&mut TestingHal::new()).is_err());
 
         mock_unlocked();
 
-        assert_eq!(get_bip39_mnemonic().unwrap().as_str(), TEST_MNEMONIC);
+        assert_eq!(
+            get_bip39_mnemonic(&mut TestingHal::new()).unwrap().as_str(),
+            TEST_MNEMONIC
+        );
     }
 
     #[test]
@@ -1423,8 +1475,10 @@ mod tests {
         // Also test with unhardened and non-zero elements.
         let keypath_5 = &[44 + HARDENED, 1 + HARDENED, 10 + HARDENED, 1, 100];
 
+        let mut mock_hal = TestingHal::new();
+
         lock();
-        assert!(get_xpub_twice(keypath).is_err());
+        assert!(get_xpub_twice(&mut mock_hal, keypath).is_err());
 
         // 24 words
         mock_unlocked_using_mnemonic(
@@ -1432,27 +1486,27 @@ mod tests {
             "",
         );
 
-        bitbox02::securechip::fake_event_counter_reset();
+        mock_hal.securechip.event_counter_reset();
 
         assert_eq!(
-            get_xpub_twice(&[])
+            get_xpub_twice(&mut mock_hal, &[])
                 .unwrap()
                 .serialize_str(bip32::XPubType::Xpub)
                 .unwrap(),
             "xpub661MyMwAqRbcEhX8d9WJh78SZrxusAzWFoykz4n5CF75uYRzixw5FZPUSoWyhaaJ1bpiPFdzdHSQqJN38PcTkyrLmxT4J2JDYfoGJQ4ioE2",
         );
 
-        assert_eq!(bitbox02::securechip::fake_event_counter(), 2);
+        assert_eq!(mock_hal.securechip.get_event_counter(), 2);
 
         assert_eq!(
-            get_xpub_twice(keypath)
+            get_xpub_twice(&mut mock_hal, keypath)
                 .unwrap()
                 .serialize_str(bip32::XPubType::Xpub)
                 .unwrap(),
             "xpub6Cj6NNCGj2CRPHvkuEG1rbW3nrNCAnLjaoTg1P67FCGoahSsbg9WQ7YaMEEP83QDxt2kZ3hTPAPpGdyEZcfAC1C75HfR66UbjpAb39f4PnG",
         );
         assert_eq!(
-            get_xpub_twice(keypath_5)
+            get_xpub_twice(&mut mock_hal, keypath_5)
                 .unwrap()
                 .serialize_str(bip32::XPubType::Xpub)
                 .unwrap(),
@@ -1465,7 +1519,7 @@ mod tests {
             "",
         );
         assert_eq!(
-            get_xpub_twice(keypath)
+            get_xpub_twice(&mut mock_hal, keypath)
                 .unwrap()
                 .serialize_str(bip32::XPubType::Xpub)
                 .unwrap(),
@@ -1478,7 +1532,7 @@ mod tests {
             "",
         );
         assert_eq!(
-            get_xpub_twice(keypath)
+            get_xpub_twice(&mut mock_hal, keypath)
                 .unwrap()
                 .serialize_str(bip32::XPubType::Xpub)
                 .unwrap(),
@@ -1489,7 +1543,8 @@ mod tests {
     #[test]
     fn test_get_xpubs_twice() {
         lock();
-        assert!(get_xpubs_twice(&[]).is_err());
+
+        assert!(get_xpubs_twice(&mut TestingHal::new(), &[]).is_err());
 
         mock_unlocked_using_mnemonic(
             "sleep own lobster state clean thrive tail exist cactus bitter pass soccer clinic riot dream turkey before sport action praise tunnel hood donate man",
@@ -1497,30 +1552,35 @@ mod tests {
         );
 
         // Helper to convert to strings.
-        let get = |keypaths| -> Vec<String> {
-            get_xpubs_twice(keypaths)
+        fn get(hal: &mut impl crate::hal::Hal, keypaths: &[&[u32]]) -> Vec<String> {
+            get_xpubs_twice(hal, keypaths)
                 .unwrap()
                 .iter()
                 .map(|xpub| xpub.serialize_str(bip32::XPubType::Xpub).unwrap())
                 .collect()
-        };
+        }
 
-        bitbox02::securechip::fake_event_counter_reset();
-        assert!(get_xpubs_twice(&[]).unwrap().is_empty());
-        assert_eq!(bitbox02::securechip::fake_event_counter(), 0);
+        let mut mock_hal = TestingHal::new();
 
-        bitbox02::securechip::fake_event_counter_reset();
+        mock_hal.securechip.event_counter_reset();
+        assert!(get_xpubs_twice(&mut mock_hal, &[]).unwrap().is_empty());
+        assert_eq!(mock_hal.securechip.get_event_counter(), 0);
+
+        mock_hal.securechip.event_counter_reset();
         assert_eq!(
-            get(&[
-                &[84 + HARDENED, HARDENED, HARDENED],
-                &[86 + HARDENED, HARDENED, HARDENED],
-            ]),
+            get(
+                &mut mock_hal,
+                &[
+                    &[84 + HARDENED, HARDENED, HARDENED],
+                    &[86 + HARDENED, HARDENED, HARDENED],
+                ]
+            ),
             vec![
                 "xpub6CNbmcHwZDudAvCAZVE5kejUoFD63mbkRbRMA2HoF9oNWsCofni87gJKp31qZJ9FsCMQR2vK9AS51mT8dgUMGsHW6SfaAKb4eSzpqJn7zwK",
                 "xpub6CGwpj8iQNuzSeeEKF4yuQt32fpLqfHj7sUfFH4uW34DoctWPksxAdjNYC9KwYgwA149B7SDdcLH1aFmucRcjBL4U6piN7HgaiFCBsToamH",
             ],
         );
-        assert_eq!(bitbox02::securechip::fake_event_counter(), 2);
+        assert_eq!(mock_hal.securechip.get_event_counter(), 2);
     }
 
     #[test]
@@ -1558,6 +1618,7 @@ mod tests {
             hex!("00112233445566778899aabbccddeeff112233445566778899aabbccddeeff00");
 
         let stretched = stretch_retained_seed_encryption_key(
+            &mut TestingHal::new(),
             &encryption_key,
             "keystore_retained_seed_access_in",
             "keystore_retained_seed_access_out",
@@ -1574,15 +1635,19 @@ mod tests {
         bitbox02::memory::set_salt_root(&[0xffu8; 32]).unwrap();
 
         let encryption_key = [0u8; 32];
-        let result =
-            stretch_retained_seed_encryption_key(&encryption_key, "purpose_in", "purpose_out");
+        let result = stretch_retained_seed_encryption_key(
+            &mut TestingHal::new(),
+            &encryption_key,
+            "purpose_in",
+            "purpose_out",
+        );
         assert!(matches!(result, Err(Error::Salt)));
     }
 
     #[test]
     fn test_bip85_bip39() {
         lock();
-        assert!(bip85_bip39(12, 0).is_err());
+        assert!(bip85_bip39(&mut TestingHal::new(), 12, 0).is_err());
 
         // Test fixtures generated using:
         // `docker build -t bip85 .`
@@ -1599,36 +1664,38 @@ mod tests {
         );
 
         assert_eq!(
-            bip85_bip39(12, 0).unwrap().as_ref() as &str,
+            bip85_bip39(&mut TestingHal::new(), 12, 0).unwrap().as_ref() as &str,
             "slender whip place siren tissue chaos ankle door only assume tent shallow",
         );
         assert_eq!(
-            bip85_bip39(12, 1).unwrap().as_ref() as &str,
+            bip85_bip39(&mut TestingHal::new(), 12, 1).unwrap().as_ref() as &str,
             "income soft level reunion height pony crane use unfold win keen satisfy",
         );
         assert_eq!(
-            bip85_bip39(12, HARDENED - 1).unwrap().as_ref() as &str,
+            bip85_bip39(&mut TestingHal::new(), 12, HARDENED - 1)
+                .unwrap()
+                .as_ref() as &str,
             "carry build nerve market domain energy mistake script puzzle replace mixture idea",
         );
         assert_eq!(
-            bip85_bip39(18, 0).unwrap().as_ref() as &str,
+            bip85_bip39(&mut TestingHal::new(), 18, 0).unwrap().as_ref() as &str,
             "enact peasant tragic habit expand jar senior melody coin acid logic upper soccer later earn napkin planet stereo",
         );
         assert_eq!(
-            bip85_bip39(24, 0).unwrap().as_ref() as &str,
+            bip85_bip39(&mut TestingHal::new(), 24, 0).unwrap().as_ref() as &str,
             "cabbage wink october add anchor mean tray surprise gasp tomorrow garbage habit beyond merge where arrive beef gentle animal office drop panel chest size",
         );
 
         // Invalid number of words.
-        assert!(bip85_bip39(10, 0).is_err());
+        assert!(bip85_bip39(&mut TestingHal::new(), 10, 0).is_err());
         // Index too high.
-        assert!(bip85_bip39(12, HARDENED).is_err());
+        assert!(bip85_bip39(&mut TestingHal::new(), 12, HARDENED).is_err());
     }
 
     #[test]
     fn test_bip85_ln() {
         lock();
-        assert!(bip85_ln(0).is_err());
+        assert!(bip85_ln(&mut TestingHal::new(), 0).is_err());
 
         mock_unlocked_using_mnemonic(
             "virtual weapon code laptop defy cricket vicious target wave leopard garden give",
@@ -1636,20 +1703,22 @@ mod tests {
         );
 
         assert_eq!(
-            bip85_ln(0).unwrap().as_slice(),
+            bip85_ln(&mut TestingHal::new(), 0).unwrap().as_slice(),
             hex!("3a5f3b888aab88e2a9ab991b60a03ed8"),
         );
         assert_eq!(
-            bip85_ln(1).unwrap().as_slice(),
+            bip85_ln(&mut TestingHal::new(), 1).unwrap().as_slice(),
             hex!("e7d9ce75f8cb17570e665417b47fa0be"),
         );
         assert_eq!(
-            bip85_ln(HARDENED - 1).unwrap().as_slice(),
+            bip85_ln(&mut TestingHal::new(), HARDENED - 1)
+                .unwrap()
+                .as_slice(),
             hex!("1f3b75ea252749700a1e453469148ca6"),
         );
 
         // Index too high.
-        assert!(bip85_ln(HARDENED).is_err());
+        assert!(bip85_ln(&mut TestingHal::new(), HARDENED).is_err());
     }
 
     #[test]
@@ -1707,11 +1776,11 @@ mod tests {
             lock();
             let seed = &seed[..test.seed_len];
 
-            let mut mock_hal = crate::hal::testing::TestingHal::new();
+            let mut mock_hal = TestingHal::new();
 
             assert!(
                 block_on(unlock_bip39(
-                    &mut mock_hal.random,
+                    &mut mock_hal,
                     seed,
                     test.mnemonic_passphrase,
                     async || {}
@@ -1728,7 +1797,7 @@ mod tests {
             mock_hal.securechip.event_counter_reset();
             assert!(
                 block_on(unlock_bip39(
-                    &mut mock_hal.random,
+                    &mut mock_hal,
                     seed,
                     test.mnemonic_passphrase,
                     async || {}
@@ -1739,20 +1808,23 @@ mod tests {
 
             assert!(!is_locked());
             assert_eq!(
-                get_bip39_mnemonic().unwrap().as_str(),
+                get_bip39_mnemonic(&mut mock_hal).unwrap().as_str(),
                 test.expected_mnemonic,
             );
             let keypath = &[44 + HARDENED, 0 + HARDENED, 0 + HARDENED];
 
             mock_hal.securechip.event_counter_reset();
-            let xpub = get_xpub_once(keypath).unwrap();
+            let xpub = get_xpub_once(&mut mock_hal, keypath).unwrap();
             assert_eq!(mock_hal.securechip.get_event_counter(), 1);
 
             assert_eq!(
                 xpub.serialize_str(crate::bip32::XPubType::Xpub).unwrap(),
                 test.expected_xpub,
             );
-            assert_eq!(get_u2f_seed().unwrap().as_slice(), test.expected_u2f_seed);
+            assert_eq!(
+                get_u2f_seed(&mut mock_hal).unwrap().as_slice(),
+                test.expected_u2f_seed
+            );
         }
     }
 
@@ -1826,7 +1898,7 @@ mod tests {
             let host_commitment: [u8; 32] = host_commitment_vec.try_into().unwrap();
 
             // Get pubkey at keypath.
-            let private_key = secp256k1_get_private_key(&keypath).unwrap();
+            let private_key = secp256k1_get_private_key(&mut TestingHal::new(), &keypath).unwrap();
             let private_key_bytes: [u8; 32] = private_key.as_slice().try_into().unwrap();
             let secret_key = secp256k1::SecretKey::from_slice(&private_key_bytes).unwrap();
             let public_key = secret_key.public_key(SECP256K1);
@@ -1881,10 +1953,10 @@ mod tests {
 
         // Test without tweak
 
-        bitbox02::securechip::fake_event_counter_reset();
-        let mut random = crate::hal::testing::TestingRandom::new();
-        let sig = secp256k1_schnorr_sign(&mut random, &keypath, &msg, None).unwrap();
-        assert_eq!(bitbox02::securechip::fake_event_counter(), 1);
+        let mut mock_hal = TestingHal::new();
+        mock_hal.securechip.event_counter_reset();
+        let sig = secp256k1_schnorr_sign(&mut mock_hal, &keypath, &msg, None).unwrap();
+        assert_eq!(mock_hal.securechip.get_event_counter(), 1);
 
         assert!(
             SECP256K1
@@ -1902,8 +1974,8 @@ mod tests {
         ))
         .unwrap();
         let (tweaked_pubkey, _) = expected_pubkey.add_tweak(SECP256K1, &tweak).unwrap();
-        let mut random = crate::hal::testing::TestingRandom::new();
-        let sig = secp256k1_schnorr_sign(&mut random, &keypath, &msg, Some(&tweak.to_be_bytes()))
+        let mut mock_hal = TestingHal::new();
+        let sig = secp256k1_schnorr_sign(&mut mock_hal, &keypath, &msg, Some(&tweak.to_be_bytes()))
             .unwrap();
         assert!(
             SECP256K1
@@ -1932,11 +2004,14 @@ mod tests {
                 assert!(encrypt_and_store_seed(&mut mock_hal, &seed[..seed_size], "foo").is_ok());
             }
             // Also unlocks, so we can get the retained seed.
-            assert_eq!(copy_seed().unwrap().as_slice(), &seed[..seed_size]);
+            assert_eq!(
+                copy_seed(&mut mock_hal).unwrap().as_slice(),
+                &seed[..seed_size]
+            );
 
             lock();
             // Can't get seed before unlock.
-            assert!(copy_seed().is_err());
+            assert!(copy_seed(&mut mock_hal).is_err());
 
             // Wrong password.
             assert!(matches!(
@@ -1952,7 +2027,10 @@ mod tests {
                     &seed[..seed_size]
                 );
             }
-            assert_eq!(copy_seed().unwrap().as_slice(), &seed[..seed_size]);
+            assert_eq!(
+                copy_seed(&mut mock_hal).unwrap().as_slice(),
+                &seed[..seed_size]
+            );
 
             // Can't store new seed once initialized.
             bitbox02::memory::set_initialized().unwrap();

--- a/src/rust/bitbox02-rust/src/keystore/ed25519.rs
+++ b/src/rust/bitbox02-rust/src/keystore/ed25519.rs
@@ -30,8 +30,8 @@ fn hmac_sha512(key: &[u8], msg: &[u8]) -> [u8; 64] {
 /// This implements a derivation compatible with Ledger according to
 /// https://github.com/LedgerHQ/orakolo/blob/0b2d5e669ec61df9a824df9fa1a363060116b490/src/python/orakolo/HDEd25519.py.
 /// Returns 96 bytes. It will contain a 64 byte expanded ed25519 private key followed by a 32 byte chain code.
-fn get_seed() -> Result<zeroize::Zeroizing<Vec<u8>>, ()> {
-    let bip39_seed = crate::keystore::copy_bip39_seed()?;
+fn get_seed(hal: &mut impl crate::hal::Hal) -> Result<zeroize::Zeroizing<Vec<u8>>, ()> {
+    let bip39_seed = crate::keystore::copy_bip39_seed(hal)?;
     let mut seed_out = zeroize::Zeroizing::new(vec![0u8; 96]);
     let first64: &mut [u8] = &mut seed_out.as_mut_slice()[..64];
     first64.copy_from_slice(&bip39_seed);
@@ -58,8 +58,8 @@ fn get_seed() -> Result<zeroize::Zeroizing<Vec<u8>>, ()> {
     Ok(seed_out)
 }
 
-fn get_xprv(keypath: &[u32]) -> Result<Xprv<Sha512>, ()> {
-    let root = get_seed()?;
+fn get_xprv(hal: &mut impl crate::hal::Hal, keypath: &[u32]) -> Result<Xprv<Sha512>, ()> {
+    let root = get_seed(hal)?;
     Ok(Xprv::<Sha512>::from_normalize(
         &root[..ED25519_EXPANDED_SECRET_KEY_SIZE],
         &root[ED25519_EXPANDED_SECRET_KEY_SIZE..],
@@ -67,8 +67,8 @@ fn get_xprv(keypath: &[u32]) -> Result<Xprv<Sha512>, ()> {
     .derive_path(keypath))
 }
 
-pub fn get_xpub(keypath: &[u32]) -> Result<Xpub<Sha512>, ()> {
-    Ok(get_xprv(keypath)?.public())
+pub fn get_xpub(hal: &mut impl crate::hal::Hal, keypath: &[u32]) -> Result<Xpub<Sha512>, ()> {
+    Ok(get_xprv(hal, keypath)?.public())
 }
 
 pub struct SignResult {
@@ -76,8 +76,12 @@ pub struct SignResult {
     pub public_key: ed25519_dalek::VerifyingKey,
 }
 
-pub fn sign(keypath: &[u32], msg: &[u8; 32]) -> Result<SignResult, ()> {
-    let xprv = get_xprv(keypath)?;
+pub fn sign(
+    hal: &mut impl crate::hal::Hal,
+    keypath: &[u32],
+    msg: &[u8; 32],
+) -> Result<SignResult, ()> {
+    let xprv = get_xprv(hal, keypath)?;
     let secret_key =
         ed25519_dalek::hazmat::ExpandedSecretKey::from_bytes(&xprv.expanded_secret_key());
     let public_key = ed25519_dalek::VerifyingKey::from(&secret_key);
@@ -119,12 +123,14 @@ mod tests {
         // https://github.com/cardano-foundation/CIPs/blob/6c249ef48f8f5b32efc0ec768fadf4321f3173f2/CIP-0003/Ledger.md#test-vectors
         // See also: https://github.com/cardano-foundation/CIPs/pull/132
 
+        let mut mock_hal = crate::hal::testing::TestingHal::new();
+
         mock_unlocked_using_mnemonic(
             "recall grace sport punch exhibit mad harbor stand obey short width stem awkward used stairs wool ugly trap season stove worth toward congress jaguar",
             "",
         );
         assert_eq!(
-            get_seed().unwrap().as_slice(),
+            get_seed(&mut mock_hal).unwrap().as_slice(),
             b"\xa0\x8c\xf8\x5b\x56\x4e\xcf\x3b\x94\x7d\x8d\x43\x21\xfb\x96\xd7\x0e\xe7\xbb\x76\x08\x77\xe3\x71\x89\x9b\x14\xe2\xcc\xf8\x86\x58\x10\x4b\x88\x46\x82\xb5\x7e\xfd\x97\xde\xcb\xb3\x18\xa4\x5c\x05\xa5\x27\xb9\xcc\x5c\x2f\x64\xf7\x35\x29\x35\xa0\x49\xce\xea\x60\x68\x0d\x52\x30\x81\x94\xcc\xef\x2a\x18\xe6\x81\x2b\x45\x2a\x58\x15\xfb\xd7\xf5\xba\xbc\x08\x38\x56\x91\x9a\xaf\x66\x8f\xe7\xe4",
         );
 
@@ -134,7 +140,7 @@ mod tests {
             "",
         );
         assert_eq!(
-            get_seed().unwrap().as_slice(),
+            get_seed(&mut mock_hal).unwrap().as_slice(),
             b"\x58\x7c\x67\x74\x35\x7e\xcb\xf8\x40\xd4\xdb\x64\x04\xff\x7a\xf0\x16\xda\xce\x04\x00\x76\x97\x51\xad\x2a\xbf\xc7\x7b\x9a\x38\x44\xcc\x71\x70\x25\x20\xef\x1a\x4d\x1b\x68\xb9\x11\x87\x78\x7a\x9b\x8f\xaa\xb0\xa9\xbb\x6b\x16\x0d\xe5\x41\xb6\xee\x62\x46\x99\x01\xfc\x0b\xed\xa0\x97\x5f\xe4\x76\x3b\xea\xbd\x83\xb7\x05\x1a\x5f\xd5\xcb\xce\x5b\x88\xe8\x2c\x4b\xba\xca\x26\x50\x14\xe5\x24\xbd",
         );
 
@@ -143,7 +149,7 @@ mod tests {
             "foo",
         );
         assert_eq!(
-            get_seed().unwrap().as_slice(),
+            get_seed(&mut mock_hal).unwrap().as_slice(),
             b"\xf0\x53\xa1\xe7\x52\xde\x5c\x26\x19\x7b\x60\xf0\x32\xa4\x80\x9f\x08\xbb\x3e\x5d\x90\x48\x4f\xe4\x20\x24\xbe\x31\xef\xcb\xa7\x57\x8d\x91\x4d\x3f\xf9\x92\xe2\x16\x52\xfe\xe6\xa4\xd9\x9f\x60\x91\x00\x69\x38\xfa\xc2\xc0\xc0\xf9\xd2\xde\x0b\xa6\x4b\x75\x4e\x92\xa4\xf3\x72\x3f\x23\x47\x20\x77\xaa\x4c\xd4\xdd\x8a\x8a\x17\x5d\xba\x07\xea\x18\x52\xda\xd1\xcf\x26\x8c\x61\xa2\x67\x9c\x38\x90",
         );
     }
@@ -151,15 +157,18 @@ mod tests {
     #[test]
     fn test_get_xpub() {
         crate::keystore::lock();
-        assert!(get_xpub(&[]).is_err());
+
+        let mut mock_hal = crate::hal::testing::TestingHal::new();
+
+        assert!(get_xpub(&mut mock_hal, &[]).is_err());
 
         mock_unlocked();
 
-        let xpub = get_xpub(&[]).unwrap();
+        let xpub = get_xpub(&mut mock_hal, &[]).unwrap();
         assert_eq!(xpub.pubkey_bytes(), b"\x1c\xc2\xc8\x0d\x6f\xb0\x3e\xc0\x9e\x8a\x26\x8b\xaa\x45\xd4\xca\x2a\xfe\x5c\x5a\xc4\xdb\x3e\xe2\x9c\x7a\xd2\x37\x55\xab\xdc\x14");
         assert_eq!(xpub.chain_code(), b"\xf0\xa5\x91\x06\x42\xd0\x77\x98\x17\x40\x2e\x5e\x7a\x75\x54\x95\xe7\x44\xf5\x5c\xf1\x1e\x49\xee\xfd\x22\xa4\x60\xe9\xb2\xf7\x53");
 
-        let xpub = get_xpub(&[10 + HARDENED_OFFSET, 10]).unwrap();
+        let xpub = get_xpub(&mut mock_hal, &[10 + HARDENED_OFFSET, 10]).unwrap();
         assert_eq!(xpub.pubkey_bytes(), b"\xab\x58\xbd\x94\x7e\x2b\xf6\x64\xa7\xc0\x66\xde\x2e\xf0\x24\x0e\xfc\x24\xf3\x6e\xfd\x50\x2d\xf8\x83\x93\xe1\x96\xaf\x3c\x91\x8e");
         assert_eq!(xpub.chain_code(), b"\xf2\x00\x13\x38\x58\x02\xa6\xf9\xc0\x5e\xe7\xb0\x36\x16\xad\xf6\x9f\x5f\x9e\xc4\x32\x53\xa5\xd0\x8b\xe9\x65\x79\x81\x90\x83\xbb");
     }
@@ -167,13 +176,16 @@ mod tests {
     #[test]
     fn test_get_xprv() {
         crate::keystore::lock();
-        assert!(get_xprv(&[]).is_err());
+
+        let mut mock_hal = crate::hal::testing::TestingHal::new();
+
+        assert!(get_xprv(&mut mock_hal, &[]).is_err());
 
         mock_unlocked();
-        let xprv = get_xprv(&[]).unwrap();
+        let xprv = get_xprv(&mut mock_hal, &[]).unwrap();
         assert_eq!(xprv.expanded_secret_key().as_slice(), b"\xf8\xcb\x28\x85\x37\x60\x2b\x90\xd1\x29\x75\x4b\xdd\x0e\x4b\xed\xf9\xe2\x92\x3a\x04\xb6\x86\x7e\xdb\xeb\xc7\x93\xa7\x17\x6f\x5d\xca\xc5\xc9\x5d\x5f\xd2\x3a\x8e\x01\x6c\x95\x57\x69\x0e\xad\x1f\x00\x2b\x0f\x35\xd7\x06\xff\x8e\x59\x84\x1c\x09\xe0\xb6\xbb\x23");
 
-        let xprv = get_xprv(&[10 + HARDENED_OFFSET, 10]).unwrap();
+        let xprv = get_xprv(&mut mock_hal, &[10 + HARDENED_OFFSET, 10]).unwrap();
         assert_eq!(xprv.expanded_secret_key().as_slice(), b"\x00\x28\x46\xb1\xeb\x06\x66\xff\x4e\xf1\x66\xde\x37\x80\xdf\xe1\x95\xed\x6f\xfd\xce\x41\x18\x09\x9d\x9d\x80\x85\xaa\x17\x6f\x5d\x1f\xcf\xf9\x55\x2e\xe4\xc0\xcb\x03\xaa\x42\x1a\xe8\x2f\x98\xa0\x0a\xfc\x65\xb6\x84\x66\x31\xaa\x41\x8e\x6d\x5a\x62\x6e\x75\xf4");
     }
 
@@ -181,10 +193,22 @@ mod tests {
     fn test_sign() {
         let msg = &[0u8; 32];
         crate::keystore::lock();
-        assert!(sign(&[10 + HARDENED_OFFSET, 10], msg).is_err());
+        assert!(
+            sign(
+                &mut crate::hal::testing::TestingHal::new(),
+                &[10 + HARDENED_OFFSET, 10],
+                msg
+            )
+            .is_err()
+        );
 
         mock_unlocked();
-        let sig = sign(&[10 + HARDENED_OFFSET, 10], msg).unwrap();
+        let sig = sign(
+            &mut crate::hal::testing::TestingHal::new(),
+            &[10 + HARDENED_OFFSET, 10],
+            msg,
+        )
+        .unwrap();
         assert_eq!(sig.public_key.as_ref(), b"\xab\x58\xbd\x94\x7e\x2b\xf6\x64\xa7\xc0\x66\xde\x2e\xf0\x24\x0e\xfc\x24\xf3\x6e\xfd\x50\x2d\xf8\x83\x93\xe1\x96\xaf\x3c\x91\x8e");
         assert_eq!(
             sig.signature,

--- a/src/rust/bitbox02-rust/src/workflow/unlock.rs
+++ b/src/rust/bitbox02-rust/src/workflow/unlock.rs
@@ -137,7 +137,7 @@ pub async fn unlock_bip39(hal: &mut impl crate::hal::Hal, seed: &[u8]) {
     let ((), result) = futures_lite::future::zip(
         super::unlock_animation::animate(),
         crate::keystore::unlock_bip39(
-            hal.random(),
+            hal,
             seed,
             &mnemonic_passphrase,
             // for the simulator, we don't yield at all, otherwise unlock becomes very slow in the
@@ -226,7 +226,9 @@ mod tests {
         assert!(!crate::keystore::is_locked());
 
         assert_eq!(
-            crate::keystore::copy_bip39_seed().unwrap().as_slice(),
+            crate::keystore::copy_bip39_seed(&mut mock_hal)
+                .unwrap()
+                .as_slice(),
             &hex!(
                 "cff4b263e5b0eb299e5fd35fcd09988f6b14e5b464f8d18fb84b152f889dd2a30550f4c2b346cae825ffedd4a87fc63fc12a9433de5125b6c7fdbc5eab0c590b"
             ),
@@ -273,7 +275,7 @@ mod tests {
         assert_eq!(mock_hal.securechip.get_event_counter(), 5);
 
         // Checks that the device is locked.
-        assert!(crate::keystore::copy_seed().is_err());
+        assert!(crate::keystore::copy_seed(&mut mock_hal).is_err());
 
         assert_eq!(
             mock_hal.ui.screens,


### PR DESCRIPTION
Due to copy_seed and copy_bip39_seed needing kdf, a ton of functions are infected by the HAL param, as so many of them transitively make use of these functions.