### PR TITLE
Refactor agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,126 +1,56 @@
-# Repository Guidelines for bitbox02-firmware
+# AGENTS.md
 
-## Project Structure & Module Organization
-Core firmware and bootloader code sits in `src/`, grouped by subsystem (`bootloader`, `usb`, `ui`,
-`securechip`, plus a `rust/` workspace). Tests live in `test/`: `unit-test/` for cmocka suites,
-`hardware-fakes/` for device shims, and `simulator/` assets. The BitB02 Python client library is in
-`py/bitbox02`. Supporting tooling is in `scripts/` (CI, J-Link macros), and `doc/` for
-manuals. Vendored dependencies are tracked in `external/`.
+This file is the entry point for Codex and other coding agents working in this
+repository. Keep it short, task-oriented, and linked to the detailed guidance in
+`doc/agent/`. OpenAI recommends using AGENTS.md for durable repository context
+such as layout, commands, engineering conventions, constraints, and verification
+steps.
+See OpenAI's AGENTS.md guidance and Codex best practices:
 
-The firmware has C and Rust code. Rust code lives in src/rust. The most important rust crates are:
-- bitbox02-rust: the main app logic. It can expose functions to C using extern "C". If it needs
-  access to C functions, it has to go through the bitbox-hal crate. Never add bitbox02 or
-  bitbox02-sys dep to bitbox02-rust.
-- bitbox02-sys: generated bindings to bitbox02 specific C code. build.rs contains the functions etc
-  that are exposed. See also `wrapper.h`, it needs to include any C headers/declarations that are
-  added to build.rs.
-- bitbox-hal: provides an interface to device specific functionality
-- bitbox02: wraps bitbox02-sys as idiomatic safe Rust and implements the bitbox-hal interface.
+- https://developers.openai.com/codex/guides/agents-md
+- https://developers.openai.com/codex/learn/best-practices
 
-bitbox02-rust is pure Rust and device agnostic. To access device specific functionality it must
-always go through bitbox-hal. The migration is a work in progress, only migrate what is necessary
-for the current scope.
+## Start Here
 
-## Build, Test, and Development Commands
-- `make dockerpull` / `make dockerdev`: fetch and enter the maintained development container.
+- Read the files below that match the task before making changes:
+  - [doc/agent/repository.md](doc/agent/repository.md): repository layout,
+    firmware architecture, and Rust crate boundaries.
+  - [doc/agent/commands.md](doc/agent/commands.md): host commands, container
+    commands, build targets, formatting, and test commands.
+  - [doc/agent/coding.md](doc/agent/coding.md): C, Rust, Python, protobuf,
+    FFI, and migration conventions.
+  - [doc/agent/testing.md](doc/agent/testing.md): unit-test layout, Rust test
+    style, and expected verification.
+  - [doc/agent/review.md](doc/agent/review.md): review focus, commit and PR
+    guidance, and change-discipline rules.
+- Prefer `rg`/`rg --files` for repository search.
+- Keep changes scoped to the task. Do not do unrelated refactors or formatting.
+- Never commit changes unless the user explicitly asks for a commit.
 
-Run regular Unix commands such as `git`, `rg`, `grep`, `ls`, `find`, `sed`, and `cat` directly on
-the host.
+## Critical Rules
 
-Cargo commands for the Rust workspace, such as `cargo test`, `cargo check`, and `cargo clippy`, may
-also be run directly on the host by passing `--manifest-path src/rust/Cargo.toml`.
+- Run regular Unix commands such as `git`, `rg`, `grep`, `ls`, `find`, `sed`,
+  and `cat` directly on the host.
+- Use `./scripts/dev_exec.sh <command>` only for project-specific commands that
+  depend on the project toolchain or compiler environment.
+- Do not wrap `./scripts/dev_exec.sh` itself in `bash -lc`. If shell features are
+  genuinely needed, pass an explicit shell as the command, for example
+  `./scripts/dev_exec.sh bash -lc 'cat versions.json | jq'`.
+- Never run multiple `make` commands in parallel. Run them sequentially.
+- If using `make -j`, always specify the job count, for example
+  `make -j$(nproc)`.
+- For Rust workspace commands on the host, use
+  `--manifest-path src/rust/Cargo.toml`.
+- If `messages/*.proto` changes, run
+  `./scripts/dev_exec.sh make generate-protobufs` before direct Rust `cargo`
+  commands.
+- Do not stop the Rust docker container unless you restart it, for example after
+  `.containerversion` changes.
 
-Use `./scripts/dev_exec.sh <command>` only for project-specific commands that depend on the project
-toolchain or compiler environment.
+## Done Means
 
-In practice, the repository `make` targets in this file are project-specific toolchain commands.
-When running from the host, invoke them via `./scripts/dev_exec.sh make <target>`.
-
-Do not wrap `./scripts/dev_exec.sh` itself in `bash -lc`. Prefer changing CWD
-with CLI args like `tar -C <PATH>`. If a command genuinely needs shell features such as pipes, pass
-an explicit shell as the command, e.g. `./scripts/dev_exec.sh bash -lc 'cat versions.json | jq'`.
-
-- `make firmware` / `make bootloader`: compile firmware or bootloader ELFs into `build/`.
-- `make simulator`: build the Linux simulator under `build-build-noasan/bin/`.
-- `make unit-test && make run-unit-tests`:  build and run the C cmocka/CTest suite with ASan/UBSan.
-- `make run-rust-clippy`: lint Rust code with the workspace configuration.
-- When invoking the above `make` targets from the host, prefer
-  `./scripts/dev_exec.sh make <target>`.
-- Rust workspace commands may also be run directly with `cargo`, without `./scripts/dev_exec.sh`:
-  -  From the repository root on the host, use
-     `cargo test --manifest-path src/rust/Cargo.toml [ -p <crate> ] --all-features -- --test-threads 1`.
-  -  For checks, use
-     `cargo check --manifest-path src/rust/Cargo.toml [ -p <crate> ] --all-features`.
-  -  If you modify `messages/*.proto`, run `make generate-protobufs` before direct Rust `cargo`
-     commands. Plain `cargo test`/`cargo check` does not regenerate the protobuf outputs.
-
-You may use `make -j$(nproc)` to speed up compilation. Do not use `make -j` without specfiying the
-number of processing units.
-
-Never run multiple `make` commands in parallel. For example, instead of
-`make -j$(nproc) firmware bootloader factory-setup`, run them one after the other: `make -j$(nproc) firmware; make -j$(nproc) bootloader; make -j$(nproc) factory-setup`.
-
-
-## Coding Style & Naming Conventions
-`.clang-format` (Chromium base, 4-space indent, Linux braces) and `.clang-tidy` govern C/C++. Use
-`snake_case` for symbols, `PascalCase` for types, and `ALL_CAPS` for macros. Python utilities follow
-`.pylintrc` rules (100-column limit, explicit imports). Rust crates rely on `rustfmt.toml` and the
-pinned toolchain in `rust-toolchain.toml`; keep module paths aligned with `src/rust` and regenerate
-bindings (`cbindgen`, protobuf) when interfaces change. When changing protobuf interfaces, run
-`make generate-protobufs`.
-
-* For C code changes, run `./scripts/dev_exec.sh ./scripts/format` to format the code.
-* For Python changes, run `./scripts/dev_exec.sh ./scripts/format-python` to format the code.
-* For Rust code changes, run
-  `./scripts/dev_exec.sh cargo fmt --manifest-path src/rust/Cargo.toml --all` to format the code.
-
-## Testing Guidelines
-Place new C specs in `test/unit-test` and add doubles to `test/hardware-fakes` when hardware
-behavior is mocked; follow the `test_<feature>.c` naming pattern and update CMake lists. Rust crates
-use standard `tests/` modules or `#[cfg(test)]` blocks. Before opening a PR, run both `make
-run-unit-tests` and `cargo test --manifest-path src/rust/Cargo.toml --all-features -- --test-threads 1`,
-and refresh `make coverage` for cryptography or security-sensitive areas.
-
-- in Rust unit tests, prefer .unwrap() over .expect().
-- In Rust unit tests, if testing a function foo, name the test `test_foo` (or `test_foo_xyz` if it
-  needs qualifiers).
-- if a Rust unit test involves futures, use `#[async_test::test] async fn test_...`.
-- in Rust unit tests, prefer .as_slice() instead of `&*` for wrapped/zeroized Vec<u8>.
-- in Rust unit tests, prefer `hex!` literals for byte arrays/constants.
-
-## Review Guidelines
-
-- when reviewing a removed function call, check that the removed behavior was not required and was
-  not dropped by accident during a refactor.
-- when reviewing a removed function call, check if the callee became unused and should also be removed.
-- Focus on memory issues
-
-## Commit & Pull Request Guidelines
-Write commits with a ≤50 character subject, blank line, and explanatory body per `CONTRIBUTING.md`;
-reference issues via `refs #1234` or `fixes #1234`. Keep patches atomic—avoid mixing formatting and
-logic. Pull requests should outline the change, list verification commands or screenshots, and flag
-hardware requirements; mark drafts with `[WIP]` until they are ready. Wait to squash until reviews
-conclude.
-
-
-## Various
-
-- when converting C code to Rust code, make the Rust code idiomatic, not a 1:1 rewrite.
-- when exposing Rust functions to C using extern "C", use util::bytes::Bytes and
-  util::Bytes::BytesMut ot pass in buffers and write to out buffers.
-- when using Zeroizing<...> for buffers, use Zeroizing<Vec<u8>>. For other sensitive data, use
-  Zeroizing<Box<...>>.
-- when wrapping C functions, always use a '-sys' crate for the bindings, make it safe idiomatic
-  Rust, with no C types in the input/output, especially no pointers. Results should be returned,
-  not passed to an out param. Check all invariants in the C code and panic in case they are not met.
-- don't stop the Rust docker container unless you have restart it, e.g. if the .containerversion
-  changed after checking out a different commit.
-- never commit a change if not explicitly being instructed to
-- when porting or refactoring or rewriting code, retain original comments and docstrings if they
-  still apply. when reviewing commits that refactor/move/rewrite code, point out if comments were
-  dropped.
-- when editing code, unless otherwise instructed, try to keep the diff small and not do any
-  unprompted refactorings or core reorganizations.
-- rust fmt all Rust files you modify, using 2024 edition.
-- when working on BitBox03 UI code, do not reach into `bitbox_lvgl` FFI directly from feature code.
-  If needed, add safe idiomatic wrappers to `bitbox-lvgl` first and use those wrappers instead.
+- The relevant detailed `doc/agent/*.md` guidance has been followed.
+- Formatting has been run for modified languages when practical.
+- Relevant tests or checks have been run, or the final response clearly states
+  why they were not run.
+- The final response summarizes changed files and verification.

--- a/doc/agent/coding.md
+++ b/doc/agent/coding.md
@@ -1,0 +1,69 @@
+# Coding Conventions
+
+This file captures language and architecture conventions for code changes.
+
+## C and C++
+
+- `.clang-format` uses Chromium base style, 4-space indent, and Linux braces.
+- `.clang-tidy` governs C and C++ checks.
+- Use `snake_case` for symbols.
+- Use `PascalCase` for types.
+- Use `ALL_CAPS` for macros.
+- For C code changes, run `./scripts/dev_exec.sh ./scripts/format`.
+
+## Python
+
+- Python utilities follow `.pylintrc`.
+- Keep lines within the configured 100-column limit.
+- Use explicit imports.
+- For Python changes, run `./scripts/dev_exec.sh ./scripts/format-python`.
+
+## Rust
+
+- Rust crates rely on `rustfmt.toml` and the pinned toolchain in
+  `rust-toolchain.toml`.
+- Keep module paths aligned with `src/rust`.
+- Rust fmt all Rust files you modify, using the 2024 edition configuration.
+- For Rust code changes, run:
+
+  ```sh
+  ./scripts/dev_exec.sh cargo fmt --manifest-path src/rust/Cargo.toml --all
+  ```
+- Prefer `hex!` literals for byte arrays and constants.
+
+## Protobuf and Bindings
+
+- When changing protobuf interfaces, run
+  `./scripts/dev_exec.sh make generate-protobufs`.
+- Regenerate bindings with `cbindgen` or protobuf tooling when interfaces
+  change and the repository requires generated outputs.
+- If you modify `messages/*.proto`, run
+  `./scripts/dev_exec.sh make generate-protobufs` before direct Rust `cargo`
+  commands.
+
+## C to Rust Migration
+
+- When converting C code to Rust code, make the Rust code idiomatic instead of a
+  1:1 rewrite.
+- Preserve original comments and docstrings during ports, refactors, and
+  rewrites when they still apply.
+- Migrate only what is necessary for the current scope.
+
+## Rust and C FFI
+
+- When exposing Rust functions to C with `extern "C"`, use `util::bytes::Bytes`
+  and `util::bytes::BytesMut` to pass buffers and write to output buffers.
+- When using `Zeroizing<...>` for buffers, use `Zeroizing<Vec<u8>>`.
+- For other sensitive data, use `Zeroizing<Box<...>>`.
+- When wrapping C functions, always use a `-sys` crate for the bindings.
+- Safe Rust wrappers around C functions must be idiomatic and must not expose C
+  types in their input or output, especially pointers.
+- Return results from wrappers instead of passing output parameters.
+- Check all invariants in C-facing wrapper code and panic if they are violated.
+
+## BitBox03 UI
+
+- When working on BitBox03 UI code, do not reach into `bitbox_lvgl` FFI directly
+  from feature code.
+- If needed, add safe idiomatic wrappers to `bitbox-lvgl` first and use those
+  wrappers instead.

--- a/doc/agent/commands.md
+++ b/doc/agent/commands.md
@@ -1,0 +1,98 @@
+# Commands
+
+This file lists the repository commands agents should use and how to run them.
+
+## Host Commands
+
+Run regular Unix commands directly on the host:
+
+- `git`
+- `rg`
+- `grep`
+- `ls`
+- `find`
+- `sed`
+- `cat`
+
+## Development Container
+
+- `make dockerpull`: fetch the maintained development container.
+- `make dockerdev`: enter the maintained development container.
+
+Do not stop the Rust docker container unless you restart it, for example after
+`.containerversion` changes.
+
+## Toolchain Commands
+
+Use `./scripts/dev_exec.sh <command>` only for project-specific commands that
+depend on the project toolchain or compiler environment.
+
+In practice, the repository `make` targets in this file are project-specific
+toolchain commands. When running from the host, invoke them through
+`./scripts/dev_exec.sh make <target>`.
+
+Do not wrap `./scripts/dev_exec.sh` itself in `bash -lc`. Prefer changing the
+working directory with command arguments such as `tar -C <PATH>`. If a command
+genuinely needs shell features such as pipes, pass an explicit shell as the
+command:
+
+```sh
+./scripts/dev_exec.sh bash -lc 'cat versions.json | jq'
+```
+
+## Build Targets
+
+Run these through `./scripts/dev_exec.sh` from the host:
+
+- `./scripts/dev_exec.sh make firmware`: compile the firmware ELF into `build/`.
+- `./scripts/dev_exec.sh make bootloader`: compile the bootloader ELF into
+  `build/`.
+- `./scripts/dev_exec.sh make simulator`: build the Linux simulator under
+  `build-build-noasan/bin/`.
+- `./scripts/dev_exec.sh make unit-test`: build the C cmocka/CTest suite with
+  ASan/UBSan.
+- `./scripts/dev_exec.sh make run-unit-tests`: run the C cmocka/CTest suite.
+- `./scripts/dev_exec.sh make run-rust-clippy`: lint Rust code with the
+  workspace configuration.
+- `./scripts/dev_exec.sh make generate-protobufs`: regenerate protobuf outputs
+  after changes to `messages/*.proto`.
+
+You may use `make -j$(nproc)` to speed up compilation. Do not use `make -j`
+without specifying the number of processing units.
+
+Never run multiple `make` commands in parallel. For example, run this:
+
+```sh
+./scripts/dev_exec.sh make -j$(nproc) firmware
+./scripts/dev_exec.sh make -j$(nproc) bootloader
+./scripts/dev_exec.sh make -j$(nproc) factory-setup
+```
+
+Do not combine those targets into one parallel `make` invocation.
+
+## Rust Workspace Commands
+
+Cargo commands for the Rust workspace may be run directly on the host by passing
+`--manifest-path src/rust/Cargo.toml`.
+
+Use these forms from the repository root:
+
+```sh
+cargo test --manifest-path src/rust/Cargo.toml [ -p <crate> ] --all-features -- --test-threads 1
+cargo check --manifest-path src/rust/Cargo.toml [ -p <crate> ] --all-features
+```
+
+If `messages/*.proto` changed, run
+`./scripts/dev_exec.sh make generate-protobufs` before direct Rust `cargo`
+commands. Plain `cargo test` and `cargo check` do not regenerate protobuf
+outputs.
+
+## Formatting Commands
+
+- C code: `./scripts/dev_exec.sh ./scripts/format`
+- Python code: `./scripts/dev_exec.sh ./scripts/format-python`
+- Rust code:
+
+```sh
+./scripts/dev_exec.sh cargo fmt --manifest-path src/rust/Cargo.toml --all
+```

--- a/doc/agent/repository.md
+++ b/doc/agent/repository.md
@@ -1,0 +1,40 @@
+# Repository Guide
+
+This file captures repository layout and architecture constraints for agents.
+
+## Layout
+
+- Core firmware and bootloader code is in `src/`.
+- Important C subsystems under `src/` include `bootloader`, `usb`, `ui`, and
+  `securechip`.
+- Rust code lives in the workspace under `src/rust/`.
+- Tests live in `test/`:
+  - `test/unit-test/` contains cmocka suites.
+  - `test/hardware-fakes/` contains device shims.
+  - `test/simulator/` contains C simulator assets.
+  - `test/simulator-graphical/` contains rust simulator assets.
+  - `test/simulator-graphical-bb03/` contains rust simulator assets.
+- The BitBox02 Python client library is in `py/bitbox02`.
+- Supporting tooling is in `scripts/`, including CI and J-Link macros.
+- Manuals and human-facing project documentation are in `doc/`.
+- Agent-maintained instruction detail lives in `doc/agent/`.
+- Vendored dependencies are tracked in `external/`.
+
+## Rust Crate Boundaries
+
+The firmware has C and Rust code. The most important Rust crates are:
+
+- `bitbox02-rust`: main app logic. It may expose functions to C with
+  `extern "C"`. If it needs access to C functions, it must go through
+  `bitbox-hal`. Never add `bitbox02` or `bitbox02-sys` as dependencies of
+  `bitbox02-rust`.
+- `bitbox02-sys`: generated bindings to BitBox02-specific C code. `build.rs`
+  contains the exposed functions. `wrapper.h` must include any C headers or
+  declarations added to `build.rs`.
+- `bitbox-hal`: device-specific interface used by device-agnostic app logic.
+- `bitbox02`: safe idiomatic wrapper around `bitbox02-sys` that implements the
+  `bitbox-hal` interface.
+
+`bitbox02-rust` is pure Rust and device agnostic. It must access
+device-specific functionality through `bitbox-hal`. The migration is in
+progress; migrate only what is necessary for the current scope.

--- a/doc/agent/review.md
+++ b/doc/agent/review.md
@@ -1,0 +1,43 @@
+# Review and Contribution Guide
+
+This file captures review focus, commit and PR expectations, and general
+change-discipline rules.
+
+## Review Focus
+
+- Focus on memory issues.
+- When reviewing a removed function call, check that required behavior was not
+  dropped accidentally during a refactor.
+- When reviewing a removed function call, check whether the callee became unused
+  and should also be removed.
+- When reviewing commits that refactor, move, or rewrite code, point out dropped
+  comments or docstrings that still apply.
+
+## Change Discipline
+
+- Keep diffs small.
+- Do not do unprompted refactorings or core reorganizations.
+- Avoid mixing formatting and logic changes.
+- Preserve comments and docstrings when porting, refactoring, or rewriting code
+  if they still apply.
+- Never commit changes unless the user explicitly asks for a commit.
+
+## Commits
+
+When the user explicitly asks for a commit:
+
+- Write a subject of 50 characters or fewer.
+- Add a blank line after the subject.
+- Include an explanatory body as described in `CONTRIBUTING.md`.
+- Keep commits atomic.
+- Ensure all commits individually pass linters.
+
+## Pull Requests
+
+PR descriptions should:
+
+- Outline the change.
+- List verification commands or screenshots.
+- Flag hardware requirements.
+- Mark drafts with `[WIP]` until they are ready.
+- Wait to squash until reviews conclude.

--- a/doc/agent/testing.md
+++ b/doc/agent/testing.md
@@ -1,0 +1,39 @@
+# Testing Guide
+
+This file captures test layout, test style, and expected verification.
+
+## C Tests
+
+- Place new C specs in `test/unit-test`.
+- Add doubles to `test/hardware-fakes` when hardware behavior is mocked.
+- Follow the `test_<feature>.c` naming pattern.
+- Update CMake lists when adding C tests.
+
+## Rust Tests
+
+- Rust crates use standard `tests/` modules or `#[cfg(test)]` blocks.
+- In Rust unit tests, prefer `.unwrap()` over `.expect()`.
+- If testing a function `foo`, name the test `test_foo`, or `test_foo_xyz` when
+  qualifiers are needed.
+- If a Rust unit test involves futures, use `#[async_test::test] async fn
+  test_...`.
+- Prefer `.as_slice()` instead of `&*` for wrapped or zeroized `Vec<u8>`.
+
+## Verification Before PR
+
+Before opening a PR, run:
+
+```sh
+./scripts/dev_exec.sh make run-unit-tests
+cargo test --manifest-path src/rust/Cargo.toml --all-features -- --test-threads 1
+```
+
+For cryptography or security-sensitive areas, refresh coverage with:
+
+```sh
+./scripts/dev_exec.sh make coverage
+```
+
+If a full verification command is too expensive or cannot be run in the current
+environment, run the most relevant narrower checks and state the limitation in
+the final response.


### PR DESCRIPTION
Make AGENTS.md a concise entry point for agent guidance and move detailed repository, command, coding, testing, and review instructions into doc/agent.

Preserve the existing repository rules while tightening command guidance and linking to OpenAI's AGENTS.md and Codex best-practices documentation.