### PR TITLE
simulator-graphical: fix factory_randomness

### DIFF
--- a/src/rust/bitbox02/src/hal/random.rs
+++ b/src/rust/bitbox02/src/hal/random.rs
@@ -6,12 +6,12 @@ pub struct BitBox02Random;
 
 impl Random for BitBox02Random {
     // C simulator still uses this.
-    #[cfg(feature = "c-unit-testing")]
+    #[cfg(any(feature = "c-unit-testing", feature = "simulator-graphical"))]
     fn factory_randomness(&mut self) -> &'static [u8; 32] {
         &[0; 32]
     }
 
-    #[cfg(not(feature = "c-unit-testing"))]
+    #[cfg(not(any(feature = "c-unit-testing", feature = "simulator-graphical")))]
     #[inline(always)]
     fn factory_randomness(&mut self) -> &'static [u8; 32] {
         let addr =


### PR DESCRIPTION
Same as cee5bdb3ba06f60b93213f9c2a183a7683fe1551, but for BB02 graphical simulator.