### PR TITLE
ui: port menu component to async

### DIFF
--- a/src/rust/bitbox02-rust/src/workflow/cancel.rs
+++ b/src/rust/bitbox02-rust/src/workflow/cancel.rs
@@ -1,54 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::bb02_async::option_no_screensaver;
-use core::cell::RefCell;
-
-use super::confirm;
-
 #[derive(Debug)]
 pub enum Error {
     Cancelled,
-}
-
-pub type ResultCell<R> = RefCell<Option<Result<R, Error>>>;
-
-/// Resolves the `with_cancel` future as cancelled.
-pub fn cancel<R>(result_cell: &ResultCell<R>) {
-    *result_cell.borrow_mut() = Some(Err(Error::Cancelled));
-}
-
-/// Resolves the `with_cancel` future with the given result.
-pub fn set_result<R>(result_cell: &ResultCell<R>, result: R) {
-    *result_cell.borrow_mut() = Some(Ok(result));
-}
-
-/// Blocks on showing/running a component until `cancel` or `result` is
-/// called on the same `result_cell`.
-/// In the former, a prompt with the given title to confirm cancellation is shown.
-///
-/// * `title` - title to show in the cancel confirm prompt.
-/// * `component` - component to process
-/// * `result_cell` - result var to synchronize the result on. Pass the same to `cancel` and
-///   `set_result`.
-pub async fn with_cancel<R>(
-    title: &str,
-    component: &mut bitbox02::ui::Component<'_>,
-    result_cell: &ResultCell<R>,
-) -> Result<R, Error> {
-    component.screen_stack_push();
-    loop {
-        let result = option_no_screensaver(result_cell).await;
-        if let Err(Error::Cancelled) = result {
-            let params = confirm::Params {
-                title,
-                body: "Do you really\nwant to cancel?",
-                ..Default::default()
-            };
-
-            if let Err(confirm::UserAbort) = confirm::confirm(&params).await {
-                continue;
-            }
-        }
-        return result;
-    }
 }

--- a/src/rust/bitbox02-rust/src/workflow/menu.rs
+++ b/src/rust/bitbox02-rust/src/workflow/menu.rs
@@ -2,25 +2,19 @@
 
 pub use super::cancel::Error as CancelError;
 
-use crate::bb02_async::option_no_screensaver;
-
-use alloc::boxed::Box;
-use core::cell::RefCell;
-
 /// Returns the index of the word chosen by the user.
 pub async fn pick(words: &[&str], title: Option<&str>) -> Result<u8, CancelError> {
-    let result = RefCell::new(None as Option<Result<u8, CancelError>>);
-    let mut component = bitbox02::ui::menu_create(bitbox02::ui::MenuParams {
+    match bitbox02::ui::menu(bitbox02::ui::MenuParams {
         words,
         title,
-        select_word_cb: Some(Box::new(|choice_idx| {
-            *result.borrow_mut() = Some(Ok(choice_idx));
-        })),
-        continue_on_last_cb: None,
-        cancel_cb: Some(Box::new(|| {
-            *result.borrow_mut() = Some(Err(CancelError::Cancelled));
-        })),
-    });
-    component.screen_stack_push();
-    option_no_screensaver(&result).await
+        select_word: true,
+        continue_on_last: false,
+        cancel_confirm_title: None,
+    })
+    .await
+    {
+        bitbox02::ui::MenuResponse::SelectWord(choice_idx) => Ok(choice_idx),
+        bitbox02::ui::MenuResponse::ContinueOnLast => panic!("unexpected continue-on-last"),
+        bitbox02::ui::MenuResponse::Cancel => Err(CancelError::Cancelled),
+    }
 }

--- a/src/rust/bitbox02/src/ui/types.rs
+++ b/src/rust/bitbox02/src/ui/types.rs
@@ -66,12 +66,25 @@ pub struct TrinaryInputStringParams<'a> {
 pub type SelectWordCb<'a> = Box<dyn FnMut(u8) + 'a>;
 pub type ContinueCancelCb<'a> = Box<dyn FnMut() + 'a>;
 
+/// Result of a resolved menu interaction.
+pub enum MenuResponse {
+    /// User chose one of the entries by index.
+    SelectWord(u8),
+    /// User reached the last item and continued.
+    ContinueOnLast,
+    /// User cancelled the menu flow.
+    Cancel,
+}
+
 pub struct MenuParams<'a> {
     pub words: &'a [&'a str],
     pub title: Option<&'a str>,
-    pub select_word_cb: Option<SelectWordCb<'a>>,
-    pub continue_on_last_cb: Option<ContinueCancelCb<'a>>,
-    pub cancel_cb: Option<ContinueCancelCb<'a>>,
+    /// If true, selecting a word is possible and `MenuResponse::SelectWord` is returned.
+    pub select_word: bool,
+    /// If true, user can continue at the last word, and `MenuResponse::ContinueOnLast` is returned.
+    pub continue_on_last: bool,
+    /// `None` means immediate cancel. `Some(title)` asks for cancel confirmation.
+    pub cancel_confirm_title: Option<&'a str>,
 }
 
 pub type TrinaryChoiceCb<'a> = Box<dyn FnMut(TrinaryChoice) + 'a>;

--- a/src/rust/bitbox02/src/ui/ui_stub.rs
+++ b/src/rust/bitbox02/src/ui/ui_stub.rs
@@ -6,8 +6,8 @@
 //! workflows now.
 
 pub use super::types::{
-    AcceptRejectCb, ConfirmParams, ContinueCancelCb, Font, MenuParams, SelectWordCb, TrinaryChoice,
-    TrinaryChoiceCb, TrinaryInputStringParams,
+    AcceptRejectCb, ConfirmParams, ContinueCancelCb, Font, MenuParams, MenuResponse, SelectWordCb,
+    TrinaryChoice, TrinaryChoiceCb, TrinaryInputStringParams,
 };
 
 use core::marker::PhantomData;
@@ -63,7 +63,7 @@ where
     panic!("not used");
 }
 
-pub fn menu_create(_params: MenuParams<'_>) -> Component<'_> {
+pub async fn menu(_params: MenuParams<'_>) -> MenuResponse {
     panic!("not used");
 }
 

--- a/src/rust/bitbox02/src/ui/ui_stub_c_unit_tests.rs
+++ b/src/rust/bitbox02/src/ui/ui_stub_c_unit_tests.rs
@@ -3,8 +3,8 @@
 //! Stubs for the Bitbox02 simulator and also C unit-tests.
 
 pub use super::types::{
-    AcceptRejectCb, ConfirmParams, ContinueCancelCb, Font, MenuParams, SelectWordCb, TrinaryChoice,
-    TrinaryChoiceCb, TrinaryInputStringParams,
+    AcceptRejectCb, ConfirmParams, ContinueCancelCb, Font, MenuParams, MenuResponse, SelectWordCb,
+    TrinaryChoice, TrinaryChoiceCb, TrinaryInputStringParams,
 };
 
 use core::marker::PhantomData;
@@ -81,7 +81,7 @@ where
     }
 }
 
-pub fn menu_create(_params: MenuParams<'_>) -> Component<'_> {
+pub async fn menu(_params: MenuParams<'_>) -> MenuResponse {
     panic!("not implemented");
 }
 


### PR DESCRIPTION
- The `cancel` field in `MenuParams` is deleted, as all callers set it to true
- The `with_cancel` primitive that works with `Component` is inlined into `bitbox02::ui::menu` - it's the only component with a cancel prompt. If there will be more, we can think of an abstraction again.