### PR TITLE
Bump Rust toolchain to 1.96

### DIFF
--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin/signtx.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin/signtx.rs
@@ -2810,21 +2810,19 @@ mod tests {
                 let next = extract_next(&response);
                 match NextType::try_from(next.r#type).unwrap() {
                     NextType::Output => unsafe { PASS2 = true },
-                    NextType::Input => {
-                        if unsafe { PASS2 } {
-                            unsafe { PASS2_INPUT_REQUESTS_COUNTER += 1 }
-                            if next.index == 0 {
-                                let mut input = tx.inputs[next.index as usize].input.clone();
-                                // Amount in first input in pass2 is bigger than the the sum of all
-                                // inputs in the first pass, which fails immediately.
-                                input.prev_out_value = tx
-                                    .inputs
-                                    .iter()
-                                    .map(|inp| inp.input.prev_out_value)
-                                    .sum::<u64>()
-                                    + 1;
-                                return Ok(Request::BtcSignInput(input));
-                            }
+                    NextType::Input if unsafe { PASS2 } => {
+                        unsafe { PASS2_INPUT_REQUESTS_COUNTER += 1 }
+                        if next.index == 0 {
+                            let mut input = tx.inputs[next.index as usize].input.clone();
+                            // Amount in first input in pass2 is bigger than the the sum of all
+                            // inputs in the first pass, which fails immediately.
+                            input.prev_out_value = tx
+                                .inputs
+                                .iter()
+                                .map(|inp| inp.input.prev_out_value)
+                                .sum::<u64>()
+                                + 1;
+                            return Ok(Request::BtcSignInput(input));
                         }
                     }
                     _ => {}
@@ -2856,15 +2854,13 @@ mod tests {
                 let next = extract_next(&response);
                 match NextType::try_from(next.r#type).unwrap() {
                     NextType::Output => unsafe { PASS2 = true },
-                    NextType::Input => {
-                        if unsafe { PASS2 } {
-                            unsafe { PASS2_INPUT_REQUESTS_COUNTER += 1 }
-                            if next.index == 0 {
-                                let mut input = tx.inputs[next.index as usize].input.clone();
-                                // errors even if we decrease the amount
-                                input.prev_out_value -= 1;
-                                return Ok(Request::BtcSignInput(input));
-                            }
+                    NextType::Input if unsafe { PASS2 } => {
+                        unsafe { PASS2_INPUT_REQUESTS_COUNTER += 1 }
+                        if next.index == 0 {
+                            let mut input = tx.inputs[next.index as usize].input.clone();
+                            // errors even if we decrease the amount
+                            input.prev_out_value -= 1;
+                            return Ok(Request::BtcSignInput(input));
                         }
                     }
                     _ => {}

--- a/src/rust/rust-toolchain.toml
+++ b/src/rust/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.93.1"
+channel = "1.96.0"
 components = ["clippy", "rust-analyzer", "rust-src", "rustfmt"]
 targets = ["thumbv7em-none-eabi", "thumbv8m.main-none-eabihf"]
 profile = "minimal"


### PR DESCRIPTION
Update the pinned Rust toolchain to 1.96.0 and adjust the BTC signtx tests for clippy's collapsible_match lint on the new toolchain.