### PR TITLE
remove testing::UnsafeSyncRefCell

### DIFF
--- a/src/rust/bitbox02/src/testing.rs
+++ b/src/rust/bitbox02/src/testing.rs
@@ -23,22 +23,3 @@ pub fn mock_memory() {
         bitbox02_sys::spi_mem_full_erase();
     }
 }
-
-/// A wrapper that adds the Sync trait to RefCell. We can use this in testing as our unit tests run
-/// single-threaded.
-pub struct UnsafeSyncRefCell<T>(core::cell::RefCell<T>);
-impl<T> UnsafeSyncRefCell<T> {
-    pub const fn new(value: T) -> Self {
-        Self(core::cell::RefCell::new(value))
-    }
-}
-
-unsafe impl<T> Sync for UnsafeSyncRefCell<T> {}
-
-impl<T> core::ops::Deref for UnsafeSyncRefCell<T> {
-    type Target = core::cell::RefCell<T>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}


### PR DESCRIPTION
Its only use was in xpubcache.rs, where we can use a regular RefCell.