### PR TITLE
usb: use a static write buffer

### DIFF
--- a/src/usb/class/hid/hww/hid_hww.c
+++ b/src/usb/class/hid/hww/hid_hww.c
@@ -45,6 +45,7 @@ static struct usbdc_handler _request_handler = {NULL, (FUNC_PTR)_request};
 static volatile bool _send_busy = false;
 static volatile bool _has_data = false;
 static volatile bool _request_in_flight = false;
+static uint8_t _write_buf[64] __attribute__((aligned(4)));
 
 // First time this function is called it initiates a transfer. Call it multiple times to poll for
 // completion. Once it returns true, there is data in the buffer.
@@ -73,7 +74,8 @@ bool hid_hww_write_poll(const uint8_t* data)
     if (_send_busy) {
         return false;
     }
-    if (hid_write(&_func_data, data, USB_HID_REPORT_OUT_SIZE) == ERR_NONE) {
+    memcpy(_write_buf, data, USB_HID_REPORT_OUT_SIZE);
+    if (hid_write(&_func_data, _write_buf, USB_HID_REPORT_OUT_SIZE) == ERR_NONE) {
         _send_busy = true;
         return true;
     }

--- a/src/usb/class/hid/u2f/hid_u2f.c
+++ b/src/usb/class/hid/u2f/hid_u2f.c
@@ -33,6 +33,7 @@ static uint8_t _report_descriptor[] = {USB_DESC_U2F_REPORT};
 static volatile bool _send_busy = false;
 static volatile bool _has_data = false;
 static volatile bool _request_in_flight = false;
+static uint8_t _write_buf[64] __attribute__((aligned(4)));
 
 /**
  * The USB device core request handler callback for the U2F interface.
@@ -75,7 +76,8 @@ bool hid_u2f_write_poll(const uint8_t* data)
     if (_send_busy) {
         return false;
     }
-    if (hid_write(&_func_data, data, USB_HID_REPORT_OUT_SIZE) == ERR_NONE) {
+    memcpy(_write_buf, data, USB_HID_REPORT_OUT_SIZE);
+    if (hid_write(&_func_data, _write_buf, USB_HID_REPORT_OUT_SIZE) == ERR_NONE) {
         _send_busy = true;
         return true;
     }


### PR DESCRIPTION
Instead of relying on the caller to not modify the buffer a copy is made to static memory. This enables the caller to use a stack allocated buffer.

Because the USB stack uses DMA to move memory all buffers need to be 32 bit aligned. By coincidence, the buffer we currently use in the "queue" were aligned. But when buffers are stack allocated there is a higher chance that they sometimes are not 32 bit aligned

This is a commit of #1690