### PR TITLE
Shrink secp256k1 callbacks

### DIFF
--- a/src/rust/bitbox-secp256k1/build.rs
+++ b/src/rust/bitbox-secp256k1/build.rs
@@ -4,23 +4,27 @@ use std::path::PathBuf;
 
 fn main() {
     let secp_dir = PathBuf::from("depend/secp256k1-zkp");
+    let callbacks = PathBuf::from("src/default_callbacks.c");
 
     println!(
         "cargo::rerun-if-changed={}",
         secp_dir.join("include").display()
     );
     println!("cargo::rerun-if-changed={}", secp_dir.join("src").display());
+    println!("cargo::rerun-if-changed={}", callbacks.display());
 
     let mut build = cc::Build::new();
     build
         .file(secp_dir.join("src/secp256k1.c"))
         .file(secp_dir.join("src/precomputed_ecmult.c"))
         .file(secp_dir.join("src/precomputed_ecmult_gen.c"))
+        .file(&callbacks)
         .include(secp_dir.join("include"))
         // Suppress all warnings in this dependency, we don't have control over them.
         .flag_if_supported("-w")
         .define("ECMULT_WINDOW_SIZE", Some("2"))
         .define("ECMULT_GEN_PREC_BITS", Some("2"))
+        .define("USE_EXTERNAL_DEFAULT_CALLBACKS", Some("1"))
         .define("ENABLE_MODULE_RECOVERY", Some("1")) // needed only in Rust unit tests.
         .define("ENABLE_MODULE_EXTRAKEYS", Some("1"))
         .define("ENABLE_MODULE_SCHNORRSIG", Some("1"))

--- a/src/rust/bitbox-secp256k1/src/default_callbacks.c
+++ b/src/rust/bitbox-secp256k1/src/default_callbacks.c
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+
+void secp256k1_default_illegal_callback_fn(const char* str, void* data)
+{
+    (void)str;
+    (void)data;
+    while (1) {
+    }
+}
+
+void secp256k1_default_error_callback_fn(const char* str, void* data)
+{
+    (void)str;
+    (void)data;
+    while (1) {
+    }
+}


### PR DESCRIPTION
Override libsecp256k1's default callbacks with tiny local stubs.

The vendored callbacks print an error and then call abort(). In the firmware image those failure-only paths pull in a large chunk of newlib stdio and signal handling even though the callbacks are only used for fatal illegal-argument and internal-consistency failures and must never return.

Saved:  2672 bytes

The final linked image drops the abort/stdio path retained only by those callbacks, including the public symbols abort, raise, _raise_r, _kill_r, _getpid_r, fprintf, printf, and _vfprintf_r. It also drops the private stdio helpers behind them, such as __sfputc_r, __sfputs_r, __swsetup_r, __swbuf_r, _fflush_r, _fwalk_sglue, __swhatbuf_r, __swrite, __sread, __sseek, __sclose, __sinit, and __smakebuf_r. Meanwhile secp256k1_default_illegal_callback_fn and secp256k1_default_error_callback_fn shrink from 28 bytes each to 2 bytes each.

This keeps the relevant behavior intact: both callbacks still trap the firmware in a non-returning fatal path, but without dragging in unused diagnostic formatting code.