### PR TITLE
eth: allow EIP-712 message signing without anti-klepto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ customers cannot upgrade their bootloader, its changes are recorded separately.
 ### [Unreleased]
 - Improve experience of moving back and forth when entering password characters
 - Ethereum: add data streaming support for transactions with large (>6144 bytes) data
+- Ethereum: allow EIP-712 typed message signing without anti-klepto host nonce commitment
 
 ### v9.25.0
 - BitBox02 Nova: improved password stretching algorithm

--- a/py/bitbox02/CHANGELOG.md
+++ b/py/bitbox02/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Bitcoin: add support for OP_RETURN outputs
 - Add `change_password()`
 - Backups: return non-naive timestamps with UTC timezone
+- Disabling anti-klepto for EIP-712 typed message signing requires firmware version v9.26.0 or newer
 
 # 7.0.0
 - get_info: add optional device initialized boolean to returned tuple

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -21,8 +21,6 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-# The secp-recovery feature is currently only needed in tests to make use of `RecoverableSignature`.
-# Attempting to enable it conditionally only for tests somehow leads to linking errors (duplicate secp256k1 symbols).
 bitcoin = { version = "0.32.7", default-features = false, features = ["secp-recovery"] }
 cortex-m = { version = "0.7.7", features = ["critical-section-single-core"] }
 

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin/signmsg.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin/signmsg.rs
@@ -111,7 +111,7 @@ pub async fn process(
             .try_into()
             .unwrap(),
         &sighash,
-        &host_nonce,
+        Some(&host_nonce),
     )?;
     let mut signature: Vec<u8> = sign_result.signature.to_vec();
     signature.push(sign_result.recid);

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin/signtx.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin/signtx.rs
@@ -1252,7 +1252,7 @@ async fn _process(
             let sign_result = crate::secp256k1::secp256k1_sign(
                 private_key.as_slice().try_into().unwrap(),
                 &sighash,
-                &host_nonce,
+                Some(&host_nonce),
             )?;
             drop(private_key);
             next_response.next.has_signature = true;

--- a/src/rust/bitbox02-rust/src/hww/api/ethereum/sign.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/ethereum/sign.rs
@@ -450,7 +450,7 @@ pub async fn _process(
             .try_into()
             .unwrap(),
         &hash,
-        &host_nonce,
+        Some(&host_nonce),
     )?;
     let mut signature: Vec<u8> = sign_result.signature.to_vec();
     signature.push(sign_result.recid);

--- a/src/rust/bitbox02-rust/src/hww/api/ethereum/sign_typed_msg.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/ethereum/sign_typed_msg.rs
@@ -563,10 +563,10 @@ pub async fn process(
             )?;
 
             // Send signer commitment to host and wait for the host nonce from the host.
-            super::antiklepto_get_host_nonce(signer_commitment).await?
+            Some(super::antiklepto_get_host_nonce(signer_commitment).await?)
         }
 
-        _ => return Err(Error::InvalidInput),
+        None => None,
     };
 
     let sign_result = crate::secp256k1::secp256k1_sign(
@@ -575,7 +575,7 @@ pub async fn process(
             .try_into()
             .unwrap(),
         &sighash,
-        &host_nonce,
+        host_nonce.as_ref(),
     )?;
     let mut signature: Vec<u8> = sign_result.signature.to_vec();
     signature.push(sign_result.recid);

--- a/src/rust/bitbox02-rust/src/hww/api/ethereum/signmsg.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/ethereum/signmsg.rs
@@ -80,7 +80,7 @@ pub async fn process(
             .try_into()
             .unwrap(),
         &sighash,
-        &host_nonce,
+        Some(&host_nonce),
     )?;
     let mut signature: Vec<u8> = sign_result.signature.to_vec();
     signature.push(sign_result.recid);

--- a/src/rust/bitbox02-rust/src/keystore.rs
+++ b/src/rust/bitbox02-rust/src/keystore.rs
@@ -1958,7 +1958,8 @@ mod tests {
             // Protocol step 3: host_nonce sent from host to signer to be used in step 4.
             // Sign - protocol step 4.
             let sign_result =
-                crate::secp256k1::secp256k1_sign(&private_key_bytes, &msg, &host_nonce).unwrap();
+                crate::secp256k1::secp256k1_sign(&private_key_bytes, &msg, Some(&host_nonce))
+                    .unwrap();
 
             let signature =
                 secp256k1::ecdsa::Signature::from_compact(&sign_result.signature).unwrap();


### PR DESCRIPTION
Some defi apps require deterministic signatures, and anti-klepto is not compatible with, as a random host nonce is contributed.

The host could instead contribute a constant nonce, which would work, but the resulting signature would not be the same as a regular RFC6979 signature that does not use the additional data. This would not be optimal in terms of interopability with other wallets.

This commit allows the host to skip the host nonce, in which case we fall back to regular deterministic signatures.