### PR TITLE
usb: fix watchdog aborting Bluetooth requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ customers cannot upgrade their bootloader, its changes are recorded separately.
 ### [Unreleased]
 - Fixed a crash when listing many backups over Bluetooth
 - Add support for BitBoxSync
+- Bluetooth: fix requests being aborted while confirming on the device
 
 ### v9.26.4
 - Ethereum: allow ':' in EIP-712 type names, used by some dapps as a namespace separator

--- a/src/rust/bitbox-hal/src/system.rs
+++ b/src/rust/bitbox-hal/src/system.rs
@@ -14,8 +14,10 @@ pub trait System {
     /// This watchdog tracks the amount of time to wait before an outstanding
     /// operation times out (for example, if the client closes).
     /// Use this for long running operations that are expected to take longer
-    /// than about 300ms (a bit less than the 500ms timeout before a task is
-    /// cancelled).
+    /// than the timeout window, which depends on the active transport.
+    ///
+    /// `value` counts in 100ms units: `0` restarts the normal window, a
+    /// negative value extends it by `abs(value)` units.
     fn communication_timeout_reset(&mut self, value: i16);
 
     fn is_btconly(&mut self) -> bool;

--- a/src/rust/bitbox02-rust/src/async_usb.rs
+++ b/src/rust/bitbox02-rust/src/async_usb.rs
@@ -90,8 +90,8 @@ where
             *state = UsbTaskState::Running(Some(task), WaitingForNextRequestState::Idle);
         }
         // This panic could happen e.g. if someone reconnects to the BitBox while a task is running,
-        // before the 500ms timeout cancels the task. The proper way to handle would be to let the
-        // host know we are busy so the host can re-retry after some time.
+        // before the outstanding-operation timeout cancels the task. The proper way to handle
+        // would be to let the host know we are busy so the host can re-retry after some time.
         _ => panic!("spawn: wrong state"),
     }
 }

--- a/src/rust/bitbox02-rust/src/communication_mode.rs
+++ b/src/rust/bitbox02-rust/src/communication_mode.rs
@@ -35,15 +35,16 @@ fn has_ble(hal: &mut impl crate::hal::Hal) -> bool {
 }
 
 #[cfg(test)]
+pub(crate) fn reset_for_testing() {
+    USB_HWW_REQUEST_SEEN.write(false);
+    HAS_BLE.write(None);
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
 
     use crate::hal::testing::TestingHal;
-
-    fn reset_for_testing() {
-        USB_HWW_REQUEST_SEEN.write(false);
-        HAS_BLE.write(None);
-    }
 
     #[test]
     fn test_ble_disabled_on_non_plus() {

--- a/src/rust/bitbox02-rust/src/hww/transport.rs
+++ b/src/rust/bitbox02-rust/src/hww/transport.rs
@@ -16,7 +16,10 @@ const HWW_RSP_ACK: u8 = 0;
 const HWW_RSP_NOT_READY: u8 = 1;
 const HWW_RSP_BUSY: u8 = 2;
 const HWW_RSP_NACK: u8 = 3;
+// Bluetooth needs a larger window than USB, because its round trip eats into the time the host
+// has to poll.
 const USB_OUTSTANDING_OP_TIMEOUT_MS: u64 = 500;
+const USB_OUTSTANDING_OP_TIMEOUT_BLE_MS: u64 = 3000;
 
 pub type HwwTransport<H> = U2fHid<HwwVendorHandler<H>>;
 
@@ -80,12 +83,19 @@ impl<H> HwwVendorHandler<H> {
             deadline_ms: None,
         }
     }
+}
 
+impl<H: Hal> HwwVendorHandler<H> {
     fn refresh_timeout(&mut self, now_ms: u64) {
         self.deadline_ms = if crate::async_usb::is_idle() {
             None
         } else {
-            Some(now_ms.saturating_add(USB_OUTSTANDING_OP_TIMEOUT_MS))
+            let timeout_ms = if crate::communication_mode::ble_enabled(&mut self.hal) {
+                USB_OUTSTANDING_OP_TIMEOUT_BLE_MS
+            } else {
+                USB_OUTSTANDING_OP_TIMEOUT_MS
+            };
+            Some(now_ms.saturating_add(timeout_ms))
         };
     }
 }
@@ -207,6 +217,8 @@ mod tests {
     fn test_guard() -> MutexGuard<'static, ()> {
         let guard = TEST_LOCK.lock().unwrap();
         crate::async_usb::cancel();
+        // Reset communication-mode statics so BLE state cannot leak between tests.
+        crate::communication_mode::reset_for_testing();
         guard
     }
 
@@ -320,6 +332,31 @@ mod tests {
         assert!(!crate::async_usb::is_idle());
 
         bitbox_u2fhid::VendorCommandHandler::tick(&mut handler, USB_OUTSTANDING_OP_TIMEOUT_MS + 1);
+        assert!(crate::async_usb::is_idle());
+    }
+
+    #[test]
+    fn test_outstanding_request_over_ble_uses_longer_timeout() {
+        let _guard = test_guard();
+        crate::async_usb::spawn(pending_task, &[]);
+        let mut handler = handler();
+        handler.hal.memory.set_platform(Platform::BitBox02Plus);
+
+        let response = handler
+            .handle_vendor_command(1, HWW_CMD, &[HWW_REQ_RETRY], 0)
+            .unwrap();
+        assert_eq!(response, vec![HWW_RSP_NOT_READY]);
+        assert!(!crate::async_usb::is_idle());
+
+        // USB timeout must not abort a healthy BLE operation.
+        bitbox_u2fhid::VendorCommandHandler::tick(&mut handler, USB_OUTSTANDING_OP_TIMEOUT_MS + 1);
+        assert!(!crate::async_usb::is_idle());
+
+        // BLE timeout does abort after the longer window.
+        bitbox_u2fhid::VendorCommandHandler::tick(
+            &mut handler,
+            USB_OUTSTANDING_OP_TIMEOUT_BLE_MS + 1,
+        );
         assert!(crate::async_usb::is_idle());
     }
 

--- a/src/rust/bitbox02-rust/src/keystore.rs
+++ b/src/rust/bitbox02-rust/src/keystore.rs
@@ -19,8 +19,8 @@ use bitcoin::hashes::{Hash, HashEngine, Hmac, HmacEngine, sha256, sha512};
 /// aes256cbc-hmac cipher adds 16 bytes IV, 16 bytes padding, 32 bytes hmac.
 const ENCRYPTION_OVERHEAD: usize = 64;
 
-// Unlocking the keystore takes longer than the default 500 ms watchdog. Bump the watchdog timeout
-// to roughly seven seconds so we don't assume communication was lost mid-unlock.
+// Unlocking the keystore takes longer than the watchdog window. Bump the watchdog timeout by
+// roughly seven seconds so we don't assume communication was lost mid-unlock.
 const LONG_TIMEOUT: i16 = -70;
 
 // After this many failed unlock attempts, the keystore becomes locked until a device reset.

--- a/src/rust/bitbox02-rust/src/reset.rs
+++ b/src/rust/bitbox02-rust/src/reset.rs
@@ -13,9 +13,9 @@ use crate::hal::{Eeprom, Memory, SecureChip, System, Ui, memory};
 /// `status` selects whether the status message indicates success or failure (user invoked vs forced).
 pub(crate) async fn reset(hal: &mut impl crate::hal::Hal, status: bool) {
     crate::keystore::lock();
-    // Resetting takes longer than the default 500 ms watchdog. Bump the watchdog timeout to roughly
-    // 7 seconds (longer than needed) so we don't assume communication was lost and this task gets
-    // dropped at an await point.
+    // Resetting takes longer than the watchdog window. Bump the watchdog timeout by roughly
+    // 7 seconds (longer than needed) so we don't assume communication was lost and this task
+    // gets dropped at an await point.
     const LONG_TIMEOUT: i16 = -70;
     hal.system().communication_timeout_reset(LONG_TIMEOUT);
 

--- a/src/usb/usb_processing.c
+++ b/src/usb/usb_processing.c
@@ -25,11 +25,15 @@ extern struct timer_descriptor TIMER_0;
 
 /**
  * Amount of time to wait before an outstanding operation times out
- * (if the client is closed).
+ * (if the client is closed). Bluetooth needs a larger window than USB,
+ * because its round trip is slower.
  */
 #define USB_OUTSTANDING_OP_TIMEOUT_MS (500)
+#define USB_OUTSTANDING_OP_TIMEOUT_BLE_MS (3000)
 #define USB_TIMER_TICK_PERIOD_MS (100)
 #define USB_OUTSTANDING_OP_TIMEOUT_TICKS (USB_OUTSTANDING_OP_TIMEOUT_MS / USB_TIMER_TICK_PERIOD_MS)
+#define USB_OUTSTANDING_OP_TIMEOUT_BLE_TICKS \
+    (USB_OUTSTANDING_OP_TIMEOUT_BLE_MS / USB_TIMER_TICK_PERIOD_MS)
 
 struct usb_processing {
     CMD_Callback* registered_cmds;
@@ -104,10 +108,10 @@ typedef struct {
     struct usb_processing* blocking_ctx;
     /**
      * Timeout counter. This is increased every 100ms by a timer,
-     * and is reset to 0 every time a new packet is send to one of the
-     * underlying stacks. When the timeout counter becomes greater then
-     * USB_OUTSTANDING_OP_TIMEOUT_TICKS, any outstanding operation is aborted
-     * and the USB stack is forcefully unlocked.
+     * and is reset to 0 every time a new packet is sent to one of the
+     * underlying stacks. When the timeout counter becomes greater than
+     * the timeout of the currently locked context, any outstanding
+     * operation is aborted and the USB stack is forcefully unlocked.
      */
     int16_t timeout_counter;
 #endif
@@ -305,6 +309,17 @@ static void _usb_consume_incoming_packets(struct usb_processing* ctx)
 
 #if !defined(BOOTLOADER)
 /**
+ * Bluetooth carries HWW traffic only, so U2F always uses the USB timeout.
+ */
+static int16_t _outstanding_op_timeout_ticks(const struct usb_processing* ctx)
+{
+    if (ctx == usb_processing_hww() && rust_communication_mode_ble_enabled()) {
+        return USB_OUTSTANDING_OP_TIMEOUT_BLE_TICKS;
+    }
+    return USB_OUTSTANDING_OP_TIMEOUT_TICKS;
+}
+
+/**
  * Check if the lock timer has expired for this context.
  * If it has, call the abort_outstanding_op function and unlock
  * the USB stack.
@@ -316,7 +331,7 @@ static void _check_lock_timeout(struct usb_processing* ctx)
     if (_usb_state.blocking_ctx != ctx) {
         return;
     }
-    if (_usb_state.timeout_counter > USB_OUTSTANDING_OP_TIMEOUT_TICKS) {
+    if (_usb_state.timeout_counter > _outstanding_op_timeout_ticks(ctx)) {
         util_log("usb_processing: timed out!");
         // ASSERT(false);
         if (!ctx->abort_outstanding_op) {

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -59,6 +59,8 @@ else()
      ""
      ugui
      ""
+     usb_processing
+     "-Wl,--wrap=rust_communication_mode_ble_enabled,--wrap=hww_abort_outstanding_op,--wrap=u2f_abort_outstanding_op"
   )
 
   list(LENGTH TEST_LIST TEST_LIST_LEN)

--- a/test/unit-test/test_usb_processing.c
+++ b/test/unit-test/test_usb_processing.c
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <cmocka.h>
+
+#include "usb/usb_processing.h"
+#include <rust/rust.h>
+
+/* Keep in sync with the thresholds in src/usb/usb_processing.c. */
+static const int16_t USB_OUTSTANDING_OP_TIMEOUT_TICKS = 5;
+static const int16_t USB_OUTSTANDING_OP_TIMEOUT_BLE_TICKS = 30;
+
+static int hww_abort_count;
+static int u2f_abort_count;
+
+void __wrap_hww_abort_outstanding_op(void)
+{
+    hww_abort_count++;
+}
+
+void __wrap_u2f_abort_outstanding_op(void)
+{
+    u2f_abort_count++;
+}
+
+bool __wrap_rust_communication_mode_ble_enabled(void)
+{
+    return mock();
+}
+
+static void _test_hww_ble_uses_long_timeout(void** state)
+{
+    (void)state;
+
+    hww_abort_count = 0;
+    u2f_abort_count = 0;
+
+    RustUsbReportQueue* hww_queue = rust_usb_report_queue_init();
+    usb_processing_init(hww_queue);
+
+    struct usb_processing* ctx = usb_processing_hww();
+
+    usb_processing_lock(ctx);
+
+    will_return(__wrap_rust_communication_mode_ble_enabled, true);
+    usb_processing_timeout_reset((int16_t)(USB_OUTSTANDING_OP_TIMEOUT_TICKS + 1));
+    usb_processing_process(ctx);
+    assert_int_equal(hww_abort_count, 0);
+    assert_int_equal(u2f_abort_count, 0);
+    assert_true(usb_processing_locked(ctx));
+
+    will_return(__wrap_rust_communication_mode_ble_enabled, true);
+    usb_processing_timeout_reset(USB_OUTSTANDING_OP_TIMEOUT_BLE_TICKS);
+    usb_processing_process(ctx);
+    assert_int_equal(hww_abort_count, 0);
+    assert_int_equal(u2f_abort_count, 0);
+    assert_true(usb_processing_locked(ctx));
+
+    will_return(__wrap_rust_communication_mode_ble_enabled, true);
+    usb_processing_timeout_reset((int16_t)(USB_OUTSTANDING_OP_TIMEOUT_BLE_TICKS + 1));
+    usb_processing_process(ctx);
+    assert_int_equal(hww_abort_count, 1);
+    assert_int_equal(u2f_abort_count, 0);
+    assert_false(usb_processing_locked(ctx));
+
+    rust_usb_report_queue_free(hww_queue);
+}
+
+static void _test_hww_usb_uses_short_timeout(void** state)
+{
+    (void)state;
+
+    hww_abort_count = 0;
+    u2f_abort_count = 0;
+
+    RustUsbReportQueue* hww_queue = rust_usb_report_queue_init();
+    usb_processing_init(hww_queue);
+
+    struct usb_processing* ctx = usb_processing_hww();
+
+    usb_processing_lock(ctx);
+
+    will_return(__wrap_rust_communication_mode_ble_enabled, false);
+    usb_processing_timeout_reset(USB_OUTSTANDING_OP_TIMEOUT_TICKS);
+    usb_processing_process(ctx);
+    assert_int_equal(hww_abort_count, 0);
+    assert_int_equal(u2f_abort_count, 0);
+    assert_true(usb_processing_locked(ctx));
+
+    will_return(__wrap_rust_communication_mode_ble_enabled, false);
+    usb_processing_timeout_reset((int16_t)(USB_OUTSTANDING_OP_TIMEOUT_TICKS + 1));
+    usb_processing_process(ctx);
+    assert_int_equal(hww_abort_count, 1);
+    assert_int_equal(u2f_abort_count, 0);
+    assert_false(usb_processing_locked(ctx));
+
+    rust_usb_report_queue_free(hww_queue);
+}
+
+static void _test_u2f_keeps_short_timeout_when_ble_enabled(void** state)
+{
+    (void)state;
+
+    hww_abort_count = 0;
+    u2f_abort_count = 0;
+
+    RustUsbReportQueue* hww_queue = rust_usb_report_queue_init();
+    usb_processing_init(hww_queue);
+    RustUsbReportQueue* u2f_queue = rust_usb_report_queue_init();
+    usb_processing_init_u2f(u2f_queue);
+
+    struct usb_processing* ctx = usb_processing_u2f();
+
+    usb_processing_lock(ctx);
+
+    /* rust_communication_mode_ble_enabled is not called for the U2F context. */
+    usb_processing_timeout_reset(USB_OUTSTANDING_OP_TIMEOUT_TICKS);
+    usb_processing_process(ctx);
+    assert_int_equal(u2f_abort_count, 0);
+    assert_int_equal(hww_abort_count, 0);
+    assert_true(usb_processing_locked(ctx));
+
+    usb_processing_timeout_reset((int16_t)(USB_OUTSTANDING_OP_TIMEOUT_TICKS + 1));
+    usb_processing_process(ctx);
+    assert_int_equal(u2f_abort_count, 1);
+    assert_int_equal(hww_abort_count, 0);
+    assert_false(usb_processing_locked(ctx));
+
+    rust_usb_report_queue_free(u2f_queue);
+    rust_usb_report_queue_free(hww_queue);
+}
+
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(_test_hww_ble_uses_long_timeout),
+        cmocka_unit_test(_test_hww_usb_uses_short_timeout),
+        cmocka_unit_test(_test_u2f_keeps_short_timeout_when_ble_enabled),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
Signing an EIP-712 typed message whose `EIP712Domain` carries no `chainId` fails over Bluetooth
with `hwwRspNack` shortly after the "Typed data has no chain ID" warning is confirmed on the
device. The same message signs correctly over USB, and the same message with a `chainId` signs
correctly over Bluetooth too.

## Cause

`hwwRspNack` in reply to an `HWW_REQ_RETRY` has one source: `_maybe_write_response()` in
`src/hww.c` falls through to `HWW_RSP_NACK` when `rust_async_usb_copy_response()` reports
`UsbResponseNack`, which `take_response()` only returns for `UsbTaskState::Nothing` — no task is
running any more. After an `HWW_REQ_NEW` the state is `Running`, and short of the host collecting
the final result, the only way out of it is `async_usb::cancel()`. Of its two call sites, the one
in `hww/api/bluetooth.rs` runs only after a successful Bluetooth firmware upgrade and is
unreachable for an Ethereum request, which leaves `hww_abort_outstanding_op()` called from
`_check_lock_timeout()` in `src/usb/usb_processing.c`.

That watchdog aborts an outstanding operation once more than `USB_OUTSTANDING_OP_TIMEOUT_MS`
(500 ms) pass between two fully processed host packets. The host polls a pending operation every
200 ms (`py/bitbox02/bitbox02/communication/bitbox_api_protocol.py`), so roughly 300 ms are left
for the complete round trip. Over USB that is ample. Over Bluetooth the round trip additionally
carries the connection interval in each direction plus the UART relay to the DA14531, so the
window is occasionally missed while the operation is perfectly healthy.

This explains every observed combination:

* With a `chainId` the device answers immediately, the retry loop is never entered, and the
  watchdog cannot fire.
* Without a `chainId` the warning holds the operation open across many poll cycles, and a single
  slow cycle is enough — which also matches the reported spread of 2 s to 10 s before failure.
* Over USB the remaining headroom is never consumed, so the same message signs.

Multi-frame framing is not involved: U2FHID reassembly completes before the task is spawned, and a
truncated request would surface as a frame error or a stall, not as a well-formed NACK.

## Change

Keep the 500 ms window for USB and use 3000 ms while Bluetooth is the active transport. 3000 ms is
fifteen poll intervals, so a healthy operation survives several consecutive slow round trips, while
a client that disappears still frees the stack quickly.

The timeout counter is shared between the HWW and the U2F stack, so the long window is limited to
the HWW context. U2F is always USB, because the Bluetooth transport only relays HWW frames.

`hww/transport.rs` carries the same constant and is scaled alongside it, so the behaviour does not
regress once it replaces the C implementation. A few existing comments named the fixed 500 ms
figure and are adjusted, since the window now depends on the transport.

## Tests

`test/unit-test/test_usb_processing.c` is new and covers the resulting matrix for both stacks: at
the threshold the operation survives, one tick above it is aborted, and U2F is aborted at the USB
threshold even while Bluetooth is active. It drives the public API only and observes the abort
through linker wraps on `hww_abort_outstanding_op` / `u2f_abort_outstanding_op`.

## What is not verified

This change is derived from the code, not from a measurement on a device, and we could not close
that gap ourselves:

* A retail device only runs firmware signed by BitBox, and a customer cannot replace the bootloader,
  so flashing this branch requires a device that ships with a development bootloader.
* The simulator cannot stand in for it. Its watchdog timer is compiled out (`_register_timer()` sits
  behind `#if !defined(BOOTLOADER) && !defined(TESTING)`), so the counter never advances, and it
  communicates over a TCP socket, so the Bluetooth latency that triggers the bug does not exist
  there.

What is verified is the mechanism: the unit test drives `_check_lock_timeout()` through
`usb_processing_process()` for both stacks and both sides of each threshold, and it fails if the
comparison is changed to `>=` or if the Bluetooth window is removed.

What remains open is whether a retry interval above 500 ms actually occurred in the reported
failures. `rawQueryV7` in bitbox02-api-go already logs the last ten retry intervals when it hits the
NACK; the reproduction in #2019 discards them by passing `&mocks.Logger{}`. With a real logger those
intervals would turn the argument above into a measurement, without needing to flash anything.

## Note on the simulator

`test/simulator-graphical` presents itself as a Nova and never sees a USB request, so
`ble_enabled()` stays true there and it consistently gets the Bluetooth window. That follows from
the documented meaning of the communication mode ("Bluetooth is active until the first USB request
is seen") rather than being a side effect of this change, so the simulator is left untouched.

fixes #2019
