### PR TITLE
py/bitbox02: list_backups returns tz aware timestamps

### DIFF
--- a/py/bitbox02/CHANGELOG.md
+++ b/py/bitbox02/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
 ## [Unreleased]
-
-# 7.1.0
 - Add `btc_xpubs()` to fetch multiple xpubs at once
 - Bitcoin: add support for OP_RETURN outputs
+- Add `change_password()`
+- Backups: return non-naive timestamps with UTC timezone
 
 # 7.0.0
 - get_info: add optional device initialized boolean to returned tuple

--- a/py/bitbox02/bitbox02/bitbox02/bitbox02.py
+++ b/py/bitbox02/bitbox02/bitbox02/bitbox02.py
@@ -5,7 +5,7 @@
 import os
 import sys
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional, List, Dict, Tuple, Any, Generator, Union, Sequence
 from typing_extensions import TypedDict
 
@@ -240,7 +240,7 @@ class BitBox02(BitBoxCommonAPI):
         request.list_backups.CopyFrom(backup.ListBackupsRequest())
         response = self._msg_query(request, expected_response="list_backups")
         for info in response.list_backups.info:
-            utcdate = datetime.utcfromtimestamp(info.timestamp)
+            utcdate = datetime.fromtimestamp(info.timestamp, timezone.utc)
             yield (info.id, info.name, utcdate)
 
     def restore_backup(self, backup_id: str) -> None:

--- a/py/send_message.py
+++ b/py/send_message.py
@@ -243,7 +243,7 @@ class SendMessage:
             return
         fmt = "%Y-%m-%d %H:%M:%S %z"
         for i, (backup_id, backup_name, date) in enumerate(backups):
-            date = local_timezone.localize(date)
+            date = date.astimezone(local_timezone)
             date_str = date.strftime(fmt)
             print(f"[{i+1}] Backup Name: {backup_name}, Time: {date_str}, ID: {backup_id}")
 


### PR DESCRIPTION
Naive timestamps without timezone are by many python functions
interpreted as being in the local timezone. The backups are timestamped
with UTC so we return timmezone aware timestamps instead so that python
tooling correctly interpret them as UTC.

Fixes a bug in send_message.py that it would display incorrect
timestamps.