### PR TITLE
Disable ASLR for unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,11 @@ unit-test: | build-build
 	$(MAKE) -C build-build
 # Must compile C tests before running them
 run-unit-tests: | build-build
-	CTEST_OUTPUT_ON_FAILURE=1 $(MAKE) -C build-build test
+	if command -v setarch >/dev/null 2>&1 && setarch "$$(uname -m)" -R true >/dev/null 2>&1; then \
+		CTEST_OUTPUT_ON_FAILURE=1 setarch "$$(uname -m)" -R $(MAKE) -C build-build test; \
+	else \
+		CTEST_OUTPUT_ON_FAILURE=1 $(MAKE) -C build-build test; \
+	fi
 # Only one test thread because of unsafe concurrent access to `SafeData`,
 # `mock_sd()` and `mock_memory()`. Using mutexes instead leads to mutex
 # poisoning and very messy output in case of a unit test failure.


### PR DESCRIPTION
 The issue is the ASan runtime interacting badly with high-entropy ASLR / vm.mmap_rnd_bits. ASan reserves large fixed virtual address ranges for shadow memory and allocator metadata. With enough mmap
  randomization, a trivial sanitized binary can start in an address range ASan cannot handle, crash during ASan startup, then recurse through ASan’s signal handler and print AddressSanitizer:DEADLYSIGNAL
  indefinitely.

  Relevant reports:

  - google/sanitizers#1614 (https://github.com/google/sanitizers/issues/1614): minimal int main(){} with gcc -fsanitize=address repeatedly prints AddressSanitizer:DEADLYSIGNAL when vm.mmap_rnd_bits=32.
  - tpm2-tss#2792 (https://github.com/tpm2-software/tpm2-tss/issues/2792): same CI hang, workaround is sudo sysctl vm.mmap_rnd_bits=28; notes newer LLVM resolves it.
  - Code Intelligence troubleshooting (https://docs.code-intelligence.com/troubleshooting): documents sanitizer crashes with high ASLR entropy and says LLVM >= 17 or lowering vm.mmap_rnd_bits fixes it.
  - actions/runner-images#9524 (https://github.com/actions/runner-images/issues/9524) and googletest#4491 (https://github.com/google/googletest/issues/4491): CI reports of endless AddressSanitizer:DEADLYSIGNAL
    loops even with trivial/no tests.

  Local confirmation: a tiny ASan hello-world also loops here, but succeeds under:

  setarch "$(uname -m)" -R /tmp/asan-simple

  So I changed Makefile so make run-unit-tests runs CTest under setarch -R when available, disabling ASLR only for that test process tree.