### PR TITLE
tests: remove C fake secure chip event counter

### DIFF
--- a/src/rust/bitbox02-rust/src/hal.rs
+++ b/src/rust/bitbox02-rust/src/hal.rs
@@ -418,14 +418,11 @@ pub mod testing {
         /// Resets the event counter.
         pub fn event_counter_reset(&mut self) {
             self.event_counter = 0;
-            // TODO: remove once all unit tests use the SecureChip HAL.
-            bitbox02::securechip::fake_event_counter_reset()
         }
 
         /// Retrieves the event counter.
         pub fn get_event_counter(&self) -> u32 {
-            // TODO: remove fake_event_counter() once all unit tests use the SecureChip HAL.
-            bitbox02::securechip::fake_event_counter() + self.event_counter
+            self.event_counter
         }
 
         /// Make the next `reset_keys()` call return an error once. Subsequent calls succeed.

--- a/src/rust/bitbox02-rust/src/keystore.rs
+++ b/src/rust/bitbox02-rust/src/keystore.rs
@@ -1627,10 +1627,7 @@ mod tests {
             "",
         );
 
-        bitbox02::securechip::fake_event_counter_reset();
         assert_eq!(root_fingerprint(), Ok(vec![0x02, 0x40, 0xe9, 0x2a]));
-        // fingerprint is precomputed during bip39 unlock, so takes no securechip events.
-        assert_eq!(bitbox02::securechip::fake_event_counter(), 0);
 
         mock_unlocked_using_mnemonic(
             "small agent wife animal marine cloth exit thank stool idea steel frame",

--- a/src/rust/bitbox02-sys/build.rs
+++ b/src/rust/bitbox02-sys/build.rs
@@ -87,8 +87,6 @@ const ALLOWLIST_FNS: &[&str] = &[
     "emit_event",
     "empty_create",
     "fake_memory_factoryreset",
-    "fake_securechip_event_counter_reset",
-    "fake_securechip_event_counter",
     "gmtime",
     "hww_setup",
     "keystore_bip39_mnemonic_to_seed",

--- a/src/rust/bitbox02/src/securechip.rs
+++ b/src/rust/bitbox02/src/securechip.rs
@@ -144,16 +144,6 @@ pub fn u2f_counter_set(_counter: u32) -> Result<(), ()> {
     Ok(())
 }
 
-#[cfg(feature = "testing")]
-pub fn fake_event_counter() -> u32 {
-    unsafe { bitbox02_sys::fake_securechip_event_counter() }
-}
-
-#[cfg(feature = "testing")]
-pub fn fake_event_counter_reset() {
-    unsafe { bitbox02_sys::fake_securechip_event_counter_reset() }
-}
-
 pub fn model() -> Result<Model, ()> {
     let mut ver = core::mem::MaybeUninit::uninit();
     match unsafe { bitbox02_sys::securechip_model(ver.as_mut_ptr()) } {

--- a/src/securechip/securechip.h
+++ b/src/securechip/securechip.h
@@ -178,11 +178,4 @@ typedef enum {
  */
 USE_RESULT bool securechip_model(securechip_model_t* model_out);
 
-#ifdef TESTING
-// Resets the event counter.
-void fake_securechip_event_counter_reset(void);
-// Retrieves the event counter.
-uint32_t fake_securechip_event_counter(void);
-#endif
-
 #endif

--- a/test/hardware-fakes/src/fake_securechip.c
+++ b/test/hardware-fakes/src/fake_securechip.c
@@ -25,27 +25,19 @@ static const uint8_t _kdfkey[32] =
     "\xd2\xe1\xe6\xb1\x8b\x6c\x6b\x08\x43\x3e\xdb\xc1\xd1\x68\xc1\xa0\x04\x37\x74\xa4\x22\x18\x77"
     "\xe7\x9e\xd5\x66\x84\xbe\x5a\xc0\x1b";
 
-// Count how man security events happen. The numbers were obtained by reading the security event
-// counter slot (0xE0C5) on a real device. We can use this to assert how many events were used in
-// unit tests. The number is relevant due to Optiga's throttling mechanism.
-static uint32_t _event_counter = 0;
-
 int securechip_kdf(const uint8_t* msg, size_t len, uint8_t* kdf_out)
 {
-    _event_counter += 1;
     rust_hmac_sha256(_kdfkey, 32, msg, len, kdf_out);
     return 0;
 }
 
 int securechip_init_new_password(const char* password)
 {
-    _event_counter += 1;
     (void)password;
     return 0;
 }
 int securechip_stretch_password(const char* password, uint8_t* stretched_out)
 {
-    _event_counter += 5;
     uint8_t key[9] = "unit-test";
     rust_hmac_sha256(key, sizeof(key), (const uint8_t*)password, strlen(password), stretched_out);
     return 0;
@@ -53,20 +45,17 @@ int securechip_stretch_password(const char* password, uint8_t* stretched_out)
 
 bool securechip_reset_keys(void)
 {
-    _event_counter += 1;
     return true;
 }
 
 bool securechip_u2f_counter_set(uint32_t counter)
 {
-    _event_counter += 0;
     _u2f_counter = counter;
     return true;
 }
 
 bool securechip_u2f_counter_inc(uint32_t* counter)
 {
-    _event_counter += 0;
     *counter = _u2f_counter++;
     return true;
 }
@@ -75,7 +64,6 @@ bool securechip_attestation_sign(const uint8_t* msg, uint8_t* signature_out)
 {
     (void)msg;
     (void)signature_out;
-    _event_counter += 1;
     return false;
 }
 
@@ -89,14 +77,4 @@ bool securechip_model(securechip_model_t* model_out)
 {
     *model_out = ATECC_ATECC608B;
     return true;
-}
-
-void fake_securechip_event_counter_reset(void)
-{
-    _event_counter = 0;
-}
-
-uint32_t fake_securechip_event_counter(void)
-{
-    return _event_counter;
 }


### PR DESCRIPTION
The events are counted in TestingHal now. The only check that is removed is for root_fingerprint(), which does not use the HAL and so is naturally not calling any securechip function.