### PR TITLE
Enable blake2 size_opt

### DIFF
--- a/src/rust/bitbox02-rust/Cargo.toml
+++ b/src/rust/bitbox02-rust/Cargo.toml
@@ -41,7 +41,7 @@ num-bigint = { workspace = true, optional = true }
 num-traits = { version = "0.2", default-features = false }
 # If you change this, also change src/rust/.cargo/config.toml.
 bip32-ed25519 = { git = "https://github.com/BitBoxSwiss/rust-bip32-ed25519", tag = "v0.2.1", optional = true }
-blake2 = { version = "0.10.6", default-features = false, optional = true }
+blake2 = { version = "0.10.6", default-features = false, features = ["size_opt"], optional = true }
 minicbor = { version = "0.24.0", default-features = false, features = ["alloc"], optional = true }
 crc = { workspace = true, optional = true }
 ed25519-dalek = { version = "2.1.1", default-features = false, features = ["hazmat", "digest"], optional = true }


### PR DESCRIPTION
The blake2 crate exposes a size_opt feature that trades aggressive inlining for a smaller implementation. In this firmware build the Blake2b compression path was still one of the largest Rust code contributors, so this is a direct ROM for speed trade that matches the current goal.

Enable size_opt for the existing optional dependency. The algorithm, test vectors, and call sites stay the same; only the crate internal code generation strategy changes.

In the resulting image, the large Blake2b compression routine is split into much smaller outlined helpers instead of one heavily inlined body. That is where the ROM reduction comes from.

Saves 11576 bytes in firmware.bin.