### PR TITLE
da14531: restore BLE UART backpressure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ customers cannot upgrade their bootloader, its changes are recorded separately.
 ## Firmware
 
 ### [Unreleased]
+- Fixed a crash when listing many backups over Bluetooth
 
 ### v9.26.1
 - Fix a payment request validation issue

--- a/src/da14531/da14531_protocol.c
+++ b/src/da14531/da14531_protocol.c
@@ -346,10 +346,11 @@ struct da14531_protocol_frame* da14531_protocol_poll(
         int len = da14531_protocol_format(
             &tmp[0], sizeof(tmp), DA14531_PROTOCOL_PACKET_TYPE_BLE_DATA, *hww_data, 64);
         ASSERT(len <= (int)sizeof(tmp));
-        util_log("out: %s", util_dbg_hex(*hww_data, 64));
-        for (int i = 0; i < len; i++) {
-            rust_bytequeue_put(out_queue, tmp[i]);
+        if (!rust_bytequeue_try_put_slice(out_queue, rust_util_bytes(tmp, len))) {
+            util_log("bytequeue full");
+            return NULL;
         }
+        util_log("out: %s", util_dbg_hex(*hww_data, 64));
         *hww_data = NULL;
     }
     struct da14531_protocol_frame* frame = NULL;

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -121,6 +121,9 @@ dependencies = [
 [[package]]
 name = "bitbox-bytequeue"
 version = "0.1.0"
+dependencies = [
+ "util",
+]
 
 [[package]]
 name = "bitbox-da14531"

--- a/src/rust/bitbox-bytequeue/Cargo.toml
+++ b/src/rust/bitbox-bytequeue/Cargo.toml
@@ -6,3 +6,6 @@ version = "0.1.0"
 authors = ["Shift Crypto AG <support@bitbox.swiss>"]
 edition = "2024"
 license = "Apache-2.0"
+
+[dependencies]
+util = { path = "../util" }

--- a/src/rust/bitbox-bytequeue/src/lib.rs
+++ b/src/rust/bitbox-bytequeue/src/lib.rs
@@ -6,6 +6,7 @@ extern crate alloc;
 
 use alloc::boxed::Box;
 use alloc::collections::VecDeque;
+use util::bytes::Bytes;
 
 pub struct ByteQueue {
     queue: VecDeque<u8>,
@@ -37,6 +38,18 @@ impl ByteQueue {
             panic!("bytequeue overflow");
         }
         self.queue.push_back(data);
+    }
+
+    /// Pushes all bytes to the back of the queue.
+    ///
+    /// Returns `false` if inserting would exceed the initial capacity. In that case, no bytes are
+    /// inserted.
+    pub fn try_put_slice(&mut self, data: &[u8]) -> bool {
+        if data.len() > self.initial_capacity - self.queue.len() {
+            return false;
+        }
+        self.queue.extend(data.iter().copied());
+        true
     }
 
     /// Pops one byte from the front of the queue.
@@ -133,6 +146,24 @@ pub unsafe extern "C" fn rust_bytequeue_put(rb: *mut RustByteQueue, data: u8) {
     }
 }
 
+/// Pushes all bytes to the back of the queue.
+///
+/// Returns false if inserting would exceed the queue capacity. In that case, no bytes are inserted.
+///
+/// # Safety
+/// `rb` must be either null or a valid pointer to a [`ByteQueue`] for the
+/// duration of this call. If non-null, the pointed-to bytequeue must not be
+/// aliased for mutable access elsewhere.
+///
+/// `data` must reference a valid byte buffer for the duration of this call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_bytequeue_try_put_slice(rb: *mut RustByteQueue, data: Bytes) -> bool {
+    let Some(rb) = (unsafe { bytequeue_mut(rb) }) else {
+        return false;
+    };
+    rb.try_put_slice(data.as_ref())
+}
+
 /// Returns the current number of queued bytes.
 ///
 /// # Safety
@@ -167,6 +198,7 @@ mod tests {
     use super::*;
 
     use core::ptr;
+    use util::bytes::rust_util_bytes;
 
     struct TestByteQueue {
         ptr: *mut RustByteQueue,
@@ -225,6 +257,19 @@ mod tests {
     }
 
     #[test]
+    fn test_bytequeue_try_put_slice_overflow_is_atomic() {
+        let mut rb = ByteQueue::with_capacity(3);
+        rb.put(1);
+        assert!(rb.try_put_slice(&[2]));
+        assert!(!rb.try_put_slice(&[3, 4]));
+
+        assert_eq!(rb.num(), 2);
+        assert_eq!(rb.get(), Some(1));
+        assert_eq!(rb.get(), Some(2));
+        assert_eq!(rb.get(), None);
+    }
+
+    #[test]
     fn test_rust_bytequeue_init_free() {
         let rb = rust_bytequeue_init(0);
         assert!(!rb.is_null());
@@ -248,6 +293,31 @@ mod tests {
 
             assert!(rust_bytequeue_get(rb.ptr, &mut out));
             assert_eq!(out, 3);
+        }
+    }
+
+    #[test]
+    fn test_rust_bytequeue_try_put_slice_overflow_is_atomic() {
+        let rb = TestByteQueue::with_capacity(3);
+        let data = [1, 2];
+        let too_much = [3, 4];
+        unsafe {
+            assert!(rust_bytequeue_try_put_slice(
+                rb.ptr,
+                rust_util_bytes(data.as_ptr(), data.len())
+            ));
+            assert!(!rust_bytequeue_try_put_slice(
+                rb.ptr,
+                rust_util_bytes(too_much.as_ptr(), too_much.len())
+            ));
+            assert_eq!(rust_bytequeue_num(rb.ptr), 2);
+
+            let mut out = 0;
+            assert!(rust_bytequeue_get(rb.ptr, &mut out));
+            assert_eq!(out, 1);
+            assert!(rust_bytequeue_get(rb.ptr, &mut out));
+            assert_eq!(out, 2);
+            assert!(!rust_bytequeue_get(rb.ptr, &mut out));
         }
     }
 

--- a/test/simulator-graphical-bb03/Cargo.lock
+++ b/test/simulator-graphical-bb03/Cargo.lock
@@ -332,6 +332,9 @@ dependencies = [
 [[package]]
 name = "bitbox-bytequeue"
 version = "0.1.0"
+dependencies = [
+ "util",
+]
 
 [[package]]
 name = "bitbox-da14531"

--- a/test/simulator-graphical/Cargo.lock
+++ b/test/simulator-graphical/Cargo.lock
@@ -294,6 +294,9 @@ dependencies = [
 [[package]]
 name = "bitbox-bytequeue"
 version = "0.1.0"
+dependencies = [
+ "util",
+]
 
 [[package]]
 name = "bitbox-da14531"


### PR DESCRIPTION
ListBackups returns one protobuf containing all SD card backups. With many backups, the response spans many 64-byte HWW/U2FHID reports. USB sends those reports directly over HID, but BLE first serial-frames each report for the DA14531 and queues the escaped bytes in the fixed-size UART ByteQueue.

The Rust ByteQueue port kept the panicking single-byte put() API and the BLE poller used it for every framed byte. That removed the previous v9.25 backpressure behavior: da14531_protocol_poll() consumed the pending HWW report before knowing whether the whole framed BLE packet fit in the 2048-byte UART queue. If ListBackups produced data faster than UART drained it, put() eventually hit capacity and panicked with bytequeue overflow. USB does not use this UART queue, which is why the same request worked there.

Add ByteQueue::try_put_slice() plus an extern C wrapper that takes util::Bytes and performs an all-or-nothing enqueue. The BLE HWW path now formats the 64-byte report into a temporary serial frame and only clears hww_data after try_put_slice() succeeds. If the queue is full, it returns without writing any bytes, preserving frame boundaries and leaving the same report pending for the next poll after UART has drained.

Keep the existing panicking put() behavior for the other bytequeue callers so the change stays scoped to the actual backpressure boundary. The separate Rust and extern-wrapper tests cover successful writes and failed overflow attempts being atomic.
