### PR TITLE
Fix GroundedCell result lifetime

### DIFF
--- a/src/rust/bitbox02-rust-c/src/u2f_c_api.rs
+++ b/src/rust/bitbox02-rust-c/src/u2f_c_api.rs
@@ -181,8 +181,8 @@ pub unsafe extern "C" fn rust_workflow_confirm_poll(result_out: &mut bool) -> bo
     unsafe {
         match CONFIRM_STATE.get().as_ref().unwrap() {
             TaskState::ResultAvailable(result) => {
-                CONFIRM_STATE.get().write(TaskState::Nothing);
                 *result_out = result.is_ok();
+                CONFIRM_STATE.get().write(TaskState::Nothing);
                 true
             }
             TaskState::Running(_) => false,


### PR DESCRIPTION
Read the confirmation result before clearing CONFIRM_STATE.
The result reference points into GroundedCell storage, so clearing the
state first invalidates it before result.is_ok() reads it.

This keeps the poll contract: publish the completed result, clear the task
state, and report completion. It also matches rust_workflow_unlock_poll().