### PR TITLE
Disable BitBoxSync API by default and prepare v9.26.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ customers cannot upgrade their bootloader, its changes are recorded separately.
 ## Firmware
 
 ### [Unreleased]
-- Fixed a crash when listing many backups over Bluetooth
 - Add support for BitBoxSync
+
+### v9.26.5
+- Fixed a crash when listing many backups over Bluetooth
+- Fix unexpected NACK responses on iOS due to slow securechip operations
 
 ### v9.26.4
 - Ethereum: allow ':' in EIP-712 type names, used by some dapps as a namespace separator

--- a/src/rust/bitbox02-rust/Cargo.toml
+++ b/src/rust/bitbox02-rust/Cargo.toml
@@ -96,6 +96,9 @@ app-cardano = [
   "dep:crc"
 ]
 
+# Temporarily disabled pending API changes.
+bitboxsync = []
+
 testing = [
   "dep:bitbox-platform-host",
   "bitbox-platform-host?/testing",

--- a/src/rust/bitbox02-rust/src/hww/api.rs
+++ b/src/rust/bitbox02-rust/src/hww/api.rs
@@ -17,6 +17,7 @@ mod cardano;
 
 mod backup;
 mod bip85;
+#[cfg(feature = "bitboxsync")]
 mod bitboxsync;
 mod bluetooth;
 mod change_password;
@@ -201,7 +202,10 @@ async fn process_api(hal: &mut impl crate::hal::Hal, request: &Request) -> Resul
         #[cfg(not(feature = "app-cardano"))]
         Request::Cardano(_) => Err(Error::Disabled),
         Request::Bip85(request) => bip85::process(hal, request).await,
+        #[cfg(feature = "bitboxsync")]
         Request::BitboxSync(request) => bitboxsync::process(hal, request).await,
+        #[cfg(not(feature = "bitboxsync"))]
+        Request::BitboxSync(_) => Err(Error::Disabled),
         Request::Bluetooth(pb::BluetoothRequest {
             request: Some(request),
         }) => bluetooth::process_api(hal, request)

--- a/versions.json
+++ b/versions.json
@@ -1,5 +1,5 @@
 {
-  "firmware": "v9.27.0",
+  "firmware": "v9.26.5",
   "bootloader": "v1.2.2",
   "stage0": 1
 }


### PR DESCRIPTION
Gate the BitBoxSync API behind a disabled-by-default Cargo feature while API changes are pending.

Requests now return the standard disabled error unless the feature is explicitly enabled.