### PR TITLE
bootloader: reduce snprintf

### DIFF
--- a/.ci/check-unwanted-symbols
+++ b/.ci/check-unwanted-symbols
@@ -63,7 +63,7 @@ check_firmware() {
         "Use integer arithmetic in firmware code instead."
 }
 
-check_production_bootloader() {
+check_bootloader() {
     local elf=$1
     checked=1
 
@@ -74,7 +74,7 @@ check_production_bootloader() {
         "stdio formatting" \
         "$printf_symbol_pattern" \
         "snprintf/printf pulls in significant bootloader bloat." \
-        "Avoid stdio formatting in production bootloaders; use fixed-format helpers instead."
+        "Avoid stdio formatting in bootloaders; use fixed-format helpers instead."
 
     local rust_fmt_symbol_pattern
     rust_fmt_symbol_pattern='(^|[[:space:]])(alloc::fmt::|core::fmt::|<alloc::string::String as core::fmt::Write>)'
@@ -83,14 +83,14 @@ check_production_bootloader() {
         "Rust formatting" \
         "$rust_fmt_symbol_pattern" \
         "Rust format!/write! formatting pulls in significant bootloader bloat." \
-        "Avoid Rust formatting in production bootloaders; use fixed-format helpers instead."
+        "Avoid Rust formatting in bootloaders; use fixed-format helpers instead."
 
     check_symbols \
         "$elf" \
         "Rust SHA-256" \
         "sha26sha256|sha2::sha256::compress256" \
-        "The RustCrypto SHA-256 implementation pulls in significant production bootloader bloat." \
-        "Use the existing PUKCC SHA-256 implementation in production bootloaders instead."
+        "The RustCrypto SHA-256 implementation pulls in significant bootloader bloat." \
+        "Use the existing PUKCC SHA-256 implementation in bootloaders instead."
 }
 
 firmware_elf=build/bin/firmware.elf
@@ -99,8 +99,8 @@ if [[ -f "$firmware_elf" ]]; then
 fi
 
 shopt -s nullglob
-for bootloader_elf in build/bin/*-bl-*-production.elf; do
-    check_production_bootloader "$bootloader_elf"
+for bootloader_elf in build/bin/bb02-bl-*.elf build/bin/bb02p-bl-*.elf; do
+    check_bootloader "$bootloader_elf"
 done
 shopt -u nullglob
 

--- a/.github/workflows/ci-common.yml
+++ b/.github/workflows/ci-common.yml
@@ -242,7 +242,7 @@ jobs:
         run: make -j$(($(nproc)+1)) ${{ matrix.target }}
 
       - name: Check unwanted symbols
-        if: (matrix.target == 'firmware' || (startsWith(matrix.target, 'bootloader') && endsWith(matrix.target, 'production'))) && !cancelled()
+        if: (matrix.target == 'firmware' || (startsWith(matrix.target, 'bootloader') && !endsWith(matrix.target, 'debug'))) && !cancelled()
         run: ./.ci/check-unwanted-symbols
 
       - name: Print hashes

--- a/src/bootloader/bootloader.c
+++ b/src/bootloader/bootloader.c
@@ -1007,8 +1007,8 @@ static bool _devdevice_enter(secbool_u32 firmware_verified)
     struct da14531_firmware_version version;
     bool res = memory_spi_get_active_ble_firmware_version(&version);
     if (res) {
-        char buf[50];
-        snprintf(buf, sizeof(buf), "ble: %d (%s)", version.version, util_dbg_hex(version.hash, 4));
+        char buf[sizeof("ble: 65535 (00112233)")];
+        bootloader_format_ble_firmware_version(buf, sizeof(buf), version.version, version.hash);
         UG_PutString(0, SCREEN_HEIGHT - 18, buf);
     }
     #endif

--- a/src/bootloader/bootloader_format.c
+++ b/src/bootloader/bootloader_format.c
@@ -4,6 +4,7 @@
 
 #include <rust/rust.h>
 #include <string.h>
+#include <util.h>
 #include <utils_assert.h>
 
 void bootloader_format_pairing_code(char* out, size_t out_len, uint32_t pairing_code)
@@ -38,6 +39,25 @@ void bootloader_format_timer(char* out, size_t out_len, uint8_t seconds)
         rust_format_uint(rust_util_bytes_mut((uint8_t*)out, out_len - 1), seconds, 1, '0');
     out[out_pos++] = 's';
     out[out_pos] = '\0';
+}
+
+void bootloader_format_ble_firmware_version(
+    char* out,
+    size_t out_len,
+    uint16_t version,
+    const uint8_t* hash)
+{
+    ASSERT(out_len >= sizeof("ble: 65535 (00112233)"));
+
+    util_strlcpy(out, "ble: ", out_len);
+    size_t out_pos = strlen(out);
+    out_pos += rust_format_uint(
+        rust_util_bytes_mut((uint8_t*)&out[out_pos], out_len - out_pos), version, 1, '0');
+    util_strlcpy(&out[out_pos], " (", out_len - out_pos);
+    out_pos = strlen(out);
+    util_uint8_to_hex(hash, 4, &out[out_pos]);
+    out_pos += 8;
+    util_strlcpy(&out[out_pos], ")", out_len - out_pos);
 }
 
 void bootloader_format_unknown_command(char* out, size_t out_len, uint8_t command)

--- a/src/bootloader/bootloader_format.h
+++ b/src/bootloader/bootloader_format.h
@@ -36,6 +36,18 @@ void bootloader_format_hash_multiline(char* out, size_t out_len, const char* has
 void bootloader_format_timer(char* out, size_t out_len, uint8_t seconds);
 
 /**
+ * Format the BLE firmware version line shown in the dev bootloader menu.
+ *
+ * The first four hash bytes are printed. out_len must be at least
+ * sizeof("ble: 65535 (00112233)").
+ */
+void bootloader_format_ble_firmware_version(
+    char* out,
+    size_t out_len,
+    uint16_t version,
+    const uint8_t* hash);
+
+/**
  * Format an unknown bootloader command message.
  *
  * out_len must be at least sizeof("Command: 255 unknown").

--- a/test/unit-test/test_bootloader_format.c
+++ b/test/unit-test/test_bootloader_format.c
@@ -64,6 +64,22 @@ static void test_timer(void** state)
     assert_string_equal(out, "10s");
 }
 
+static void test_ble_firmware_version(void** state)
+{
+    (void)state;
+    char out[sizeof("ble: 65535 (00112233)")];
+    const uint8_t hash[] = {
+        0x00,
+        0x11,
+        0x22,
+        0x33,
+        0x44,
+    };
+
+    bootloader_format_ble_firmware_version(out, sizeof(out), 65535, hash);
+    assert_string_equal(out, "ble: 65535 (00112233)");
+}
+
 static void test_unknown_command(void** state)
 {
     (void)state;
@@ -80,6 +96,7 @@ int main(void)
         cmocka_unit_test(test_progress),
         cmocka_unit_test(test_hash_multiline),
         cmocka_unit_test(test_timer),
+        cmocka_unit_test(test_ble_firmware_version),
         cmocka_unit_test(test_unknown_command),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
Move the BLE dev menu version formatting to the fixed-format bootloader formatter and add unit coverage.

Extend the unwanted-symbol check to regular development and production bootloader outputs.

Reduces binary size.