### PR TITLE
pip: fix editable imports for pip >= 25

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -385,6 +385,10 @@ docker exec -u 0 -it bitbox02-firmware-dev bash -c 'apt update && apt install -y
 
 There is a Python api library in `py/bitbox02`.
 
+> [!IMPORTANT]  
+> The Python scripts and editable installs require **pip ≥ 25**. Older pip versions will fail.  
+> For setup and usage instructions, see [`py/README.md`](py/README.md).
+
 ### BitBox02 CLI client
 
 Run `pip install -r py/requirements.txt` to install the deps (virtualenv recommended).

--- a/py/README.md
+++ b/py/README.md
@@ -1,9 +1,18 @@
 # Python scripts
 
-To use the scripts (`send_message.py`, `load_firmware.py` for example) go into the `bitbox02`
-directory and run `pip3 install .`.
+**Important: pip >= 25 is required.**  
+Editable installs (`pip install -e …`) are only supported with pip 25 or newer.  
+Older pip versions will fail due to changes in how editable installs are handled (PEP 660).
 
-If you plan to work on the scripts run `pip3 install -e .` instead.
+To use the scripts (e.g. `send_message.py`, `load_firmware.py`):
+```bash
+pip3 install py/bitbox02
+```
+
+To work on the library/scripts and install in editable mode:
+```bash
+pip install -e py/bitbox02
+```
 
 It is highly recommended that you use the dockerized setup while developing, guide for setting it up
 can be found in [BUILD.md](../BUILD.md).

--- a/py/bitbox02/bitbox02/__init__.py
+++ b/py/bitbox02/bitbox02/__init__.py
@@ -1,0 +1,32 @@
+"""
+This file re-exports all symbols from the nested bitbox02 subpackage.
+
+This is needed for compatibility with pip >= 25, which changed how editable installs
+resolve imports. With pip 25, "from .bitbox02 import common" inside util.py resolves
+to this outer __init__.py instead of the inner bitbox02 subpackage.
+"""
+
+# Re-export all symbols from the nested package
+from .bitbox02 import *  # noqa: F401, F403
+
+# Explicitly list all public exports for type checkers and documentation
+from .bitbox02 import (
+    __version__,
+    btc_sign_needs_prevtxs,
+    Backup,
+    BitBox02,
+    BTCInputType,
+    BTCOutputExternal,
+    BTCOutputInternal,
+    BTCOutputType,
+    BTCPrevTxInputType,
+    BTCPrevTxOutputType,
+    DuplicateEntryException,
+    hww,
+    btc,
+    cardano,
+    common,
+    eth,
+    system,
+    Bootloader,
+)


### PR DESCRIPTION
Pip versions >=25 changed editable install behavior per PEP 660, causing relative imports like "from .bitbox02 import common" to resolve to the outer init.py instead of the inner subpackage, breaking dev workflows. 

Re-exporting symbols from the nested bitbox02 module fixes this resolution issue while preserving the existing package structure and API for downstream users. This ensures pip install -e . works reliably without flattening.

With pip 25 and before this change the following command (from repo root) does not work:

`pip uninstall -y bitbox02 && pip install -e py/bitbox02 && python py/send_message.py` will return an import error.

With pip 25 and after this change, the same command will not return an import error.