### PR TITLE
Move get_datetime/format_datetime to HAL

### DIFF
--- a/src/rust/bitbox02-rust/src/backup.rs
+++ b/src/rust/bitbox02-rust/src/backup.rs
@@ -16,7 +16,7 @@ use prost::Message;
 
 use crate::pb_backup;
 
-use crate::hal::Sd;
+use crate::hal::{Sd, Time};
 
 use alloc::boxed::Box;
 use alloc::string::String;
@@ -239,7 +239,10 @@ pub async fn create(
         .or(Err(Error::SdList))?;
 
     let filename_datetime = {
-        let tm = bitbox02::get_datetime(backup_create_timestamp).map_err(|_| Error::Generic)?;
+        let tm = hal
+            .time()
+            .get_datetime(backup_create_timestamp)
+            .map_err(|_| Error::Generic)?;
         format!(
             "{}_{}T{}-{}-{}Z",
             tm.weekday(),

--- a/src/rust/bitbox02-rust/src/hww/api/backup.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/backup.rs
@@ -19,7 +19,7 @@ use alloc::vec::Vec;
 use pb::response::Response;
 
 use crate::backup;
-use crate::hal::{Memory, Sd, Ui};
+use crate::hal::{Memory, Sd, Time, Ui};
 use crate::workflow::{confirm, unlock};
 
 pub async fn check(
@@ -79,11 +79,14 @@ pub async fn create(
         timezone_offset,
     }: &pb::CreateBackupRequest,
 ) -> Result<Response, Error> {
+    let formatted_datetime = hal
+        .time()
+        .format_datetime(timestamp, timezone_offset, true)
+        .map_err(|_| Error::InvalidInput)?;
     hal.ui()
         .confirm(&confirm::Params {
             title: "Is today?",
-            body: &bitbox02::format_datetime(timestamp, timezone_offset, true)
-                .map_err(|_| Error::InvalidInput)?,
+            body: &formatted_datetime,
             ..Default::default()
         })
         .await?;

--- a/src/rust/bitbox02-rust/src/hww/api/restore.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/restore.rs
@@ -17,9 +17,9 @@ use crate::pb;
 
 use pb::response::Response;
 
-#[cfg(feature = "app-u2f")]
-use crate::hal::SecureChip;
 use crate::hal::{Memory, Ui};
+#[cfg(feature = "app-u2f")]
+use crate::hal::{SecureChip, Time};
 use crate::workflow::{confirm, mnemonic, password, unlock};
 
 pub async fn from_file(
@@ -54,9 +54,10 @@ pub async fn from_file(
 
     #[cfg(feature = "app-u2f")]
     {
-        let datetime_string =
-            bitbox02::format_datetime(request.timestamp, request.timezone_offset, false)
-                .map_err(|_| Error::InvalidInput)?;
+        let datetime_string = hal
+            .time()
+            .format_datetime(request.timestamp, request.timezone_offset, false)
+            .map_err(|_| Error::InvalidInput)?;
         let params = confirm::Params {
             title: "Is now?",
             body: &datetime_string,
@@ -104,7 +105,9 @@ pub async fn from_mnemonic(
 ) -> Result<Response, Error> {
     #[cfg(feature = "app-u2f")]
     {
-        let datetime_string = bitbox02::format_datetime(timestamp, timezone_offset, false)
+        let datetime_string = hal
+            .time()
+            .format_datetime(timestamp, timezone_offset, false)
             .map_err(|_| Error::InvalidInput)?;
         hal.ui()
             .confirm(&confirm::Params {


### PR DESCRIPTION
A new trait "Time" was added to HAL, as the
functions do not fit well into an existing trait.

No new tests were added, my current opinion is that
the tests which already exist cover well.