### PR TITLE
py: fix fmt linter

### DIFF
--- a/.ci/check-pep8
+++ b/.ci/check-pep8
@@ -11,12 +11,12 @@ set -o pipefail
 command -v git >/dev/null 2>&1 || { echo >&2 "git is missing"; exit 1; }
 
 # grep will exit with 1 if no lines are found
-FILES=$(git --no-pager diff --diff-filter=d --name-only ${TARGET_BRANCH} HEAD | grep -v -e "old/" -e "generated/" -e "rust/vendor/" | grep -E ".py\$" || exit 0)
+FILES=$(git --no-pager diff --diff-filter=d --name-only ${TARGET_BRANCH} HEAD | grep -v -e "old/" -e "generated/" -e "rust/vendor/" -e "external/" | grep -E ".py\$" || exit 0)
 if [ -z "${FILES}" ] ; then
        exit 0
 fi
 
-./scripts/format-python --check --fast ${FILES}
+./scripts/format-python --config py/pyproject.toml --check --fast ${FILES}
 # We lint all default Python files, as linting only a subset can lead to errors (e.g. if
 # send_message.py only is linted without the bitbox02 dep).
 ./scripts/lint-python

--- a/releases/describe_signed_firmware.py
+++ b/releases/describe_signed_firmware.py
@@ -74,18 +74,14 @@ def main() -> int:
         "the signatures are not being verified."
     )
 
-    firmware_padded = firmware + b"\xFF" * (MAX_FIRMWARE_SIZE - len(firmware))
+    firmware_padded = firmware + b"\xff" * (MAX_FIRMWARE_SIZE - len(firmware))
 
-    print(
-        "The hash of the unsigned firmware binary is (compare with reproducible build):"
-    )
+    print("The hash of the unsigned firmware binary is (compare with reproducible build):")
     print(hashlib.sha256(firmware).hexdigest())
     version = sigdata[SIGNING_PUBKEYS_DATA_LEN:][:VERSION_LEN]
     print("The monotonic firmware version is:", struct.unpack("<I", version)[0])
     print("The hash of the firmware as verified/shown by the bootloader is:")
-    print(
-        hashlib.sha256(hashlib.sha256(version + firmware_padded).digest()).hexdigest()
-    )
+    print(hashlib.sha256(hashlib.sha256(version + firmware_padded).digest()).hexdigest())
 
     return 0
 

--- a/scripts/graphics/convert.py
+++ b/scripts/graphics/convert.py
@@ -33,9 +33,7 @@ def main():
     """Main function"""
     parser = argparse.ArgumentParser()
     parser.add_argument("pbmfile")
-    parser.add_argument(
-        "--name", help="Name to give to the resulting variable", nargs="?"
-    )
+    parser.add_argument("--name", help="Name to give to the resulting variable", nargs="?")
     args = parser.parse_args()
 
     with open(args.pbmfile) as file:


### PR DESCRIPTION
Before a recent black update, black would, for each file it formatted, apply the pyproject.toml related to it, e.g. py/pyproject.toml for all files in py/, and not for files outside of py/. Since the black update, if formatting files both inside and outside of py/, it would ignore pyproject.toml, as it's not in the root.

We do a workaround by supplying configuring the linter to use py/pyproject.toml for all files. Alternative would be to apply black file-by-file, but that is much slower. Another alternative is to make split it into two runs, but that was too much trouble. Moving pyproject.toml from py/ to the root seemed wrong, as the root is not a Py project.