### PR TITLE
reset: do not loop forever in C simulator

### DIFF
--- a/src/rust/bitbox02-rust/src/reset.rs
+++ b/src/rust/bitbox02-rust/src/reset.rs
@@ -64,7 +64,7 @@ pub(crate) async fn reset(hal: &mut impl crate::hal::Hal, status: bool) {
         hal.system().reset_ble();
     }
 
-    #[cfg(not(feature = "testing"))]
+    #[cfg(not(any(feature = "testing", feature = "c-unit-testing")))]
     hal.system().reboot();
 }
 


### PR DESCRIPTION
A simulator regression from when we put `reboot` into the HAL. Before, it was a no-op, and then it became a busy loop in bitbox02's System HAL. This broke simulator tests in bitbox02-api-go.