### PR TITLE
simulator: fix factory_randomness

### DIFF
--- a/src/rust/bitbox02/src/hal/random.rs
+++ b/src/rust/bitbox02/src/hal/random.rs
@@ -5,6 +5,13 @@ use bitbox_hal::Random;
 pub struct BitBox02Random;
 
 impl Random for BitBox02Random {
+    // C simulator still uses this.
+    #[cfg(feature = "c-unit-testing")]
+    fn factory_randomness(&mut self) -> &'static [u8; 32] {
+        &[0; 32]
+    }
+
+    #[cfg(not(feature = "c-unit-testing"))]
     #[inline(always)]
     fn factory_randomness(&mut self) -> &'static [u8; 32] {
         let addr =


### PR DESCRIPTION
The C simulator still uses the BitBox02 Hal. The newly introduced factory_randomness method there dereferenced the same static address as on the device, leading to a segfault.