### PR TITLE
bug: Prevent memory_reset_hww from masking flash write failures

### DIFF
--- a/src/memory/memory.c
+++ b/src/memory/memory.c
@@ -371,7 +371,6 @@ bool memory_reset_hww(void)
     }
 
     // Initialize hww memory
-
     chunk_1_t chunk = {0};
     CLEANUP_CHUNK(chunk);
     _read_chunk(CHUNK_1, chunk_bytes);
@@ -405,7 +404,7 @@ bool memory_reset_hww(void)
         chunk_shared.fields.ble_identity_address[0] |= 0xc;
 
         memset(&chunk_shared.fields.ble_bond_db, 0xff, sizeof(chunk_shared.fields.ble_bond_db));
-        res |= _write_to_address(FLASH_SHARED_DATA_START, 0, chunk_shared.bytes);
+        res = _write_to_address(FLASH_SHARED_DATA_START, 0, chunk_shared.bytes) && res;
     }
 
     return res;


### PR DESCRIPTION
memory_reset_hww combined the CHUNK_1 write result and the shared BLE chunk write using |=, so a later successful write could hide an earlier failure. Change both writes to be checked individually and return false if any of the two write operations fails, but ensuring both operations are attempted.

What could go wrong in the old code:

when `_write_chunk(CHUNK_1, chunk.bytes);` return `false` and `_write_to_address(FLASH_SHARED_DATA_START, 0, chunk_shared.bytes)` returns true, then `bool memory_reset_hww(void)` returns true due to the `|=` operator.