### PR TITLE
.gitattributes: fix path to vendor folder

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 /py/bitbox02/bitbox02/generated/* linguist-generated=true
-/src/rust/vendor/** linguist-generated=true
+/external/vendor/** linguist-generated=true


### PR DESCRIPTION
Split out of https://github.com/BitBoxSwiss/bitbox02-firmware/pull/1695