### PR TITLE
Add local flash driver

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -48,7 +48,6 @@ if(CMAKE_CROSSCOMPILING)
     asf4-drivers/hal/src/hal_timer.c
     asf4-drivers/hal/src/hal_usb_device.c
     asf4-drivers/hal/src/hal_rand_sync.c
-    asf4-drivers/hal/src/hal_flash.c
     asf4-drivers/hal/src/hal_pac.c
     asf4-drivers/hal/src/hal_io.c
     asf4-drivers/hal/src/hal_sha_sync.c

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -108,6 +108,7 @@ set(DBB-BOOTLOADER-SOURCES
 set(DBB-BOOTLOADER-SOURCES ${DBB-BOOTLOADER-SOURCES} PARENT_SCOPE)
 
 set(DRIVER-SOURCES
+  ${CMAKE_SOURCE_DIR}/src/flash.c
   ${CMAKE_SOURCE_DIR}/src/platform/platform_init.c
   ${CMAKE_SOURCE_DIR}/src/platform/driver_init.c
   ${CMAKE_SOURCE_DIR}/src/ui/oled/oled.c

--- a/src/bootloader/bootloader.c
+++ b/src/bootloader/bootloader.c
@@ -8,6 +8,7 @@
 
 #include <driver_init.h>
 #include <flags.h>
+#include <flash.h>
 #include <memory/memory.h>
 #include <memory/memory_shared.h>
 #include <memory/nvmctrl.h>
@@ -476,15 +477,10 @@ static size_t _api_write_chunk(const uint8_t* buf, uint8_t chunknum, uint8_t* ou
         return _report_status(OP_STATUS_OK, output);
     }
 
-    // Erase is handled inside of flash_write
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdiscarded-qualifiers"
-    if (flash_write(
-            &FLASH_0, FLASH_APP_START + (chunknum * FIRMWARE_CHUNK_LEN), buf, FIRMWARE_CHUNK_LEN) !=
-        ERR_NONE) {
+    // Erase is handled inside of flash_write.
+    if (!flash_write(FLASH_APP_START + (chunknum * FIRMWARE_CHUNK_LEN), buf, FIRMWARE_CHUNK_LEN)) {
         return _report_status(OP_STATUS_ERR_WRITE, output);
     }
-#pragma GCC diagnostic pop
 
     if (!MEMEQ(
             (const void*)(FLASH_APP_START + (chunknum * FIRMWARE_CHUNK_LEN)),
@@ -515,8 +511,7 @@ static size_t _api_firmware_erase(uint8_t firmware_num_chunks, uint8_t* output)
     }
     _loading_ready = false;
     for (uint32_t i = 0; i < (uint32_t)FLASH_APP_PAGE_NUM; i += FLASH_REGION_PAGE_NUM) {
-        if (flash_unlock(&FLASH_0, FLASH_APP_START + i * FLASH_PAGE_SIZE, FLASH_REGION_PAGE_NUM) !=
-            FLASH_REGION_PAGE_NUM) {
+        if (!flash_unlock_region(FLASH_APP_START + i * FLASH_PAGE_SIZE)) {
             return _report_status(OP_STATUS_ERR_UNLOCK, output);
         }
     }
@@ -529,7 +524,7 @@ static size_t _api_firmware_erase(uint8_t firmware_num_chunks, uint8_t* output)
         if (MEMEQ((const void*)addr, empty_page, sizeof(empty_page))) {
             continue;
         }
-        if (flash_erase(&FLASH_0, addr, FLASH_ERASE_PAGE_NUM) != ERR_NONE) {
+        if (!flash_erase_pages(addr, FLASH_ERASE_PAGE_NUM)) {
             return _report_status(OP_STATUS_ERR_ERASE, output);
         }
         if (!MEMEQ((const void*)addr, empty_page, sizeof(empty_page))) {
@@ -630,7 +625,7 @@ static secbool_u32 _firmware_verified_jump(const boot_data_t* data, secbool_u32 
     }
 
     for (uint32_t i = 0; i < (uint32_t)FLASH_APP_PAGE_NUM; i += FLASH_REGION_PAGE_NUM) {
-        flash_lock(&FLASH_0, FLASH_APP_START + i * FLASH_PAGE_SIZE, FLASH_REGION_PAGE_NUM);
+        flash_lock_region(FLASH_APP_START + i * FLASH_PAGE_SIZE);
     }
 
     // Verify the firmware, signed by the signing keys
@@ -672,19 +667,14 @@ static secbool_u32 _firmware_verified_jump(const boot_data_t* data, secbool_u32 
 static uint8_t _write_chunk(uint32_t address, const uint8_t* data)
 {
     const uint32_t lock_size = FLASH_ERASE_PAGE_NUM * FLASH_PAGE_SIZE;
-    if (flash_unlock(&FLASH_0, address & ~(lock_size - 1), FLASH_REGION_PAGE_NUM) !=
-        FLASH_REGION_PAGE_NUM) {
+    if (!flash_unlock_region(address & ~(lock_size - 1))) {
         return OP_STATUS_ERR_UNLOCK;
     }
-    // Erase is handled inside of flash_write
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdiscarded-qualifiers"
-    if (flash_write(&FLASH_0, address, data, FLASH_BOOTDATA_LEN) != ERR_NONE) {
+    // Erase is handled inside of flash_write.
+    if (!flash_write(address, data, FLASH_BOOTDATA_LEN)) {
         return OP_STATUS_ERR_WRITE;
     }
-#pragma GCC diagnostic pop
-    if (flash_lock(&FLASH_0, address & ~(lock_size - 1), FLASH_REGION_PAGE_NUM) !=
-        FLASH_REGION_PAGE_NUM) {
+    if (!flash_lock_region(address & ~(lock_size - 1))) {
         return OP_STATUS_ERR_LOCK;
     }
     return OP_STATUS_OK;

--- a/src/flags.h
+++ b/src/flags.h
@@ -55,8 +55,7 @@
 // aligned at 16 pages (8kB); app start must be multiple of 8kB.
 #define FLASH_REGION_NUM (32U)
 #define FLASH_REGION_PAGE_NUM (FLASH_SIZE / (FLASH_REGION_NUM * FLASH_PAGE_SIZE)) // = 64
-// Erase granularity: can only erase this many pages at a time in a single flash_erase() call.
-// (erasing more does not work due to a bug (?) with _flash_erase_block() not working as expected.
+// Erase granularity: can only erase this many pages in one hardware erase block.
 #define FLASH_ERASE_PAGE_NUM (16U)
 #define FLASH_ERASE_MIN_LEN \
     (FLASH_ERASE_PAGE_NUM * FLASH_PAGE_SIZE) // 8kB; minimum erase granularity

--- a/src/flash.c
+++ b/src/flash.c
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "flash.h"
+
+#include "flags.h"
+
+#include <hpl_nvmctrl_config.h>
+#include <hri_nvmctrl_d51.h>
+#include <sam.h>
+#include <string.h>
+
+#define FLASH_ERROR_FLAGS \
+    (NVMCTRL_INTFLAG_ADDRE | NVMCTRL_INTFLAG_PROGE | NVMCTRL_INTFLAG_LOCKE | NVMCTRL_INTFLAG_NVME)
+
+#define FLASH_BLOCK_SIZE (FLASH_ERASE_PAGE_NUM * FLASH_PAGE_SIZE)
+#define FLASH_PAGE_WORDS (FLASH_PAGE_SIZE / sizeof(uint32_t))
+#define FLASH_BLOCK_WORDS (FLASH_BLOCK_SIZE / sizeof(uint32_t))
+#define NVM_MEMORY ((volatile uint32_t*)FLASH_ADDR)
+
+_Static_assert(FLASH_PAGE_SIZE == NVMCTRL_PAGE_SIZE, "flash page size mismatch");
+_Static_assert(FLASH_BLOCK_SIZE == NVMCTRL_BLOCK_SIZE, "flash block size mismatch");
+
+static bool _ready(void)
+{
+    return hri_nvmctrl_get_STATUS_READY_bit(NVMCTRL);
+}
+
+static void _clear_errors(void)
+{
+    hri_nvmctrl_clear_INTFLAG_reg(NVMCTRL, FLASH_ERROR_FLAGS);
+}
+
+static bool _status_ok(void)
+{
+    return (hri_nvmctrl_read_INTFLAG_reg(NVMCTRL) & FLASH_ERROR_FLAGS) == 0;
+}
+
+static bool _ready_wait(void)
+{
+    while (!_ready()) {
+    }
+    return _status_ok();
+}
+
+static bool _start_command(uint32_t addr, uint16_t command)
+{
+    if (!_ready_wait()) {
+        return false;
+    }
+    _clear_errors();
+    hri_nvmctrl_write_ADDR_reg(NVMCTRL, addr);
+    hri_nvmctrl_write_CTRLB_reg(NVMCTRL, command | NVMCTRL_CTRLB_CMDEX_KEY);
+    return true;
+}
+
+static bool _start_command_no_addr(uint16_t command)
+{
+    if (!_ready_wait()) {
+        return false;
+    }
+    _clear_errors();
+    hri_nvmctrl_write_CTRLB_reg(NVMCTRL, command | NVMCTRL_CTRLB_CMDEX_KEY);
+    return true;
+}
+
+static bool _flash_range_ok(uint32_t addr, size_t len)
+{
+    if (len == 0 || len > FLASH_SIZE) {
+        return false;
+    }
+#if FLASH_ADDR != 0
+    if (addr < FLASH_ADDR) {
+        return false;
+    }
+#endif
+    return addr - FLASH_ADDR <= FLASH_SIZE - len;
+}
+
+static bool _flash_page_range_ok(uint32_t addr, uint32_t num_pages)
+{
+    if (num_pages == 0 || (addr % FLASH_PAGE_SIZE) != 0 ||
+        num_pages > FLASH_SIZE / FLASH_PAGE_SIZE) {
+        return false;
+    }
+    return _flash_range_ok(addr, (size_t)num_pages * FLASH_PAGE_SIZE);
+}
+
+static bool _flash_erase_block(uint32_t block_addr);
+static bool _flash_program_page(uint32_t page_addr, const uint32_t* page_words);
+
+static bool _program_block(uint32_t block_addr, const uint32_t* block_words)
+{
+    for (uint32_t offset = 0; offset < FLASH_BLOCK_SIZE; offset += FLASH_PAGE_SIZE) {
+        if (!_flash_program_page(block_addr + offset, &block_words[offset / sizeof(uint32_t)]) ||
+            !_ready_wait()) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void flash_init(void)
+{
+    (void)_ready_wait();
+
+    uint32_t ctrla = hri_nvmctrl_read_CTRLA_reg(NVMCTRL);
+    ctrla &= ~(NVMCTRL_CTRLA_CACHEDIS0 | NVMCTRL_CTRLA_CACHEDIS1 | NVMCTRL_CTRLA_PRM_Msk);
+    ctrla |= (CONF_NVM_CACHE0 << NVMCTRL_CTRLA_CACHEDIS0_Pos) |
+             (CONF_NVM_CACHE1 << NVMCTRL_CTRLA_CACHEDIS1_Pos) |
+             NVMCTRL_CTRLA_PRM(CONF_NVM_SLEEPPRM);
+    hri_nvmctrl_write_CTRLA_reg(NVMCTRL, ctrla);
+}
+
+void flash_deinit(void)
+{
+    (void)_ready_wait();
+}
+
+bool flash_disable_bootprot(void)
+{
+    return _start_command_no_addr(NVMCTRL_CTRLB_CMD_SBPDIS) && _ready_wait();
+}
+
+bool flash_lock_region(uint32_t addr_in_region)
+{
+    return _start_command(addr_in_region, NVMCTRL_CTRLB_CMD_LR) && _ready_wait();
+}
+
+bool flash_unlock_region(uint32_t addr_in_region)
+{
+    return _start_command(addr_in_region, NVMCTRL_CTRLB_CMD_UR) && _ready_wait();
+}
+
+bool flash_erase_pages(uint32_t page_addr, uint32_t num_pages)
+{
+    if (!_ready_wait()) {
+        return false;
+    }
+    if (!_flash_page_range_ok(page_addr, num_pages)) {
+        return false;
+    }
+
+    uint32_t block[FLASH_BLOCK_WORDS];
+    uint32_t addr = page_addr;
+    size_t remaining = (size_t)num_pages * FLASH_PAGE_SIZE;
+    while (remaining > 0) {
+        const uint32_t block_addr = addr & ~(FLASH_BLOCK_SIZE - 1U);
+        const size_t block_offset = addr - block_addr;
+        size_t len = FLASH_BLOCK_SIZE - block_offset;
+        if (len > remaining) {
+            len = remaining;
+        }
+
+        if (block_offset == 0 && len == FLASH_BLOCK_SIZE) {
+            if (!_flash_erase_block(block_addr) || !_ready_wait()) {
+                return false;
+            }
+        } else {
+            memcpy(block, (const void*)(uintptr_t)block_addr, sizeof(block));
+            memset((uint8_t*)block + block_offset, 0xff, len);
+            if (!_flash_erase_block(block_addr) || !_ready_wait() ||
+                !_program_block(block_addr, block)) {
+                return false;
+            }
+        }
+        addr += len;
+        remaining -= len;
+    }
+    return true;
+}
+
+bool flash_write(uint32_t addr, const uint8_t* data, size_t len)
+{
+    if (!_ready_wait()) {
+        return false;
+    }
+    if (data == NULL || !_flash_range_ok(addr, len)) {
+        return false;
+    }
+
+    uint32_t block[FLASH_BLOCK_WORDS];
+    const uint8_t* src = data;
+    size_t remaining = len;
+    while (remaining > 0) {
+        const uint32_t block_addr = addr & ~(FLASH_BLOCK_SIZE - 1U);
+        const size_t block_offset = addr - block_addr;
+        size_t len_in_block = FLASH_BLOCK_SIZE - block_offset;
+        if (len_in_block > remaining) {
+            len_in_block = remaining;
+        }
+
+        memcpy(block, (const void*)(uintptr_t)block_addr, sizeof(block));
+        memcpy((uint8_t*)block + block_offset, src, len_in_block);
+        if (!_flash_erase_block(block_addr) || !_ready_wait() ||
+            !_program_block(block_addr, block)) {
+            return false;
+        }
+
+        addr += len_in_block;
+        src += len_in_block;
+        remaining -= len_in_block;
+    }
+    return true;
+}
+
+static bool _flash_erase_block(uint32_t block_addr)
+{
+    return _start_command(block_addr, NVMCTRL_CTRLB_CMD_EB);
+}
+
+static bool _flash_program_page(uint32_t page_addr, const uint32_t* page_words)
+{
+    if (!_start_command_no_addr(NVMCTRL_CTRLB_CMD_PBC) || !_ready_wait()) {
+        return false;
+    }
+
+    volatile uint32_t* dst = &NVM_MEMORY[page_addr / sizeof(uint32_t)];
+    for (uint32_t i = 0; i < FLASH_PAGE_WORDS; i++) {
+        dst[i] = page_words[i];
+    }
+
+    return _start_command(page_addr, NVMCTRL_CTRLB_CMD_WP);
+}

--- a/src/flash.h
+++ b/src/flash.h
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef _BB02_FLASH_H_
+#define _BB02_FLASH_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+// Configures the NVMCTRL flash controller. The NVMCTRL clock must already be enabled.
+void flash_init(void);
+
+// Waits until any in-flight flash command has finished.
+void flash_deinit(void);
+
+// Disables the boot protection fuse until the next reset.
+bool flash_disable_bootprot(void);
+
+// Locks the flash region containing `addr_in_region`.
+bool flash_lock_region(uint32_t addr_in_region);
+
+// Unlocks the flash region containing `addr_in_region`.
+bool flash_unlock_region(uint32_t addr_in_region);
+
+// Erases `num_pages` pages, preserving bytes in partially covered erase blocks.
+bool flash_erase_pages(uint32_t page_addr, uint32_t num_pages);
+
+// Writes bytes, preserving bytes outside the written range.
+bool flash_write(uint32_t addr, const uint8_t* data, size_t len);
+
+#endif

--- a/src/memory/memory.c
+++ b/src/memory/memory.c
@@ -5,8 +5,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "driver_init.h"
 #include "flags.h"
+#include "flash.h"
 #include "hardfault.h"
 #include "memory.h"
 #include "memory_shared.h"
@@ -188,24 +188,21 @@ static bool _write_to_address(uint32_t base, uint32_t offset, uint8_t* chunk)
         lock_addr = (n_pages - FLASH_REGION_PAGE_NUM) * FLASH_PAGE_SIZE;
     }
 
-    int res = flash_unlock(&FLASH_0, lock_addr, FLASH_REGION_PAGE_NUM);
-    if (res != FLASH_REGION_PAGE_NUM) {
+    if (!flash_unlock_region(lock_addr)) {
         return false;
     }
     if (chunk == NULL) {
-        // Usually has a minimum granularity of 16 pages (one chunk), but the
-        // flash_erase driver manually handles smaller/bigger erases.
-        if (flash_erase(&FLASH_0, addr, FLASH_ERASE_PAGE_NUM) != ERR_NONE) {
+        // The flash driver preserves bytes outside the requested pages.
+        if (!flash_erase_pages(addr, FLASH_ERASE_PAGE_NUM)) {
             return false;
         }
     } else {
-        // Usually flash_erase is needed before flash_write, the flash_write
-        // driver already handles this.
-        if (flash_write(&FLASH_0, addr, chunk, CHUNK_SIZE) != ERR_NONE) {
+        // flash_write handles the erase and preserves bytes outside the write.
+        if (!flash_write(addr, chunk, CHUNK_SIZE)) {
             return false;
         }
     }
-    if (flash_lock(&FLASH_0, lock_addr, FLASH_REGION_PAGE_NUM) != FLASH_REGION_PAGE_NUM) {
+    if (!flash_lock_region(lock_addr)) {
         // pass, not a critical error.
     }
     return true;

--- a/src/memory/memory_shared.c
+++ b/src/memory/memory_shared.c
@@ -5,8 +5,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <driver_init.h>
 #include <flags.h>
+#include <flash.h>
 #include <rust/rust.h>
 #include <util.h>
 #include <utils_assert.h>
@@ -61,24 +61,21 @@ static bool _write_to_address(uint32_t base, uint32_t offset, uint8_t* chunk)
         lock_addr = (n_pages - FLASH_REGION_PAGE_NUM) * FLASH_PAGE_SIZE;
     }
 
-    int res = flash_unlock(&FLASH_0, lock_addr, FLASH_REGION_PAGE_NUM);
-    if (res != FLASH_REGION_PAGE_NUM) {
+    if (!flash_unlock_region(lock_addr)) {
         return false;
     }
     if (chunk == NULL) {
-        // Usually has a minimum granularity of 16 pages (one chunk), but the
-        // flash_erase driver manually handles smaller/bigger erases.
-        if (flash_erase(&FLASH_0, addr, FLASH_ERASE_PAGE_NUM) != ERR_NONE) {
+        // The flash driver preserves bytes outside the requested pages.
+        if (!flash_erase_pages(addr, FLASH_ERASE_PAGE_NUM)) {
             return false;
         }
     } else {
-        // Usually flash_erase is needed before flash_write, the flash_write
-        // driver already handles this.
-        if (flash_write(&FLASH_0, addr, chunk, CHUNK_SIZE) != ERR_NONE) {
+        // flash_write handles the erase and preserves bytes outside the write.
+        if (!flash_write(addr, chunk, CHUNK_SIZE)) {
             return false;
         }
     }
-    if (flash_lock(&FLASH_0, lock_addr, FLASH_REGION_PAGE_NUM) != FLASH_REGION_PAGE_NUM) {
+    if (!flash_lock_region(lock_addr)) {
         // pass, not a critical error.
     }
     return true;

--- a/src/platform/driver_init.c
+++ b/src/platform/driver_init.c
@@ -4,6 +4,7 @@
 
 #include "driver_init.h"
 #include "bitbox02_pins.h"
+#include "flash.h"
 #include "memory/memory_shared.h"
 #include "util.h"
 #include <compiler.h>
@@ -16,7 +17,6 @@
 
 struct sha_sync_descriptor HASH_ALGORITHM_0;
 struct timer_descriptor TIMER_0;
-struct flash_descriptor FLASH_0;
 struct i2c_m_sync_desc I2C_0;
 struct mci_sync_desc MCI_0;
 struct rand_sync_desc RAND_0;
@@ -63,7 +63,16 @@ static void _sha_init(void)
 static void _flash_memory_init(void)
 {
     hri_mclk_set_AHBMASK_NVMCTRL_bit(MCLK);
-    flash_init(&FLASH_0, NVMCTRL);
+    flash_init();
+}
+
+/**
+ * Disables FLASH memory access
+ */
+static void _flash_memory_deinit(void)
+{
+    flash_deinit();
+    hri_mclk_clear_AHBMASK_NVMCTRL_bit(MCLK);
 }
 
 /**
@@ -424,12 +433,13 @@ void system_close_interfaces(void)
     // Display remains on last screen
     SPI_OLED_disable();
     // Flash
-    flash_deinit(&FLASH_0);
+    _flash_memory_deinit();
     // USB
     usb_d_deinit();
     // Hardware crypto
     sha_sync_deinit(&HASH_ALGORITHM_0);
     rand_sync_deinit(&RAND_0);
+    _is_initialized = false;
 }
 
 void bootloader_close_interfaces(void)
@@ -441,10 +451,11 @@ void bootloader_close_interfaces(void)
     // Display remains on last screen
     SPI_OLED_disable();
     // Flash
-    flash_deinit(&FLASH_0);
+    _flash_memory_deinit();
     // USB
     usb_d_deinit();
     // Hardware crypto
     sha_sync_deinit(&HASH_ALGORITHM_0);
     rand_sync_deinit(&RAND_0);
+    _is_initialized = false;
 }

--- a/src/platform/driver_init.h
+++ b/src/platform/driver_init.h
@@ -10,7 +10,6 @@
     #include <bitbox02_pins.h>
     #include <hal_atomic.h>
     #include <hal_delay.h>
-    #include <hal_flash.h>
     #include <hal_i2c_m_sync.h>
     #include <hal_init.h>
     #include <hal_io.h>
@@ -42,7 +41,6 @@ extern struct i2c_m_sync_desc I2C_0;
 extern struct mci_sync_desc MCI_0;
 extern struct aes_sync_descriptor CRYPTOGRAPHY_0;
 extern struct sha_sync_descriptor HASH_ALGORITHM_0;
-extern struct flash_descriptor FLASH_0;
 extern struct rand_sync_desc RAND_0;
 extern PPUKCL_PARAM pvPUKCLParam;
 extern PUKCL_PARAM PUKCLParam;


### PR DESCRIPTION
Replace the ASF HAL flash descriptor usage with the local NVMCTRL flash driver and update firmware, bootloader, and memory call sites to use the new API.

Remove hal_flash.c from the external ASF driver build.

reduces fw size by 832B and bl size by 576B.