### PR TITLE
da14531: simplify da14531_set_name by dropping len param

### DIFF
--- a/src/bootloader/startup.c
+++ b/src/bootloader/startup.c
@@ -101,7 +101,7 @@ int main(void)
     // only the MCU.
     char buf[MEMORY_DEVICE_NAME_MAX_LEN] = {0};
     memory_random_name(buf);
-    da14531_set_name(buf, strlen(buf), &uart_write_queue);
+    da14531_set_name(buf, &uart_write_queue);
 
     // Ask for the current conection state
     da14531_get_connection_state(&uart_write_queue);

--- a/src/da14531/da14531.c
+++ b/src/da14531/da14531.c
@@ -60,8 +60,9 @@ void da14531_set_product(
     }
 }
 
-void da14531_set_name(const char* name, size_t name_len, struct ringbuffer* uart_out)
+void da14531_set_name(const char* name, struct ringbuffer* uart_out)
 {
+    size_t name_len = strlen(name);
     uint8_t payload[64] = {0};
     payload[0] = CTRL_CMD_DEVICE_NAME;
     memcpy(&payload[1], name, MIN(name_len, sizeof(payload) - 1));

--- a/src/da14531/da14531.h
+++ b/src/da14531/da14531.h
@@ -40,7 +40,7 @@ void da14531_set_product(
     volatile uint16_t product_len,
     struct ringbuffer* uart_out);
 
-void da14531_set_name(const char* name, size_t name_len, struct ringbuffer* uart_out);
+void da14531_set_name(const char* name, struct ringbuffer* uart_out);
 
 void da14531_get_connection_state(struct ringbuffer* uart_out);
 

--- a/src/firmware_main_loop.c
+++ b/src/firmware_main_loop.c
@@ -68,7 +68,7 @@ void firmware_main_loop(void)
     /// the fw. Send it over.
     char buf[MEMORY_DEVICE_NAME_MAX_LEN] = {0};
     memory_get_device_name(buf);
-    da14531_set_name(buf, strlen(buf), &uart_write_queue);
+    da14531_set_name(buf, &uart_write_queue);
 
     // This starts the async orientation screen workflow, which is processed by the loop below.
     rust_workflow_spawn_orientation_screen();


### PR DESCRIPTION
The string is null-terminated, all callsites call `strlen()`.

Part of a fixup of https://github.com/BitBoxSwiss/bitbox02-firmware/pull/1690/.