### PR TITLE
Disable Rust Debug formatting

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -219,7 +219,7 @@ if(CMAKE_CROSSCOMPILING)
   set(RUST_TARGET_ARCH_DIR ${RUST_TARGET_ARCH})
   set(RUST_TARGET_ARCH_ARG --target ${RUST_TARGET_ARCH})
   set(RUST_CARGO_FLAGS ${RUST_CARGO_FLAGS} -Zbuild-std=core,alloc -Zbuild-std-features=optimize_for_size)
-  string(JOIN " " RUSTFLAGS "${RUSTFLAGS}" "-Zunstable-options -Cpanic=immediate-abort")
+  string(JOIN " " RUSTFLAGS "${RUSTFLAGS}" "-Zunstable-options -Zfmt-debug=none -Cpanic=immediate-abort")
 else()
   set(RUST_TARGET_ARCH_DIR .)
 endif()
@@ -259,7 +259,9 @@ if(NOT CMAKE_CROSSCOMPILING)
           --target-dir ${RUST_BINARY_DIR}/clippy
           --release
           --tests
-          -- # disabled linters:
+          -- # enabled linters:
+            -W clippy::use_debug
+            # disabled linters:
             -A clippy::large_enum_variant
             -A clippy::identity_op
             -A clippy::new_without_default

--- a/src/rust/bitbox02-rust/src/backup.rs
+++ b/src/rust/bitbox02-rust/src/backup.rs
@@ -24,6 +24,17 @@ pub enum Error {
     Check,
 }
 
+pub fn format_error(error: &Error) -> &'static str {
+    match error {
+        Error::Generic => "Generic",
+        Error::Stale => "Stale",
+        Error::SdList => "SdList",
+        Error::SdRead => "SdRead",
+        Error::SdWrite => "SdWrite",
+        Error::Check => "Check",
+    }
+}
+
 #[derive(Default)]
 pub struct BackupData(pub Box<pb_backup::BackupData>);
 

--- a/src/rust/bitbox02-rust/src/hww/api/backup.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/backup.rs
@@ -124,7 +124,10 @@ pub async fn create(
             Ok(Response::Success(pb::Success {}))
         }
         Err(err) => {
-            let msg = format!("Backup not created\nPlease contact\nsupport ({:?})", err);
+            let msg = format!(
+                "Backup not created\nPlease contact\nsupport ({})",
+                backup::format_error(&err)
+            );
             hal.ui().status(&msg, false).await;
             Err(Error::Generic)
         }

--- a/src/rust/bitbox02-rust/src/hww/api/change_password.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/change_password.rs
@@ -27,7 +27,9 @@ pub async fn process(hal: &mut impl crate::hal::Hal) -> Result<Response, Error> 
 
     // Re-encrypt seed with new password
     if let Err(err) = keystore::re_encrypt_seed(hal, &seed, &new_password).await {
-        hal.ui().status(&format!("Error\n{:?}", err), false).await;
+        hal.ui()
+            .status(&format!("Error\n{}", keystore::format_error(&err)), false)
+            .await;
         return Err(Error::Generic);
     }
 

--- a/src/rust/bitbox02-rust/src/hww/api/restore.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/restore.rs
@@ -61,7 +61,13 @@ pub async fn from_file(
     if let Err(err) = crate::keystore::encrypt_and_store_seed(hal, seed, &password).await {
         drop(unlock_animation);
         hal.ui()
-            .status(&format!("Could not\nrestore backup\n{:?}", err), false)
+            .status(
+                &format!(
+                    "Could not\nrestore backup\n{}",
+                    crate::keystore::format_error(&err)
+                ),
+                false,
+            )
             .await;
         return Err(Error::Generic);
     }
@@ -139,7 +145,13 @@ pub async fn from_mnemonic(
     if let Err(err) = crate::keystore::encrypt_and_store_seed(hal, &seed, &password).await {
         drop(unlock_animation);
         hal.ui()
-            .status(&format!("Could not\nrestore backup\n{:?}", err), false)
+            .status(
+                &format!(
+                    "Could not\nrestore backup\n{}",
+                    crate::keystore::format_error(&err)
+                ),
+                false,
+            )
             .await;
         return Err(Error::Generic);
     };

--- a/src/rust/bitbox02-rust/src/hww/api/set_password.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/set_password.rs
@@ -27,7 +27,9 @@ pub async fn process(
     let unlock_animation = hal.ui().unlock_animation_create();
     if let Err(err) = keystore::create_and_store_seed(hal, &password, entropy).await {
         drop(unlock_animation);
-        hal.ui().status(&format!("Error\n{:?}", err), false).await;
+        hal.ui()
+            .status(&format!("Error\n{}", keystore::format_error(&err)), false)
+            .await;
         return Err(Error::Generic);
     }
     let seed = keystore::copy_seed(hal).await?;

--- a/src/rust/bitbox02-rust/src/keystore.rs
+++ b/src/rust/bitbox02-rust/src/keystore.rs
@@ -121,6 +121,21 @@ pub enum Error {
     Decrypt,
 }
 
+pub fn format_error(error: &Error) -> String {
+    match error {
+        Error::InvalidState => "InvalidState".into(),
+        Error::CannotUnlockBIP39 => "CannotUnlockBIP39".into(),
+        Error::IncorrectPassword => "IncorrectPassword".into(),
+        Error::MaxAttemptsExceeded => "MaxAttemptsExceeded".into(),
+        Error::Unseeded => "Unseeded".into(),
+        Error::Memory => "Memory".into(),
+        Error::SecureChip(code) => format!("SecureChip({})", code),
+        Error::SeedSize => "SeedSize".into(),
+        Error::Salt => "Salt".into(),
+        Error::Decrypt => "Decrypt".into(),
+    }
+}
+
 impl core::convert::From<securechip::Error> for Error {
     fn from(error: securechip::Error) -> Self {
         match error {

--- a/src/rust/bitbox02-rust/src/workflow/unlock.rs
+++ b/src/rust/bitbox02-rust/src/workflow/unlock.rs
@@ -123,7 +123,10 @@ pub async fn unlock_keystore(
             Err(UnlockError::IncorrectPassword)
         }
         Err(err) => {
-            let msg = format!("keystore unlock failed\n{:?}", err);
+            let msg = format!(
+                "keystore unlock failed\n{}",
+                crate::keystore::format_error(&err)
+            );
             hal.ui().status(&msg, false).await;
             Err(UnlockError::Generic)
         }

--- a/src/rust/util/src/bytes.rs
+++ b/src/rust/util/src/bytes.rs
@@ -14,7 +14,7 @@ pub extern "C" fn rust_util_uint8_to_hex(buf: Bytes, mut out: BytesMut) {
     // https://github.com/rust-lang/rust/issues/83925
     match hex::encode_to_slice(bytes, &mut out.as_mut()[..hexlen]) {
         Ok(()) => {}
-        Err(err) => panic!("{:?}", err),
+        Err(_) => panic!("hex encoding failed"),
     }
     // Null terminator.
     out.as_mut()[hexlen] = 0;


### PR DESCRIPTION
Pass `-Zfmt-debug=none` in the firmware Rust build.

According to
clippy::no_debug (https://rust-lang.github.io/rust-clippy/master/index.html?search=use_debug):

> It should not be used in user-facing output

This tells rustc not to emit normal `Debug` formatter implementations into the cross-compiled firmware image. The option also makes `{:?}` print nothing, so app-visible error status messages must not rely on derived `Debug`.

Keep the live keystore and backup error status screens explicit by formatting those errors through small match-based helpers instead of `Debug`. This preserves the visible diagnostic strings while still allowing derived Debug formatting to be compiled out of the firmware.

There are still live library `Debug` formatting paths in a no-flag build even when our callers map those errors to `InvalidInput`. Protobuf and Miniscript parsers construct detailed errors internally before the caller discards them, for example `WireType` decode errors and Miniscript `NonTopLevel(format!("{:?}", ...))` errors. `fmt-debug=none` prevents those detailed `Debug` formatters and their generic formatting helpers from being linked.

Savings: 6464 bytes