### PR TITLE
build: Avoid hard coding path to compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,11 +72,18 @@ message(FATAL_ERROR
 )
 endif()
 
+# Figure out what target our compiler builds for
+execute_process(
+  COMMAND ${CMAKE_C_COMPILER} -dumpmachine
+  OUTPUT_VARIABLE TARGET_TRIPLE
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
 # Finds objcopy and other utilities for us
 include(CMakeFindBinUtils)
 if(CMAKE_CROSSCOMPILING)
-  find_program(CMAKE_SIZE "${TOOLCHAIN_PREFIX}size")
-  message(STATUS "size: ${CMAKE_SIZE} ${TOOLCHAIN_PREFIX}size")
+  find_program(CMAKE_SIZE "${TARGET_TRIPLE}-size")
+  message(STATUS "size: ${CMAKE_SIZE} ${TARGET_TRIPLE}-size")
 endif()
 
 
@@ -213,6 +220,12 @@ execute_process(
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
+execute_process(
+  COMMAND ${CMAKE_C_COMPILER} --print-sysroot
+  OUTPUT_VARIABLE CMAKE_SYSROOT
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
 message(STATUS "\n\n=============================================")
 message(STATUS "            - General -")
 message(STATUS "Firmware version:       ${FIRMWARE_VERSION_FULL}")
@@ -225,6 +238,8 @@ message(STATUS "Processor:              ${CMAKE_SYSTEM_PROCESSOR}")
 message(STATUS "             - Build -")
 message(STATUS "Compiler version:       ${CMAKE_C_COMPILER_ID} ${C_COMPILER_VERSION}")
 message(STATUS "Compiler:               ${CMAKE_C_COMPILER}")
+message(STATUS "Sysroot:                ${CMAKE_SYSROOT}")
+message(STATUS "Target triple:          ${TARGET_TRIPLE}")
 message(STATUS "Compiler cache:         ${CMAKE_C_COMPILER_LAUNCHER}")
 message(STATUS "Linker:                 ${CMAKE_LINKER}")
 message(STATUS "Archiver:               ${CMAKE_AR}")

--- a/arm.cmake
+++ b/arm.cmake
@@ -1,10 +1,7 @@
 set(CMAKE_SYSTEM_NAME "Generic")
 set(CMAKE_SYSTEM_PROCESSOR "arm")
 
-set(TOOLCHAIN_PREFIX_PREFIX "arm-none-eabi")
-set(TOOLCHAIN_PREFIX "${TOOLCHAIN_PREFIX_PREFIX}-")
-set(CMAKE_C_COMPILER "/usr/local/bin/${TOOLCHAIN_PREFIX}gcc")
-set(CMAKE_SYSROOT "/usr/local/${TOOLCHAIN_PREFIX_PREFIX}")
+set(CMAKE_C_COMPILER "arm-none-eabi-gcc")
 
 # Search for programs in the build host directories
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)


### PR DESCRIPTION
This commit allows developers to choose compiler by modifying PATH

why: beacuse I don't want to install the compiler to `/usr/local/bin` because the arm toolchain installer wants to put it in `/Applications`