### PR TITLE
ui: port tx fee confirm to async

### DIFF
--- a/src/rust/bitbox02/src/ui/ui_stub.rs
+++ b/src/rust/bitbox02/src/ui/ui_stub.rs
@@ -78,12 +78,11 @@ pub async fn confirm_transaction_address(_amount: &str, _address: &str) -> Confi
     panic!("not used");
 }
 
-pub fn confirm_transaction_fee_create<'a, 'b>(
-    _amount: &'a str,
-    _fee: &'a str,
+pub async fn confirm_transaction_fee(
+    _amount: &str,
+    _fee: &str,
     _longtouch: bool,
-    _callback: AcceptRejectCb<'b>,
-) -> Component<'b> {
+) -> ConfirmResponse {
     panic!("not used");
 }
 

--- a/src/rust/bitbox02/src/ui/ui_stub_c_unit_tests.rs
+++ b/src/rust/bitbox02/src/ui/ui_stub_c_unit_tests.rs
@@ -96,21 +96,16 @@ pub async fn confirm_transaction_address(_amount: &str, _address: &str) -> Confi
     ConfirmResponse::Approved
 }
 
-pub fn confirm_transaction_fee_create<'a, 'b>(
-    _amount: &'a str,
-    _fee: &'a str,
+pub async fn confirm_transaction_fee(
+    _amount: &str,
+    _fee: &str,
     _longtouch: bool,
-    mut callback: AcceptRejectCb<'b>,
-) -> Component<'b> {
+) -> ConfirmResponse {
     crate::print_stdout(&format!(
         "CONFIRM TRANSACTION FEE SCREEN START\nAMOUNT: {}\nFEE: {}\nCONFIRM TRANSACTION FEE SCREEN END\n",
         _amount, _fee
     ));
-    callback(true);
-    Component {
-        is_pushed: false,
-        _p: PhantomData,
-    }
+    ConfirmResponse::Approved
 }
 
 pub fn screen_stack_pop_all() {}


### PR DESCRIPTION
Port confirm_transaction_fee_create() to async/await.

Note: remove Component::on_drop because all component constructors now set it to None, so the field and drop callback path are dead code.