### PR TITLE
Shrink mbedtls AES tables

### DIFF
--- a/external/mbedtls_config.h
+++ b/external/mbedtls_config.h
@@ -65,6 +65,7 @@
 /* Save RAM at the expense of ROM */
 #define MBEDTLS_AES_ROM_TABLES
 #define MBEDTLS_AES_FEWER_TABLES
+#define MBEDTLS_SHA256_SMALLER
 
 /* Save some RAM by adjusting to your exact needs */
 #define MBEDTLS_PSK_MAX_LEN    16 /* 128-bits keys are generally enough */

--- a/external/mbedtls_config.h
+++ b/external/mbedtls_config.h
@@ -64,6 +64,7 @@
 
 /* Save RAM at the expense of ROM */
 #define MBEDTLS_AES_ROM_TABLES
+#define MBEDTLS_AES_FEWER_TABLES
 
 /* Save some RAM by adjusting to your exact needs */
 #define MBEDTLS_PSK_MAX_LEN    16 /* 128-bits keys are generally enough */

--- a/external/mbedtls_config.h
+++ b/external/mbedtls_config.h
@@ -63,7 +63,8 @@
 #define MBEDTLS_SSL_OUT_CONTENT_LEN             1024
 
 /* Save RAM at the expense of ROM */
-#define MBEDTLS_AES_ROM_TABLES
+// #define MBEDTLS_AES_ROM_TABLES
+
 #define MBEDTLS_AES_FEWER_TABLES
 #define MBEDTLS_SHA256_SMALLER
 


### PR DESCRIPTION
Enable MBEDTLS_AES_FEWER_TABLES in the Optiga Trust M mbedTLS user config.

This keeps the same AES/CCM functionality, but trades a small amount of AES speed for smaller ROM usage by deriving the extra AES lookup tables from FT0/RT0 instead of keeping all eight tables in flash.

- savings: 6208 bytes

The main win is that six live 1024-byte AES tables drop out of the final image: FT1, FT2, FT3, RT1, RT2, and RT3. FT0 and RT0 remain, and the AES encrypt/decrypt functions shrink slightly as well.

No functionality changes are intended; this is a ROM-for-speed tradeoff in the mbedTLS AES implementation used by the Optiga Trust M integration.